### PR TITLE
Add output parameter analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "etrace",
  "lazy_static",
  "serde",
+ "serde_json",
  "toml",
  "toml_edit",
  "tracing",
@@ -158,6 +159,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -230,6 +237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +260,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ clap = { version = "4.5.40", features = ["derive"] }
 etrace = { version = "1.1.1" }
 typed-arena = "2.0.2"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.107"
 toml = "0.8.23"
 toml_edit = "0.22.27"
 lazy_static = "1.5.0"

--- a/src/bin/crat.rs
+++ b/src/bin/crat.rs
@@ -55,7 +55,7 @@ struct Args {
     outparam_analysis_file: Option<PathBuf>,
     #[arg(
         long,
-        help = "Print analysis times of the functions with top-n analysis time"
+        help = "Print the analysis times for the n functions with the longest times."
     )]
     outparam_function_times: Option<usize>,
     #[arg(long, help = "Print analysis results of the specified functions")]

--- a/src/bin/crat.rs
+++ b/src/bin/crat.rs
@@ -53,6 +53,13 @@ struct Args {
     outparam_simplify: bool,
     #[arg(long, help = "File containing the result of output parameter analysis")]
     outparam_analysis_file: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Print analysis times of the functions with top-n analysis time"
+    )]
+    outparam_function_times: Option<usize>,
+    #[arg(long, help = "Print analysis results of the specified functions")]
+    outparam_print_functions: Vec<String>,
 
     #[arg(short, long, help = "Enable verbose output")]
     verbose: bool,
@@ -215,6 +222,13 @@ fn main() {
     config.outparam.check_param_alias |= args.outparam_check_param_alias;
     config.outparam.no_widening |= args.outparam_no_widening;
     config.outparam.simplify |= args.outparam_simplify;
+
+    config.outparam.function_times = args.outparam_function_times;
+    config
+        .outparam
+        .print_functions
+        .extend(args.outparam_print_functions);
+
     if args.outparam_analysis_file.is_some() {
         config.outparam.analysis_file = args.outparam_analysis_file;
     }

--- a/src/bin/crat.rs
+++ b/src/bin/crat.rs
@@ -201,9 +201,16 @@ fn main() {
         config.r#union.points_to_file = args.points_to_file.clone();
     }
 
-    if let Some(v) = args.outparam_max_loop_head_states {
-        config.outparam.max_loop_head_states = v;
-    }
+    config.outparam.max_loop_head_states = if let Some(v) = args.outparam_max_loop_head_states {
+        if v == 0 {
+            eprintln!("max_loop_head_states should be greater than 0");
+            std::process::exit(1);
+        }
+        v
+    } else {
+        usize::MAX
+    };
+
     config.outparam.check_global_alias |= args.outparam_check_global_alias;
     config.outparam.check_param_alias |= args.outparam_check_param_alias;
     config.outparam.no_widening |= args.outparam_no_widening;

--- a/src/compile_util.rs
+++ b/src/compile_util.rs
@@ -15,7 +15,10 @@ use rustc_errors::{
 use rustc_feature::UnstableFeatures;
 use rustc_hash::FxHashMap;
 use rustc_interface::Config;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::{
+    ty::TyCtxt,
+    mir::{Body, TerminatorKind},
+};
 use rustc_session::{
     EarlyDiagCtxt,
     config::{CrateType, ErrorOutputType, Input, Options},
@@ -211,4 +214,31 @@ fn toolchain_path(home: Option<String>, toolchain: Option<String>) -> Option<Pat
             path
         })
     })
+}
+
+pub fn body_to_str(body: &Body<'_>) -> String {
+    use std::fmt::Write;
+    let mut s = String::new();
+    writeln!(s, "{:?} {{", body.source.instance.def_id()).unwrap();
+    for (bb, bbd) in body.basic_blocks.iter_enumerated() {
+        writeln!(s, "    {:?}:", bb).unwrap();
+        for stmt in &bbd.statements {
+            writeln!(s, "        {:?}", stmt).unwrap();
+        }
+        if !matches!(
+            bbd.terminator().kind,
+            TerminatorKind::Return | TerminatorKind::Assert { .. }
+        ) {
+            writeln!(s, "        {:?}", bbd.terminator().kind).unwrap();
+        }
+    }
+    writeln!(s, "}}").unwrap();
+    s
+}
+
+pub fn body_size(body: &Body<'_>) -> usize {
+    body.basic_blocks
+        .iter()
+        .map(|bbd| bbd.statements.len() + 1)
+        .sum()
 }

--- a/src/compile_util.rs
+++ b/src/compile_util.rs
@@ -221,9 +221,9 @@ pub fn body_to_str(body: &Body<'_>) -> String {
     let mut s = String::new();
     writeln!(s, "{:?} {{", body.source.instance.def_id()).unwrap();
     for (bb, bbd) in body.basic_blocks.iter_enumerated() {
-        writeln!(s, "    {:?}:", bb).unwrap();
+        writeln!(s, "    {bb:?}:").unwrap();
         for stmt in &bbd.statements {
-            writeln!(s, "        {:?}", stmt).unwrap();
+            writeln!(s, "        {stmt:?}").unwrap();
         }
         if !matches!(
             bbd.terminator().kind,

--- a/src/compile_util.rs
+++ b/src/compile_util.rs
@@ -15,10 +15,7 @@ use rustc_errors::{
 use rustc_feature::UnstableFeatures;
 use rustc_hash::FxHashMap;
 use rustc_interface::Config;
-use rustc_middle::{
-    mir::{Body, TerminatorKind},
-    ty::TyCtxt,
-};
+use rustc_middle::ty::TyCtxt;
 use rustc_session::{
     EarlyDiagCtxt,
     config::{CrateType, ErrorOutputType, Input, Options},
@@ -214,31 +211,4 @@ fn toolchain_path(home: Option<String>, toolchain: Option<String>) -> Option<Pat
             path
         })
     })
-}
-
-pub fn body_to_str(body: &Body<'_>) -> String {
-    use std::fmt::Write;
-    let mut s = String::new();
-    writeln!(s, "{:?} {{", body.source.instance.def_id()).unwrap();
-    for (bb, bbd) in body.basic_blocks.iter_enumerated() {
-        writeln!(s, "    {bb:?}:").unwrap();
-        for stmt in &bbd.statements {
-            writeln!(s, "        {stmt:?}").unwrap();
-        }
-        if !matches!(
-            bbd.terminator().kind,
-            TerminatorKind::Return | TerminatorKind::Assert { .. }
-        ) {
-            writeln!(s, "        {:?}", bbd.terminator().kind).unwrap();
-        }
-    }
-    writeln!(s, "}}").unwrap();
-    s
-}
-
-pub fn body_size(body: &Body<'_>) -> usize {
-    body.basic_blocks
-        .iter()
-        .map(|bbd| bbd.statements.len() + 1)
-        .sum()
 }

--- a/src/compile_util.rs
+++ b/src/compile_util.rs
@@ -16,8 +16,8 @@ use rustc_feature::UnstableFeatures;
 use rustc_hash::FxHashMap;
 use rustc_interface::Config;
 use rustc_middle::{
-    ty::TyCtxt,
     mir::{Body, TerminatorKind},
+    ty::TyCtxt,
 };
 use rustc_session::{
     EarlyDiagCtxt,

--- a/src/graph_util.rs
+++ b/src/graph_util.rs
@@ -228,7 +228,7 @@ pub fn reflexive_transitive_closure<T: Copy + Eq + std::hash::Hash>(
 ) -> FxHashMap<T, FxHashSet<T>> {
     let mut new_graph = transitive_closure(graph);
     for v in graph.keys() {
-        new_graph.get_mut(v).unwrap().insert(v.clone());
+        new_graph.get_mut(v).unwrap().insert(*v);
     }
     new_graph
 }

--- a/src/graph_util.rs
+++ b/src/graph_util.rs
@@ -223,6 +223,16 @@ pub fn bitset_transitive_closure<T: Idx>(graph: &mut IndexVec<T, ChunkedBitSet<T
     }
 }
 
+pub fn reflexive_transitive_closure<T: Copy + Eq + std::hash::Hash>(
+    graph: &FxHashMap<T, FxHashSet<T>>,
+) -> FxHashMap<T, FxHashSet<T>> {
+    let mut new_graph = transitive_closure(graph);
+    for v in graph.keys() {
+        new_graph.get_mut(v).unwrap().insert(v.clone());
+    }
+    new_graph
+}
+
 pub fn reachable_vertices<T: Copy + Eq + std::hash::Hash>(
     graph: &FxHashMap<T, FxHashSet<T>>,
     v: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 extern crate rustc_abi;
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
+extern crate rustc_const_eval;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_errors;
@@ -26,7 +27,6 @@ extern crate rustc_span;
 extern crate rustc_type_ir;
 extern crate smallvec;
 extern crate thin_vec;
-extern crate rustc_const_eval;
 
 pub mod preprocessor;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ extern crate rustc_span;
 extern crate rustc_type_ir;
 extern crate smallvec;
 extern crate thin_vec;
+extern crate rustc_const_eval;
 
 pub mod preprocessor;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
+#![feature(map_try_insert)]
 
 extern crate rustc_abi;
 extern crate rustc_ast;

--- a/src/outparam_replacer/ai/analysis.rs
+++ b/src/outparam_replacer/ai/analysis.rs
@@ -1,17 +1,1912 @@
-use std::path::Path;
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    path::Path,
+};
 
-use rustc_middle::ty::TyCtxt;
+use etrace::some_or;
+use rustc_abi::{FieldIdx, VariantIdx};
+use rustc_const_eval::interpret::{GlobalAlloc, Scalar};
+use rustc_data_structures::graph::Successors;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{
+    def::{DefKind, Res},
+    intravisit::Visitor as HVisitor,
+    Expr, ExprKind, HirId, QPath,
+};
+use rustc_index::{bit_set::DenseBitSet, IndexVec};
+use rustc_middle::{
+    hir::nested_filter,
+    mir::{
+        visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor as MVisitor},
+        BasicBlock, Body, Const, ConstOperand, ConstValue, Local, Location, Rvalue, Statement,
+        StatementKind, Terminator, TerminatorKind,
+    },
+    ty::{AdtKind, Ty, TyCtxt, TyKind},
+};
+use rustc_mir_dataflow::Analysis as _;
+use rustc_span::{
+    def_id::{DefId, LocalDefId},
+    Span,
+};
+use serde::{Deserialize, Serialize};
+use serde_json;
+use typed_arena::Arena;
 
-pub struct AnalysisResult {}
+use super::{
+    domains::*,
+    semantics::{CallKind, TransferedTerminator},
+    pre_analysis::{self, PreAnalysisContext},
+};
 
-pub fn write_analysis_result(_path: &Path, _result: &AnalysisResult) {
-    todo!()
+use crate::{
+    points_to::andersen::{self, Loc},
+    ty_shape,
+    graph_util,
+};
+
+// TODO: Remove span translation
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LoHi {
+    pub lo: u32,
+    pub hi: u32,
+}
+
+impl LoHi {
+    #[inline]
+    fn new(lo: u32, hi: u32) -> Self {
+        Self { lo, hi }
+    }
+
+    #[inline]
+    pub fn from_span(span: Span) -> Self {
+        assert!(span.ctxt().is_root());
+        assert!(span.parent().is_none());
+        Self::new(span.lo().0, span.hi().0)
+    }
+}
+
+// The result of the output parameter analysis
+pub type AnalysisResult = FxHashMap<String, (FunctionSummary, FnAnalysisRes)>;
+
+#[derive(Clone, Debug)]
+pub struct FunctionSummary {
+    pub init_state: AbsState,
+    pub return_states: BTreeMap<(MustPathSet, AbsNulls), AbsState>,
+    pub has_side_effects: bool,
+}
+
+impl FunctionSummary {
+    fn new(
+        init_state: AbsState,
+        return_states: BTreeMap<(MustPathSet, AbsNulls), AbsState>,
+        has_side_effects: bool,
+    ) -> Self {
+        Self {
+            init_state,
+            return_states,
+            has_side_effects,
+        }
+    }
+
+    fn bot() -> Self {
+        Self {
+            init_state: AbsState::bot(),
+            return_states: BTreeMap::new(),
+            has_side_effects: false,
+        }
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        let init_state = self.init_state.join(&other.init_state);
+        let keys: BTreeSet<_> = self
+            .return_states
+            .keys()
+            .chain(other.return_states.keys())
+            .cloned()
+            .collect();
+        let return_states = keys
+            .into_iter()
+            .map(|k| {
+                let v = match (self.return_states.get(&k), other.return_states.get(&k)) {
+                    (Some(v1), Some(v2)) => v1.join(v2),
+                    (Some(v), None) | (None, Some(v)) => (*v).clone(),
+                    _ => unreachable!(),
+                };
+                (k, v)
+            })
+            .collect();
+        let has_side_effects = self.has_side_effects || other.has_side_effects;
+        Self::new(init_state, return_states, has_side_effects)
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        self.init_state.ord(&other.init_state)
+            && {
+                self.return_states
+                    .iter()
+                    .all(|(k, v)| other.return_states.get(k).is_some_and(|w| v.ord(w)))
+            }
+            && self.has_side_effects == other.has_side_effects
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FnAnalysisRes {
+    pub output_params: Vec<OutputParam>,
+    pub wbrs: Vec<WriteBeforeReturn>,
+    pub rcfws: Rcfws,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OutputParam {
+    pub index: usize,
+    pub must: bool,
+    pub return_values: ReturnValues,
+    pub complete_writes: Vec<CompleteWrite>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WriteBeforeReturn {
+    pub span: LoHi,
+    pub mays: BTreeSet<usize>,
+    pub musts: BTreeSet<usize>,
+}
+
+// Removable checks for Write s
+pub type Rcfws = BTreeMap<usize, BTreeSet<LoHi>>;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct CompleteWrite {
+    pub block: usize,
+    pub statement_index: usize,
+    pub write_arg: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ReturnValues {
+    None,
+    Int(AbsInt, AbsInt),
+    Uint(AbsUint, AbsUint),
+    Bool(AbsBool, AbsBool),
+}
+
+pub fn write_analysis_result(path: &Path, result: &AnalysisResult) {
+    let file = std::fs::File::create(path).unwrap();
+    let writes = result
+        .iter()
+        .filter_map(|(def_id, (_summary, res))| {
+            if res.output_params.is_empty() {
+                None
+            } else {
+                Some((def_id, res))
+            }
+        })
+        .collect::<BTreeMap<_, _>>();
+    serde_json::to_writer_pretty(file, &writes).unwrap();
 }
 
 pub fn analyze(
-    _config: &crate::outparam_replacer::Config,
-    _verbose: bool,
-    _tcx: TyCtxt<'_>,
+    config: &crate::outparam_replacer::Config,
+    verbose: bool,
+    tcx: TyCtxt<'_>,
 ) -> AnalysisResult {
-    todo!()
+    let mut call_graph = FxHashMap::default();
+    let mut inputs_map = FxHashMap::default();
+    for id in tcx.hir_free_items() {
+        let item = tcx.hir_item(id);
+        if let Some(ident) = item.kind.ident() {
+            if ident.name.as_str() == "main" {
+                continue;
+            }
+        }
+        let inputs = if let rustc_hir::ItemKind::Fn { sig, .. } = &item.kind {
+            sig.decl.inputs.len()
+        } else {
+            continue;
+        };
+        let def_id = item.item_id().owner_id.def_id.to_def_id();
+        inputs_map.insert(def_id, inputs);
+        let mut visitor = CallVisitor::new(tcx);
+        visitor.visit_item(item);
+        call_graph.insert(def_id, visitor.callees);
+    }
+
+    let funcs: FxHashSet<_> = call_graph.keys().cloned().collect();
+    for callees in call_graph.values_mut() {
+        callees.retain(|callee| funcs.contains(callee));
+    }
+
+    let sccs = graph_util::sccs_copied::<DefId, true>(&call_graph);
+    let transitive = graph_util::reflexive_transitive_closure(&call_graph);
+    let po: Vec<_> = sccs
+        .post_order()
+        .collect();
+
+    let mut visitor = FnPtrVisitor::new(tcx);
+    let mut global_visitor = GlobalVisitor::new(tcx);
+    tcx.hir_visit_all_item_likes_in_crate(&mut visitor);
+
+    let info_map: FxHashMap<_, _> = funcs
+        .iter()
+        .map(|def_id| {
+            let inputs = inputs_map[def_id];
+            let body = tcx.optimized_mir(def_id);
+            let param_tys = get_param_tys(body, inputs, tcx);
+            let pre_rpo_map = get_rpo_map(body);
+            let loop_blocks = get_loop_blocks(body, &pre_rpo_map);
+            let rpo_map = compute_rpo_map(body, &loop_blocks);
+            let dead_locals = get_dead_locals(body, tcx);
+            let fn_ptr = visitor.fn_ptrs.contains(def_id);
+            global_visitor.visit_body(body);
+            let globals = std::mem::take(&mut global_visitor.globals);
+            let info = FuncInfo {
+                inputs,
+                param_tys,
+                loop_blocks,
+                rpo_map,
+                dead_locals,
+                fn_ptr,
+                globals,
+            };
+            (*def_id, info)
+        })
+        .collect();
+
+    let arena = Arena::new();
+    let tss = ty_shape::get_ty_shapes(&arena, tcx);
+    let pre = andersen::pre_analyze(&tss, tcx);
+    let solutions = if let Some(path) = &config.points_to_file {
+        let arr = std::fs::read(path).unwrap();
+        andersen::deserialize_solutions(&arr)
+    } else {
+        andersen::analyze(&pre, &tss, tcx)
+    };
+
+    let pre_data = pre_analysis::compute_alias(
+        pre,
+        &solutions,
+        &inputs_map,
+        tcx,
+        config.check_global_alias,
+        config.check_param_alias,
+    );
+
+    let mut ptr_params_map = FxHashMap::default();
+    let mut ptr_params_inv_map = FxHashMap::default();
+    let mut output_params_map = FxHashMap::default();
+    let mut summaries = FxHashMap::default();
+    let mut results = FxHashMap::default();
+    let mut wm_map = FxHashMap::default();
+    let mut call_args_map = FxHashMap::default();
+    let mut analysis_times: FxHashMap<_, u128> = FxHashMap::default();
+
+    let mut wbrs: FxHashMap<DefId, Vec<WriteBeforeReturn>> = FxHashMap::default();
+    let mut bb_musts: FxHashMap<DefId, BTreeMap<BasicBlock, BTreeSet<usize>>> =
+        FxHashMap::default();
+    let mut is_units = FxHashMap::default();
+
+    let mut rcfws = FxHashMap::default();
+    for id in &po {
+        let def_ids = &sccs.scc_elems[*id];
+        let recursive = if def_ids.len() == 1 {
+            let def_id = def_ids.iter().next().unwrap();
+            call_graph[def_id].contains(def_id)
+        } else {
+            true
+        };
+
+        loop {
+            if recursive {
+                for def_id in def_ids {
+                    let _ = summaries.try_insert(*def_id, FunctionSummary::bot());
+                }
+            }
+
+            let mut need_rerun = false;
+            for def_id in def_ids {
+                let start = std::time::Instant::now();
+
+                let pre_context = PreAnalysisContext::new(*def_id, &pre_data, &solutions);
+
+                let mut analyzer =
+                    Analyzer::new(tcx, &info_map[def_id], config, &summaries, pre_context);
+                let body = tcx.optimized_mir(*def_id);
+                if verbose {
+                    println!(
+                        "{:?} {} {}",
+                        def_id,
+                        body.basic_blocks.len(),
+                        body.local_decls.len()
+                    );
+                }
+
+                let AnalyzedBody {
+                    states,
+                    writes_map,
+                    init_state,
+                    call_info_map,
+                    is_merged,
+                } = analyzer.analyze_body(body);
+
+                let ret_location = return_location(body);
+
+                let mut return_states = ret_location
+                    .and_then(|ret| states.get(&ret))
+                    .cloned()
+                    .unwrap_or_default();
+
+                // If there is a merged block, always check all parameters
+                let (candidates, nonnull_params) = if is_merged {
+                    (
+                        (1..=(analyzer.info.inputs))
+                            .map(Local::from_usize)
+                            .collect::<BTreeSet<Local>>(),
+                        BTreeSet::new(),
+                    )
+                } else {
+                    // If not, we filter the parameters which are implicity non-null
+                    analyzer.get_nullable_candidates(&return_states)
+                };
+
+                let nullable_params = analyzer.find_nullable_params(
+                    tcx,
+                    &states,
+                    body,
+                    &writes_map,
+                    &call_info_map,
+                    candidates,
+                );
+
+                let alias_params = if config.check_global_alias {
+                    analyzer.check_reachable_globals(
+                        &info_map,
+                        &pre_data.globals,
+                        transitive.get(def_id).unwrap(),
+                    )
+                } else {
+                    BTreeSet::new()
+                };
+
+                let null_exclude_paths: Vec<_> = nullable_params
+                    .iter()
+                    .flat_map(|p| analyzer.expands_path(&AbsPath::new(*p, vec![])))
+                    .collect();
+                let alias_exclude_paths: Vec<_> = alias_params
+                    .iter()
+                    .flat_map(|p| analyzer.expands_path(&AbsPath::new(*p, vec![])))
+                    .collect();
+
+                let mut wbr = vec![];
+                let mut bb_must = BTreeMap::new();
+
+                let mut stack = vec![];
+
+                if let Some(ret_location) = ret_location {
+                    if let Some((ret_loc_assign0, ret_loc)) =
+                        exists_assign0(body, ret_location.block)
+                    {
+                        stack.push((ret_loc, ret_loc_assign0));
+                    } else if let Some(v) = body.basic_blocks.predecessors().get(ret_location.block)
+                    {
+                        for i in v {
+                            if let Some((sp, ret_loc)) = exists_assign0(body, *i) {
+                                stack.push((ret_loc, sp));
+                            }
+                        }
+                    }
+
+                    let empty_map = BTreeMap::new();
+                    for (loc, sp) in stack.iter() {
+                        let writes: Vec<_> = states
+                            .get(loc)
+                            .unwrap_or(&empty_map)
+                            .values()
+                            .map(|st| st.writes.as_set())
+                            .collect();
+                        let musts: BTreeSet<_> = writes
+                            .iter()
+                            .copied()
+                            .fold(None, |acc: Option<BTreeSet<_>>, ws| {
+                                Some(match acc {
+                                    Some(acc) => acc.intersection(ws).cloned().collect(),
+                                    None => ws.clone(),
+                                })
+                            })
+                            .unwrap_or_default()
+                            .iter()
+                            .map(|p| p.base.index() - 1)
+                            .collect();
+                        let mays: BTreeSet<_> = writes
+                            .into_iter()
+                            .flatten()
+                            .map(|p| p.base.index() - 1)
+                            .collect();
+                        let span = LoHi::from_span(*sp);
+                        bb_must.insert(loc.block, musts.clone());
+                        wbr.push(WriteBeforeReturn { span, mays, musts });
+                    }
+                }
+
+                wbrs.insert(*def_id, wbr);
+                bb_musts.insert(*def_id, bb_must);
+                is_units.insert(*def_id, stack.is_empty());
+
+                // Handle unremovable parameters
+                for st in return_states.values_mut() {
+                    st.writes.remove(&nullable_params);
+                    st.writes.remove(&alias_params);
+
+                    st.add_excludes(alias_exclude_paths.iter().cloned());
+                    st.add_null_excludes(null_exclude_paths.iter().cloned());
+
+                    st.null_excludes.remove(&nonnull_params);
+                }
+
+                let mut has_side_effects = call_info_map.values().flatten().any(|kind| {
+                    matches!(
+                        kind,
+                        CallKind::TOP
+                            | CallKind::RustEffect(_)
+                            | CallKind::CEffect
+                            | CallKind::IntraEffect
+                    )
+                });
+
+                has_side_effects = has_side_effects || analyzer.check_global_writes();
+
+                let summary = FunctionSummary::new(init_state, return_states, has_side_effects);
+                results.insert(*def_id, states);
+                ptr_params_map.insert(*def_id, analyzer.ptr_params);
+                ptr_params_inv_map.insert(*def_id, analyzer.ptr_params_inv);
+                wm_map.insert(*def_id, writes_map);
+                call_args_map.insert(*def_id, analyzer.call_args);
+
+                let (summary, updated) = if let Some(old) = summaries.get(def_id) {
+                    let new_summary = summary.join(old);
+                    let updated = !new_summary.ord(old);
+                    (new_summary, updated)
+                } else {
+                    (summary, false)
+                };
+                summaries.insert(*def_id, summary);
+                need_rerun |= updated;
+
+                *analysis_times.entry(*def_id).or_default() += start.elapsed().as_millis();
+            }
+
+            if !need_rerun {
+                for def_id in def_ids {
+                    let pre_context = PreAnalysisContext::new(*def_id, &pre_data, &solutions);
+                    let mut analyzer =
+                        Analyzer::new(tcx, &info_map[def_id], config, &summaries, pre_context);
+                    analyzer.ptr_params = ptr_params_map.remove(def_id).unwrap();
+                    analyzer.ptr_params_inv = ptr_params_inv_map.remove(def_id).unwrap();
+                    let summary = &summaries[def_id];
+                    let return_ptrs = analyzer.get_return_ptrs(summary);
+                    let mut output_params =
+                        analyzer.find_output_params(summary, &return_ptrs, *def_id);
+                    let writes_map = wm_map.remove(def_id).unwrap();
+                    let call_args = call_args_map.remove(def_id).unwrap();
+                    let result = results.remove(def_id).unwrap();
+                    for p in &mut output_params {
+                        analyzer.find_complete_write(p, &result, &writes_map, &call_args, *def_id);
+                    }
+
+                    let body = tcx.optimized_mir(*def_id);
+                    let bb_must = &bb_musts[def_id];
+                    let mut rcfw: Rcfws = BTreeMap::new();
+
+                    if !is_units[def_id] {
+                        for p in &output_params {
+                            let OutputParam {
+                                index,
+                                complete_writes,
+                                ..
+                            } = p;
+                            for complete_write in complete_writes {
+                                let CompleteWrite {
+                                    block,
+                                    statement_index,
+                                    ..
+                                } = complete_write;
+
+                                let mut stack = vec![BasicBlock::from_usize(*block)];
+                                let mut visited: BTreeSet<_> = stack.iter().cloned().collect();
+
+                                let always_write = loop {
+                                    if let Some(bb) = stack.pop() {
+                                        if let Some(musts) = bb_must.get(&bb) {
+                                            if !musts.contains(index) {
+                                                break false;
+                                            }
+                                        }
+
+                                        let term = body.basic_blocks[bb].terminator();
+                                        for bb in term.successors() {
+                                            if !visited.contains(&bb) {
+                                                visited.insert(bb);
+                                                stack.push(bb);
+                                            }
+                                        }
+                                    } else {
+                                        break true;
+                                    }
+                                };
+
+                                if always_write {
+                                    let location = Location {
+                                        block: BasicBlock::from_usize(*block),
+                                        statement_index: *statement_index,
+                                    };
+                                    let span = LoHi::from_span(body.source_info(location).span);
+                                    let entry = rcfw.entry(*index);
+                                    entry.or_default().insert(span);
+                                }
+                            }
+                        }
+                    }
+
+                    rcfws.insert(*def_id, rcfw);
+                    output_params_map.insert(*def_id, output_params);
+                }
+                break;
+            }
+        }
+    }
+
+
+    if config.max_loop_head_states <= 1 {
+        wbrs.clear();
+        rcfws.clear();
+    }
+
+    summaries
+        .into_iter()
+        .map(|(def_id, summary)| {
+            let output_params = output_params_map.remove(&def_id).unwrap();
+            let wbrs = wbrs.remove(&def_id).unwrap_or_default();
+            let rcfws = rcfws.remove(&def_id).unwrap_or_default();
+            let res = FnAnalysisRes {
+                output_params,
+                wbrs,
+                rcfws,
+            };
+            (tcx.def_path_str(def_id), (summary, res))
+        })
+        .collect()
+}
+
+fn return_location(body: &Body<'_>) -> Option<Location> {
+    for block in body.basic_blocks.indices() {
+        let bbd = &body.basic_blocks[block];
+        if let Some(terminator) = &bbd.terminator {
+            if terminator.kind == TerminatorKind::Return {
+                let location = Location {
+                    block,
+                    statement_index: bbd.statements.len(),
+                };
+                return Some(location);
+            }
+        }
+    }
+    None
+}
+
+fn exists_assign0(body: &Body<'_>, bb: BasicBlock) -> Option<(Span, Location)> {
+    for (i, stmt) in body.basic_blocks[bb].statements.iter().enumerate() {
+        if let StatementKind::Assign(rb) = &stmt.kind {
+            if (**rb).0.local.as_u32() == 0u32 {
+                return Some((
+                    stmt.source_info.span,
+                    Location {
+                        block: bb,
+                        statement_index: i,
+                    },
+                ));
+            }
+        }
+    }
+    let term = body.basic_blocks[bb].terminator();
+    if let TerminatorKind::Call {
+        func: _,
+        args: _,
+        destination,
+        target,
+        unwind: _,
+        call_source: _,
+        fn_span: _,
+    } = term.kind
+    {
+        if destination.local.as_u32() == 0u32 {
+            return Some((
+                term.source_info.span,
+                Location {
+                    block: target.unwrap(),
+                    statement_index: 0,
+                },
+            ));
+        }
+    }
+    None
+}
+
+
+pub struct Analyzer<'a, 'tcx> {
+    pub tcx: TyCtxt<'tcx>,
+    info: &'a FuncInfo,
+    config: &'a crate::outparam_replacer::Config,
+    pub summaries: &'a FxHashMap<DefId, FunctionSummary>,
+    pub ptr_params: IndexVec<ArgIdx, Local>,
+    pub ptr_params_inv: FxHashMap<Local, ArgIdx>,
+    pub call_args: BTreeMap<Location, BTreeMap<usize, usize>>,
+    pub pre_context: PreAnalysisContext<'a>,
+    pub indirect_assigns: BTreeSet<Local>,
+    pub is_merged: bool,
+}
+
+struct AnalyzedBody {
+    states: BTreeMap<Location, BTreeMap<(MustPathSet, AbsNulls), AbsState>>,
+    writes_map: BTreeMap<Location, BTreeSet<AbsPath>>,
+    init_state: AbsState,
+    call_info_map: BTreeMap<Location, Vec<CallKind>>,
+    is_merged: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Write {
+    All,
+    Partial,
+    None,
+}
+
+impl<'a, 'tcx> Analyzer<'a, 'tcx> {
+    fn new(
+        tcx: TyCtxt<'tcx>,
+        info: &'a FuncInfo,
+        config: &'a crate::outparam_replacer::Config,
+        summaries: &'a FxHashMap<DefId, FunctionSummary>,
+        pre_context: PreAnalysisContext<'a>,
+    ) -> Self {
+        Self {
+            tcx,
+            info,
+            config,
+            summaries,
+            ptr_params: IndexVec::new(),
+            ptr_params_inv: FxHashMap::default(),
+            call_args: BTreeMap::new(),
+            pre_context,
+            indirect_assigns: BTreeSet::new(),
+            is_merged: false,
+        }
+    }
+
+    fn get_return_ptrs(&self, summary: &FunctionSummary) -> BTreeSet<Local> {
+        summary
+            .return_states
+            .values()
+            .flat_map(|st| {
+                let v = st.local.get(Local::ZERO);
+                self.get_read_paths_of_ptr(&v.ptrv, &[])
+            })
+            .map(|p| p.base)
+            .collect()
+    }
+
+    // Check if any local is used in the following blocks
+    fn check_local_uses(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        body: &Body<'tcx>,
+        block: &BasicBlock,
+        locs: &BTreeSet<Location>,
+        locals: &BTreeSet<Local>,
+    ) -> bool {
+        if locals.is_empty() {
+            return true;
+        }
+
+        for local in locals {
+            let mut work_list = VecDeque::new();
+            work_list.extend(body.basic_blocks.successors(*block));
+            let mut visited = BTreeSet::new();
+            let mut visitor = LocalVisitor::new(tcx, *local);
+
+            'outer: while let Some(bb) = work_list.pop_front() {
+                if visited.insert(bb) {
+                    let bbd = &body.basic_blocks[bb];
+
+                    for (i, stmt) in bbd.statements.iter().enumerate() {
+                        let loc = Location {
+                            block: bb,
+                            statement_index: i,
+                        };
+
+                        if !locs.contains(&loc) {
+                            visitor.clear();
+                            visitor.visit_statement(stmt, loc);
+                            match visitor.check_result {
+                                StatementCheck::None => {} /* no use -- continue to check next statement */
+                                StatementCheck::UseExist => return false, // found a use
+                                StatementCheck::Overwritten => {
+                                    continue 'outer;
+                                } /* value is overwritten -- stop checking */
+                            }
+                        }
+                    }
+
+                    let term = bbd.terminator();
+                    let loc = Location {
+                        block: bb,
+                        statement_index: bbd.statements.len(),
+                    };
+
+                    if !locs.contains(&loc) {
+                        visitor.clear();
+                        visitor.visit_terminator(term, loc);
+                        match visitor.check_result {
+                            StatementCheck::None => {}
+                            StatementCheck::UseExist => return false,
+                            StatementCheck::Overwritten => continue,
+                        }
+                    }
+                    work_list.extend(body.basic_blocks.successors(bb));
+                }
+            }
+        }
+        true
+    }
+
+    fn check_indirect_pure(&self, local: Local, local_writes: &mut BTreeSet<Local>) -> bool {
+        let var_nodes = self.pre_context.var_nodes;
+        let loc = var_nodes[&(self.pre_context.local_def_id, local)].index;
+
+        if self.check_may_points_global(loc) {
+            return false;
+        }
+
+        let sol = self.pre_context.solutions[loc].clone();
+        local_writes.extend(
+            sol.iter()
+                .flat_map(|loc| self.pre_context.index_local_map.get(&loc)),
+        );
+        true
+    }
+
+    fn check_terminator_pure(
+        &self,
+        loc: &Location,
+        local_writes: &mut BTreeSet<Local>,
+        param: Local,
+        call_info_map: &BTreeMap<Location, Vec<CallKind>>,
+        term: &Terminator<'_>,
+    ) -> bool {
+        match &term.kind {
+            TerminatorKind::Call { destination, .. } => {
+                let call_info = call_info_map.get(loc).unwrap();
+                if destination.local == Local::ZERO {
+                    return false;
+                }
+
+                let is_indirection = destination.is_indirect_first_projection();
+
+                if is_indirection
+                    && destination.local != param
+                    && !self.check_indirect_pure(destination.local, local_writes)
+                {
+                    return false;
+                }
+
+                if !is_indirection {
+                    local_writes.insert(destination.local);
+                }
+
+                // check the writes of callee
+                call_info.iter().all(|kind| match kind {
+                    CallKind::Method
+                    | CallKind::RustPure
+                    | CallKind::CPure
+                    | CallKind::IntraPure => true,
+                    CallKind::CEffect
+                    | CallKind::TOP
+                    | CallKind::RustEffect(None)
+                    | CallKind::IntraEffect => false,
+                    CallKind::RustEffect(Some(bases)) => {
+                        bases.iter().all(|p| match p {
+                            AbsBase::Local(idx) => {
+                                // Defer the check to the caller
+                                local_writes.insert(*idx);
+                                true
+                            }
+                            AbsBase::Heap => false,
+                            AbsBase::Null | AbsBase::Arg(_) => true,
+                        })
+                    }
+                })
+            }
+            TerminatorKind::InlineAsm { .. } => false,
+            _ => true,
+        }
+    }
+
+    fn check_assign_pure(
+        &self,
+        local_writes: &mut BTreeSet<Local>,
+        param: Local,
+        stmt: &StatementKind<'_>,
+    ) -> bool {
+        if let StatementKind::Assign(box (place, _)) = stmt {
+            let local = place.local;
+            if local == Local::ZERO {
+                return false;
+            }
+            if place.is_indirect_first_projection() {
+                if local == param {
+                    return true;
+                }
+                return self.check_indirect_pure(local, local_writes);
+            }
+
+            local_writes.insert(place.local);
+            true
+        } else {
+            unreachable!("{:?}", stmt)
+        }
+    }
+
+    // Compute locations where the parameters are non-null or null
+    fn compute_nonnull_null_locs(
+        &self,
+        result: &BTreeMap<Location, BTreeMap<(MustPathSet, AbsNulls), AbsState>>,
+        candidates: BTreeSet<Local>,
+    ) -> Vec<(Local, BTreeSet<Location>, BTreeSet<Location>)> {
+        let mut locs = vec![];
+
+        for l in candidates {
+            let mut nonnull_locs = BTreeSet::new();
+            let mut null_locs = BTreeSet::new();
+            // collection of locations except non-null or null
+            let mut non_nonnull_locs = BTreeSet::new();
+            let mut non_null_locs = BTreeSet::new();
+            for (loc, sts) in result {
+                for (_, nulls) in sts.keys() {
+                    if let Some(arg) = self.ptr_params_inv.get(&l) {
+                        match nulls.get(*arg) {
+                            AbsNull::Null => {
+                                null_locs.insert(*loc);
+                                non_nonnull_locs.insert(*loc);
+                            }
+                            AbsNull::Nonnull => {
+                                nonnull_locs.insert(*loc);
+                                non_null_locs.insert(*loc);
+                            }
+                            AbsNull::Top => {
+                                non_nonnull_locs.insert(*loc);
+                                non_null_locs.insert(*loc);
+                            }
+                        }
+                    }
+                }
+            }
+
+            let nonnull_locs = nonnull_locs
+                .difference(&non_nonnull_locs)
+                .cloned()
+                .collect();
+            let null_locs = null_locs.difference(&non_null_locs).cloned().collect();
+            locs.push((l, nonnull_locs, null_locs));
+        }
+        locs
+    }
+
+    // We consider a parameter to be nullable if below sets are not the same:
+    // 1. The set of locations that are reachable when x is non-null and have side-effects
+    // 2. The set of locations that are reachable when x is null and have side-effects
+    fn find_nullable_params(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        result: &BTreeMap<Location, BTreeMap<(MustPathSet, AbsNulls), AbsState>>,
+        body: &Body<'tcx>,
+        writes_map: &BTreeMap<Location, BTreeSet<AbsPath>>,
+        call_info_map: &BTreeMap<Location, Vec<CallKind>>,
+        candidates: BTreeSet<Local>,
+    ) -> BTreeSet<Local> {
+        self.compute_nonnull_null_locs(result, candidates)
+            .into_iter()
+            .filter_map(|(param, nonnull, null)| {
+                if null.is_empty() && nonnull.is_empty() {
+                    return None;
+                }
+
+                let nonnull_diff = nonnull.iter().fold(
+                    BTreeMap::new(),
+                    |mut acc: BTreeMap<BasicBlock, BTreeSet<Location>>, loc| {
+                        acc.entry(loc.block).or_default().insert(*loc);
+                        acc
+                    },
+                );
+                let null_diff = null.iter().fold(
+                    BTreeMap::new(),
+                    |mut acc: BTreeMap<BasicBlock, BTreeSet<Location>>, loc| {
+                        acc.entry(loc.block).or_default().insert(*loc);
+                        acc
+                    },
+                );
+
+                let check = |block, locs: &BTreeSet<_>, diff_locs| {
+                    let mut local_writes = BTreeSet::new();
+                    locs.iter().all(|loc| {
+                        let writes = writes_map.get(loc).unwrap();
+                        let Location {
+                            block,
+                            statement_index,
+                        } = loc;
+
+                        if writes.iter().any(|p| p.base != param) {
+                            return false;
+                        }
+
+                        let bbd = &body.basic_blocks[*block];
+                        if *statement_index < bbd.statements.len() {
+                            let stmt = &bbd.statements[*statement_index];
+                            self.check_assign_pure(&mut local_writes, param, &stmt.kind)
+                        } else {
+                            let term = bbd.terminator();
+                            self.check_terminator_pure(
+                                loc,
+                                &mut local_writes,
+                                param,
+                                call_info_map,
+                                term,
+                            )
+                        }
+                    }) && self.check_local_uses(tcx, body, block, diff_locs, &local_writes)
+                };
+                if nonnull_diff
+                    .iter()
+                    .all(|(b, locs)| check(b, locs, &nonnull))
+                    && null_diff.iter().all(|(b, locs)| check(b, locs, &null))
+                {
+                    None
+                } else {
+                    Some(param)
+                }
+            })
+            .collect::<BTreeSet<_>>()
+    }
+
+    // We consider a parameter p is implicitly non-null if every execution either:
+    // 1. effectively writes to the parameter when p -> Top
+    // 2. does not write to the parameter and p -> Top (no null check)
+    fn get_nullable_candidates(
+        &self,
+        return_states: &BTreeMap<(MustPathSet, AbsNulls), AbsState>,
+    ) -> (BTreeSet<Local>, BTreeSet<Local>) {
+        let mut candidates = BTreeSet::new();
+        let mut nonnull_params = BTreeSet::new();
+        for i in 1..=(self.info.inputs) {
+            let l = Local::from_usize(i);
+            let Some(arg) = self.ptr_params_inv.get(&l) else {
+                continue;
+            };
+
+            if return_states.values().all(|st| {
+                let writes = st.writes.iter().map(|p| p.base).collect::<FxHashSet<_>>();
+                (!writes.contains(&l) && st.nulls.is_top(*arg))
+                    || (writes.contains(&l) && st.nonnulls.contains(l))
+            }) {
+                nonnull_params.insert(l);
+            } else {
+                candidates.insert(l);
+            }
+        }
+        (candidates, nonnull_params)
+    }
+
+    // Check if the global variables that is reachable from the function
+    // is an alias of the function parameters
+    fn check_reachable_globals(
+        &self,
+        info_map: &FxHashMap<DefId, FuncInfo>,
+        globals: &FxHashMap<LocalDefId, Loc>,
+        reachables: &FxHashSet<DefId>,
+    ) -> BTreeSet<Local> {
+        let mut indexes = FxHashSet::default();
+
+        for reachable in reachables {
+            let globals = info_map[reachable]
+                .globals
+                .iter()
+                .filter_map(|def_id| {
+                    let local_id = def_id.as_local()?;
+                    let start = globals.get(&local_id).copied()?;
+                    let end = self.pre_context.ends[start];
+                    Some(start..=end)
+                })
+                .flatten();
+            indexes.extend(globals);
+        }
+
+        indexes
+            .into_iter()
+            .flat_map(|index| self.pre_context.check_index_global(index))
+            .collect()
+    }
+
+    fn check_may_points_global(&self, loc: Loc) -> bool {
+        let mut sol = self.pre_context.solutions[loc].clone();
+        sol.intersect(self.pre_context.globals);
+
+        if !sol.is_empty() {
+            return true;
+        }
+        false
+    }
+
+    fn check_global_writes(&self) -> bool {
+        self.indirect_assigns.iter().any(|local| {
+            let var_nodes = self.pre_context.var_nodes;
+            // We only check start since the local is a pointer
+            // If the local is the first parameter of the function, ends[loc] may not be the same as start
+            let start = var_nodes[&(self.pre_context.local_def_id, *local)].index;
+            self.check_may_points_global(start)
+        })
+    }
+
+    fn find_output_params(
+        &self,
+        summary: &FunctionSummary,
+        return_ptrs: &BTreeSet<Local>,
+        def_id: DefId,
+    ) -> Vec<OutputParam> {
+        if self.info.fn_ptr || summary.return_states.values().any(|st| st.writes.is_bot()) {
+            return vec![];
+        }
+
+        let reads: BTreeSet<_> = summary
+            .return_states
+            .values()
+            .flat_map(|st| st.reads.as_set())
+            .map(|p| p.base)
+            .collect();
+        let null_excludes: BTreeSet<_> = summary
+            .return_states
+            .values()
+            .flat_map(|st| st.null_excludes.as_set())
+            .map(|p| p.base)
+            .collect();
+        let excludes: BTreeSet<_> = summary
+            .return_states
+            .values()
+            .flat_map(|st| st.excludes.as_set())
+            .map(|p| p.base)
+            .collect();
+
+        let body = self.tcx.optimized_mir(def_id);
+        let mut writes = vec![];
+        for i in 1..=self.info.inputs {
+            let i = Local::from_usize(i);
+            if reads.contains(&i)
+                || excludes.contains(&i)
+                || null_excludes.contains(&i)
+                || return_ptrs.contains(&i)
+                || self.info.param_tys[i] == TypeInfo::Union
+            {
+                continue;
+            }
+
+            let ty = &body.local_decls[i].ty;
+            let TyKind::RawPtr(ty, ..) = ty.kind() else {
+                continue;
+            };
+            if ty.is_c_void(self.tcx) {
+                continue;
+            }
+
+            let expanded: BTreeSet<_> = self
+                .expands_path(&AbsPath::new(i, vec![]))
+                .into_iter()
+                .collect();
+            let wrs: Vec<_> = summary
+                .return_states
+                .values()
+                .filter_map(|st| {
+                    let arg = self.ptr_params_inv.get(&i).unwrap();
+                    if st.nulls.is_null(*arg) {
+                        None
+                    } else {
+                        let writes: BTreeSet<_> = st
+                            .writes
+                            .iter()
+                            .filter_map(|p| if p.base == i { Some(p.clone()) } else { None })
+                            .collect();
+                        let w = if writes.is_empty() {
+                            Write::None
+                        } else if writes == expanded {
+                            Write::All
+                        } else {
+                            Write::Partial
+                        };
+                        let rv = st.local.get(Local::ZERO).clone();
+                        Some((w, rv))
+                    }
+                })
+                .collect();
+
+            if wrs.iter().any(|(w, _)| *w == Write::All)
+                && wrs.iter().all(|(w, _)| *w != Write::Partial)
+            {
+                writes.push((i, wrs));
+            }
+        }
+        if writes.is_empty() {
+            return vec![];
+        }
+
+        let ret_ty = &body.local_decls[Local::from_usize(0)].ty;
+        writes
+            .into_iter()
+            .map(|(index, wrs)| {
+                let must = wrs.iter().all(|(w, _)| *w == Write::All);
+                let return_values = if !must {
+                    let (wst, nwst): (Vec<_>, Vec<_>) =
+                        wrs.into_iter().partition(|(w, _)| *w == Write::All);
+                    let w = wst
+                        .into_iter()
+                        .map(|(_, v)| v)
+                        .reduce(|a, b| a.join(&b))
+                        .unwrap();
+                    let nw = nwst
+                        .into_iter()
+                        .map(|(_, v)| v)
+                        .reduce(|a, b| a.join(&b))
+                        .unwrap();
+                    match ret_ty.kind() {
+                        TyKind::Int(_) => ReturnValues::Int(w.intv.clone(), nw.intv.clone()),
+                        TyKind::Uint(_) => ReturnValues::Uint(w.uintv.clone(), nw.uintv.clone()),
+                        TyKind::Bool => ReturnValues::Bool(w.boolv, nw.boolv),
+                        _ => ReturnValues::None,
+                    }
+                } else {
+                    ReturnValues::None
+                };
+                OutputParam {
+                    index: index.index() - 1,
+                    must,
+                    return_values,
+                    complete_writes: vec![],
+                }
+            })
+            .collect()
+    }
+
+    fn find_complete_write(
+        &self,
+        param: &mut OutputParam,
+        result: &BTreeMap<Location, BTreeMap<(MustPathSet, AbsNulls), AbsState>>,
+        writes_map: &BTreeMap<Location, BTreeSet<AbsPath>>,
+        call_args: &BTreeMap<Location, BTreeMap<usize, usize>>,
+        def_id: DefId,
+    ) {
+        if param.must {
+            return;
+        }
+
+        let paths = self.expands_path(&AbsPath::new(Local::from_usize(param.index + 1), vec![]));
+
+        let body = self.tcx.optimized_mir(def_id);
+        let predecessors = body.basic_blocks.predecessors();
+        for (location, sts) in result {
+            let complete = sts.keys().any(|(w, _)| {
+                let w = w.as_set();
+                paths.iter().all(|p| w.contains(p))
+            });
+            if !complete {
+                continue;
+            }
+            let prevs = if location.statement_index == 0 {
+                predecessors[location.block]
+                    .iter()
+                    .map(|bb| {
+                        let bbd = &body.basic_blocks[*bb];
+                        Location {
+                            block: *bb,
+                            statement_index: bbd.statements.len(),
+                        }
+                    })
+                    .collect()
+            } else {
+                let mut l = *location;
+                l.statement_index -= 1;
+                vec![l]
+            };
+            for prev in prevs {
+                let sts = some_or!(result.get(&prev), continue);
+                let pcomplete = sts.keys().all(|(w, _)| {
+                    let w = w.as_set();
+                    paths.iter().all(|p| w.contains(p))
+                });
+                if pcomplete {
+                    continue;
+                }
+                let writes = some_or!(writes_map.get(&prev), continue);
+                let pwrite = paths.iter().any(|p| writes.contains(p));
+                if !pwrite {
+                    continue;
+                }
+                let Location {
+                    block,
+                    statement_index,
+                } = prev;
+                let write_arg = call_args
+                    .get(&prev)
+                    .and_then(|call_args| call_args.get(&param.index))
+                    .cloned();
+                let block = block.as_usize();
+                let cw = CompleteWrite {
+                    block,
+                    statement_index,
+                    write_arg,
+                };
+                param.complete_writes.push(cw);
+            }
+        }
+    }
+
+    fn analyze_body(&mut self, body: &Body<'tcx>) -> AnalyzedBody {
+        let mut start_state = AbsState::bot();
+        start_state.writes = MustPathSet::top();
+        start_state.nulls = AbsNulls::bot();
+        start_state.nonnulls = MustLocalSet::top();
+
+        for i in 1..=self.info.inputs {
+            let local = Local::from_usize(i);
+            let ty = &body.local_decls[local].ty;
+            let v = if let TyKind::RawPtr(ty, ..) = ty.kind() {
+                let v = self.top_value_of_ty(ty);
+                let idx = start_state.args.push(v);
+                start_state.nulls.push_top();
+                self.ptr_params.push(local);
+                self.ptr_params_inv.insert(local, idx);
+                AbsValue::arg(idx)
+            } else {
+                self.top_value_of_ty(ty)
+            };
+            start_state.local.set(local, v);
+        }
+
+        if self.config.check_param_alias {
+            for a in self.pre_context.alias {
+                start_state.excludes.insert(AbsPath::new(*a, vec![]));
+            }
+        }
+
+        let init_state = start_state.clone();
+
+        let start_label = Label {
+            location: Location::START,
+            writes: start_state.writes.clone(),
+            nulls: start_state.nulls.clone(),
+        };
+        let bot = AbsState::bot();
+
+        let loop_heads: BTreeSet<Location> = self
+            .info
+            .loop_blocks
+            .keys()
+            .map(|bb| bb.start_location())
+            .collect();
+        let mut merging_blocks = if self.config.max_loop_head_states <= 1 {
+            self.info.loop_blocks.values().flatten().cloned().collect()
+        } else {
+            BTreeSet::new()
+        };
+
+        let (states, writes_map, call_info_map) = 'analysis_loop: loop {
+            if !merging_blocks.is_empty() {
+                self.is_merged = true;
+            }
+            let mut work_list = WorkList::new(&self.info.rpo_map);
+            work_list.push(start_label.clone());
+
+            let mut states: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
+            states.entry(start_label.location).or_default().insert(
+                (start_label.writes.clone(), start_label.nulls.clone()),
+                start_state.clone(),
+            );
+            let mut writes_map: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+            let mut call_info_map: BTreeMap<_, Vec<_>> = BTreeMap::new();
+
+            self.call_args.clear();
+            while let Some(label) = work_list.pop() {
+                let state = states
+                    .get(&label.location)
+                    .and_then(|states| states.get(&(label.writes.clone(), label.nulls.clone())))
+                    .unwrap_or(&bot);
+                let Location {
+                    block,
+                    statement_index,
+                } = label.location;
+                let bbd = &body.basic_blocks[block];
+                let (new_next_states, next_locations, writes) =
+                    if statement_index < bbd.statements.len() {
+                        let stmt = &bbd.statements[statement_index];
+                        let (new_next_state, writes) = self.transfer_statement(stmt, state);
+                        let next_location = Location {
+                            block,
+                            statement_index: statement_index + 1,
+                        };
+                        (vec![new_next_state], vec![next_location], writes)
+                    } else {
+                        let TransferedTerminator {
+                            next_states,
+                            next_locations,
+                            writes,
+                            call_info,
+                        } = self.transfer_terminator(bbd.terminator(), state, label.location);
+                        // Record locations and call info of function calls
+                        call_info_map
+                            .entry(label.location)
+                            .or_default()
+                            .extend(call_info);
+                        (next_states, next_locations, writes)
+                    };
+                writes_map.entry(label.location).or_default().extend(writes);
+
+                for location in &next_locations {
+                    let dead_locals = &self.info.dead_locals[location.block];
+                    if merging_blocks.contains(&location.block) {
+                        let next_state = if let Some(states) = states.get(location) {
+                            assert_eq!(states.len(), 1);
+                            states.first_key_value().unwrap().1
+                        } else {
+                            &bot
+                        };
+                        let mut joined = next_state.clone();
+                        if let Some(st) = new_next_states.first() {
+                            let mut new_next_state = st.clone();
+                            for st in new_next_states.iter().skip(1) {
+                                new_next_state = new_next_state.join(st);
+                            }
+                            if loop_heads.contains(location) && !self.config.no_widening {
+                                joined = joined.widen(&new_next_state);
+                            } else {
+                                joined = joined.join(&new_next_state);
+                            }
+                        }
+                        if location.statement_index == 0 {
+                            joined.local.clear_dead_locals(dead_locals);
+                        }
+                        if !joined.ord(next_state) {
+                            work_list.remove_location(*location);
+                            let next_label = Label {
+                                location: *location,
+                                writes: joined.writes.clone(),
+                                nulls: joined.nulls.clone(),
+                            };
+                            work_list.push(next_label);
+
+                            let mut new_map = BTreeMap::new();
+                            new_map.insert((joined.writes.clone(), joined.nulls.clone()), joined);
+                            states.insert(*location, new_map);
+                        }
+                    } else {
+                        for new_next_state in &new_next_states {
+                            let next_state = states
+                                .get(location)
+                                .and_then(|states| {
+                                    states.get(&(
+                                        new_next_state.writes.clone(),
+                                        new_next_state.nulls.clone(),
+                                    ))
+                                })
+                                .unwrap_or(&bot);
+
+                            let mut joined = if loop_heads.contains(location) && !self.config.no_widening
+                            {
+                                next_state.widen(new_next_state)
+                            } else {
+                                next_state.join(new_next_state)
+                            };
+                            if location.statement_index == 0 {
+                                joined.local.clear_dead_locals(dead_locals);
+                            }
+                            if !joined.ord(next_state) {
+                                let next_label = Label {
+                                    location: *location,
+                                    writes: new_next_state.writes.clone(),
+                                    nulls: new_next_state.nulls.clone(),
+                                };
+                                states.entry(*location).or_default().insert(
+                                    (next_label.writes.clone(), next_label.nulls.clone()),
+                                    joined,
+                                );
+                                work_list.push(next_label);
+                            }
+                        }
+                    }
+                }
+                let mut restart = false;
+                for next_location in next_locations {
+                    for blocks in self.info.loop_blocks.values() {
+                        if !blocks.contains(&next_location.block) {
+                            continue;
+                        }
+                        let len = states[&next_location].keys().len();
+                        if len > self.config.max_loop_head_states {
+                            merging_blocks.extend(blocks);
+                            restart = true;
+                        }
+                    }
+                }
+                if restart {
+                    continue 'analysis_loop;
+                }
+            }
+            break (states, writes_map, call_info_map);
+        };
+
+        AnalyzedBody {
+            states,
+            writes_map,
+            init_state,
+            call_info_map,
+            is_merged: self.is_merged,
+        }
+    }
+
+    pub fn expands_path(&self, place: &AbsPath) -> Vec<AbsPath> {
+        self.info.expands_path(place)
+    }
+
+    pub fn def_id_to_string(&self, def_id: DefId) -> String {
+        self.tcx.def_path(def_id).to_string_no_crate_verbose()
+    }
+
+    pub fn span_to_string(&self, span: Span) -> String {
+        self.tcx.sess.source_map().span_to_snippet(span).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Label {
+    pub location: Location,
+    pub writes: MustPathSet,
+    pub nulls: AbsNulls,
+}
+
+#[derive(Debug)]
+struct WorkList<'a> {
+    rpo_map: &'a BTreeMap<BasicBlock, usize>,
+    labels: BTreeMap<(usize, usize), Vec<Label>>,
+}
+
+impl<'a> WorkList<'a> {
+    fn new(rpo_map: &'a BTreeMap<BasicBlock, usize>) -> Self {
+        Self {
+            rpo_map,
+            labels: BTreeMap::new(),
+        }
+    }
+
+    fn pop(&mut self) -> Option<Label> {
+        let mut entry = self.labels.first_entry()?;
+        let labels = entry.get_mut();
+        let label = labels.pop().unwrap();
+        if labels.is_empty() {
+            entry.remove();
+        }
+        Some(label)
+    }
+
+    fn push(&mut self, label: Label) {
+        let block_idx = self.rpo_map[&label.location.block];
+        let labels = self
+            .labels
+            .entry((block_idx, label.location.statement_index))
+            .or_default();
+        if !labels.contains(&label) {
+            labels.push(label)
+        }
+    }
+
+    fn remove_location(&mut self, location: Location) {
+        let block_idx = self.rpo_map[&location.block];
+        self.labels.remove(&(block_idx, location.statement_index));
+    }
+
+    #[allow(unused)]
+    fn len(&self) -> usize {
+        self.labels.values().map(|v| v.len()).sum()
+    }
+}
+
+
+// structs and functions used computing the FuncInfos
+#[derive(Debug, Clone)]
+struct FuncInfo {
+    inputs: usize,
+    param_tys: IndexVec<Local, TypeInfo>,
+    loop_blocks: BTreeMap<BasicBlock, BTreeSet<BasicBlock>>,
+    rpo_map: BTreeMap<BasicBlock, usize>,
+    dead_locals: IndexVec<BasicBlock, DenseBitSet<Local>>,
+    fn_ptr: bool,
+    globals: FxHashSet<DefId>,
+}
+
+impl FuncInfo {
+    fn expands_path(&self, place: &AbsPath) -> Vec<AbsPath> {
+        if let Some(ty) = self.param_tys.get(place.base) {
+            if let TypeInfo::Struct(fields) = ty {
+                expand_projections(&place.projections, fields, vec![])
+                    .into_iter()
+                    .map(|projections| AbsPath::new(place.base, projections))
+                    .collect()
+            } else {
+                vec![AbsPath::new(place.base, vec![])]
+            }
+        } else {
+            vec![]
+        }
+    }
+}
+
+fn expand_projections(
+    projections: &[FieldIdx],
+    tys: &IndexVec<FieldIdx, TypeInfo>,
+    mut curr: Vec<FieldIdx>,
+) -> Vec<Vec<FieldIdx>> {
+    if let Some(first) = projections.first() {
+        curr.push(*first);
+        if let Some(ty) = tys.get(*first) {
+            if let TypeInfo::Struct(fields) = ty {
+                expand_projections(&projections[1..], fields, curr)
+            } else {
+                vec![curr]
+            }
+        } else {
+            vec![]
+        }
+    } else {
+        tys.iter_enumerated()
+            .flat_map(|(n, ty)| {
+                let mut curr = curr.clone();
+                curr.push(n);
+                if let TypeInfo::Struct(fields) = ty {
+                    expand_projections(projections, fields, curr)
+                } else {
+                    vec![curr]
+                }
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TypeInfo {
+    Struct(IndexVec<FieldIdx, TypeInfo>),
+    Union,
+    NonStruct,
+}
+
+impl TypeInfo {
+    fn from_ty<'tcx>(ty: &Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
+        if let TyKind::Adt(adt_def, generic_args) = ty.kind() {
+            match adt_def.adt_kind() {
+                AdtKind::Struct => {
+                    let variant = adt_def.variant(VariantIdx::from_usize(0));
+                    let tys = variant
+                        .fields
+                        .iter()
+                        .map(|field| Self::from_ty(&field.ty(tcx, generic_args), tcx))
+                        .collect();
+                    Self::Struct(tys)
+                }
+                AdtKind::Union => Self::Union,
+                AdtKind::Enum => Self::NonStruct,
+            }
+        } else {
+            Self::NonStruct
+        }
+    }
+}
+
+
+fn get_param_tys<'tcx>(
+    body: &Body<'tcx>,
+    inputs: usize,
+    tcx: TyCtxt<'tcx>,
+) -> IndexVec<Local, TypeInfo> {
+    let mut param_tys = IndexVec::new();
+    for (i, local) in body.local_decls.iter_enumerated() {
+        if i.index() > inputs {
+            break;
+        }
+        let ty = if let TyKind::RawPtr(ty, ..) = local.ty.kind() {
+            TypeInfo::from_ty(ty, tcx)
+        } else {
+            TypeInfo::NonStruct
+        };
+        param_tys.push(ty);
+    }
+    param_tys
+}
+
+fn get_rpo_map(body: &Body<'_>) -> BTreeMap<BasicBlock, usize> {
+    body.basic_blocks
+        .reverse_postorder()
+        .iter()
+        .enumerate()
+        .map(|(i, bb)| (*bb, i))
+        .collect()
+}
+
+fn get_loop_blocks(
+    body: &Body<'_>,
+    rpo_map: &BTreeMap<BasicBlock, usize>,
+) -> BTreeMap<BasicBlock, BTreeSet<BasicBlock>> {
+    let dominators = body.basic_blocks.dominators();
+    let loop_heads: BTreeSet<_> = body
+        .basic_blocks
+        .indices()
+        .flat_map(|bb| {
+            assert!(dominators.is_reachable(bb));
+            let mut doms: Vec<_> =
+                std::iter::successors(Some(bb), |&bb_| dominators.immediate_dominator(bb_))
+                    .collect();
+            let succs: BTreeSet<_> = body.basic_blocks.successors(bb).collect();
+            doms.retain(|dom| succs.contains(dom));
+            doms
+        })
+        .collect();
+    let mut loop_heads: Vec<_> = loop_heads.into_iter().collect();
+    loop_heads.sort_by_key(|bb| rpo_map[bb]);
+
+    let succ_map: FxHashMap<_, FxHashSet<_>> = body
+        .basic_blocks
+        .indices()
+        .map(|bb| (bb, body.basic_blocks.successors(bb).collect()))
+        .collect();
+    let mut inv_map = graph_util::inverse(&succ_map);
+    loop_heads
+        .into_iter()
+        .map(|head| {
+            let reachables = graph_util::reachable_vertices(&inv_map, head);
+            for succs in inv_map.values_mut() {
+                succs.remove(&head);
+            }
+            let loop_blocks = body
+                .basic_blocks
+                .indices()
+                .filter(|bb| dominators.dominates(head, *bb) && reachables.contains(bb))
+                .collect();
+            (head, loop_blocks)
+        })
+        .collect()
+}
+
+fn compute_rpo_map(
+    body: &Body<'_>,
+    loop_blocks: &BTreeMap<BasicBlock, BTreeSet<BasicBlock>>,
+) -> BTreeMap<BasicBlock, usize> {
+    fn traverse(
+        current: BasicBlock,
+        visited: &mut BTreeSet<BasicBlock>,
+        po: &mut Vec<BasicBlock>,
+        body: &Body<'_>,
+        loop_blocks: &BTreeMap<BasicBlock, BTreeSet<BasicBlock>>,
+    ) {
+        if visited.contains(&current) {
+            return;
+        }
+        visited.insert(current);
+        let loops: Vec<_> = loop_blocks
+            .values()
+            .filter(|blocks| blocks.contains(&current))
+            .collect();
+        let mut succs: Vec<_> = body.basic_blocks.successors(current).collect();
+        succs.sort_by_key(|succ| loops.iter().filter(|blocks| blocks.contains(succ)).count());
+        for succ in succs {
+            traverse(succ, visited, po, body, loop_blocks);
+        }
+        po.push(current);
+    }
+    let mut visited = BTreeSet::new();
+    let mut rpo = vec![];
+    traverse(
+        BasicBlock::from_usize(0),
+        &mut visited,
+        &mut rpo,
+        body,
+        loop_blocks,
+    );
+    rpo.reverse();
+    rpo.into_iter().enumerate().map(|(i, bb)| (bb, i)).collect()
+}
+
+fn get_dead_locals<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> IndexVec<BasicBlock, DenseBitSet<Local>> {
+    let mut borrowed_locals = rustc_mir_dataflow::impls::borrowed_locals(body);
+    borrowed_locals.insert(Local::from_usize(0));
+    let mut cursor = rustc_mir_dataflow::impls::MaybeLiveLocals
+        .iterate_to_fixpoint(tcx, body, None)
+        .into_results_cursor(body);
+    body.basic_blocks
+        .indices()
+        .map(|bb| {
+            cursor.seek_to_block_start(bb);
+            let live_locals = cursor.get();
+            let mut borrowed_or_live_locals = borrowed_locals.clone();
+            borrowed_or_live_locals.union(live_locals);
+            let mut dead_locals = DenseBitSet::new_filled(body.local_decls.len());
+            dead_locals.subtract(&borrowed_or_live_locals);
+            dead_locals
+        })
+        .collect()
+}
+
+
+// MIR, HIR Visitors
+struct CallVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    callees: FxHashSet<DefId>,
+}
+
+impl<'tcx> CallVisitor<'tcx> {
+    fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self {
+            tcx,
+            callees: FxHashSet::default(),
+        }
+    }
+}
+
+impl<'tcx> HVisitor<'tcx> for CallVisitor<'tcx> {
+    type NestedFilter = nested_filter::OnlyBodies;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
+        if let ExprKind::Call(callee, _) = expr.kind {
+            if let ExprKind::Path(QPath::Resolved(_, path)) = callee.kind {
+                if let Res::Def(DefKind::Fn, def_id) = path.res {
+                    self.callees.insert(def_id);
+                }
+            }
+        }
+        rustc_hir::intravisit::walk_expr(self, expr);
+    }
+}
+
+struct FnPtrVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    callees: FxHashSet<HirId>,
+    fn_ptrs: FxHashSet<DefId>,
+}
+
+impl<'tcx> FnPtrVisitor<'tcx> {
+    fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self {
+            tcx,
+            callees: FxHashSet::default(),
+            fn_ptrs: FxHashSet::default(),
+        }
+    }
+}
+
+impl<'tcx> HVisitor<'tcx> for FnPtrVisitor<'tcx> {
+    type NestedFilter = nested_filter::OnlyBodies;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
+        match expr.kind {
+            ExprKind::Call(callee, _) => {
+                self.callees.insert(callee.hir_id);
+            }
+            ExprKind::Path(QPath::Resolved(_, path)) => {
+                if !self.callees.contains(&expr.hir_id) {
+                    if let Res::Def(def_kind, def_id) = path.res {
+                        if def_kind.is_fn_like() {
+                            self.fn_ptrs.insert(def_id);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        rustc_hir::intravisit::walk_expr(self, expr);
+    }
+}
+
+enum StatementCheck {
+    None,
+    UseExist,
+    Overwritten,
+}
+
+struct LocalVisitor<'tcx> {
+    _tcx: TyCtxt<'tcx>,
+    local: Local,
+    check_result: StatementCheck,
+}
+
+impl<'tcx> LocalVisitor<'tcx> {
+    fn new(tcx: TyCtxt<'tcx>, local: Local) -> Self {
+        Self {
+            _tcx: tcx,
+            local,
+            check_result: StatementCheck::None,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.check_result = StatementCheck::None;
+    }
+}
+
+impl<'tcx> MVisitor<'tcx> for LocalVisitor<'tcx> {
+    fn visit_local(&mut self, local: Local, context: PlaceContext, _location: Location) {
+        if self.local == local {
+            match context {
+                PlaceContext::MutatingUse(MutatingUseContext::Store)
+                | PlaceContext::MutatingUse(MutatingUseContext::Call)
+                | PlaceContext::MutatingUse(MutatingUseContext::AsmOutput)
+                | PlaceContext::MutatingUse(MutatingUseContext::Yield) => {
+                    self.check_result = StatementCheck::Overwritten;
+                }
+                PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy)
+                | PlaceContext::NonMutatingUse(NonMutatingUseContext::Move)
+                | PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection)
+                | PlaceContext::NonMutatingUse(NonMutatingUseContext::RawBorrow)
+                | PlaceContext::MutatingUse(MutatingUseContext::Borrow)
+                | PlaceContext::MutatingUse(MutatingUseContext::RawBorrow) => {
+                    self.check_result = StatementCheck::UseExist;
+                }
+                _ => {
+                    self.check_result = StatementCheck::None;
+                }
+            }
+        }
+    }
+}
+
+struct GlobalVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    globals: FxHashSet<DefId>,
+}
+
+impl<'tcx> GlobalVisitor<'tcx> {
+    fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self {
+            tcx,
+            globals: FxHashSet::default(),
+        }
+    }
+}
+
+impl<'tcx> MVisitor<'tcx> for GlobalVisitor<'tcx> {
+    fn visit_const_operand(&mut self, constant: &ConstOperand<'tcx>, _location: Location) {
+        if let Const::Val(ConstValue::Scalar(Scalar::Ptr(ptr, _)), _) = constant.const_ {
+            if let GlobalAlloc::Static(def_id) = self.tcx.global_alloc(ptr.provenance.alloc_id()) {
+                self.globals.insert(def_id);
+            }
+        }
+    }
+
+    fn visit_statement(&mut self, stmt: &Statement<'tcx>, location: Location) {
+        let StatementKind::Assign(box (_l, r)) = &stmt.kind else {
+            return;
+        };
+        if let Rvalue::ThreadLocalRef(def_id) = r {
+            self.globals.insert(*def_id);
+        }
+        self.super_statement(stmt, location);
+    }
 }

--- a/src/outparam_replacer/ai/analysis.rs
+++ b/src/outparam_replacer/ai/analysis.rs
@@ -194,9 +194,10 @@ pub fn analyze(
     for id in tcx.hir_free_items() {
         let item = tcx.hir_item(id);
         if let Some(ident) = item.kind.ident()
-            && ident.name.as_str() == "main" {
-                continue;
-            }
+            && ident.name.as_str() == "main"
+        {
+            continue;
+        }
         let inputs = if let rustc_hir::ItemKind::Fn { sig, .. } = &item.kind {
             sig.decl.inputs.len()
         } else {
@@ -512,9 +513,10 @@ pub fn analyze(
                                 let always_write = loop {
                                     if let Some(bb) = stack.pop() {
                                         if let Some(musts) = bb_must.get(&bb)
-                                            && !musts.contains(index) {
-                                                break false;
-                                            }
+                                            && !musts.contains(index)
+                                        {
+                                            break false;
+                                        }
 
                                         let term = body.basic_blocks[bb].terminator();
                                         for bb in term.successors() {
@@ -574,13 +576,14 @@ fn return_location(body: &Body<'_>) -> Option<Location> {
     for block in body.basic_blocks.indices() {
         let bbd = &body.basic_blocks[block];
         if let Some(terminator) = &bbd.terminator
-            && terminator.kind == TerminatorKind::Return {
-                let location = Location {
-                    block,
-                    statement_index: bbd.statements.len(),
-                };
-                return Some(location);
-            }
+            && terminator.kind == TerminatorKind::Return
+        {
+            let location = Location {
+                block,
+                statement_index: bbd.statements.len(),
+            };
+            return Some(location);
+        }
     }
     None
 }
@@ -588,15 +591,16 @@ fn return_location(body: &Body<'_>) -> Option<Location> {
 fn exists_assign0(body: &Body<'_>, bb: BasicBlock) -> Option<(Span, Location)> {
     for (i, stmt) in body.basic_blocks[bb].statements.iter().enumerate() {
         if let StatementKind::Assign(rb) = &stmt.kind
-            && (**rb).0.local.as_u32() == 0u32 {
-                return Some((
-                    stmt.source_info.span,
-                    Location {
-                        block: bb,
-                        statement_index: i,
-                    },
-                ));
-            }
+            && (**rb).0.local.as_u32() == 0u32
+        {
+            return Some((
+                stmt.source_info.span,
+                Location {
+                    block: bb,
+                    statement_index: i,
+                },
+            ));
+        }
     }
     let term = body.basic_blocks[bb].terminator();
     if let TerminatorKind::Call {
@@ -608,15 +612,16 @@ fn exists_assign0(body: &Body<'_>, bb: BasicBlock) -> Option<(Span, Location)> {
         call_source: _,
         fn_span: _,
     } = term.kind
-        && destination.local.as_u32() == 0u32 {
-            return Some((
-                term.source_info.span,
-                Location {
-                    block: target.unwrap(),
-                    statement_index: 0,
-                },
-            ));
-        }
+        && destination.local.as_u32() == 0u32
+    {
+        return Some((
+            term.source_info.span,
+            Location {
+                block: target.unwrap(),
+                statement_index: 0,
+            },
+        ));
+    }
     None
 }
 
@@ -1759,9 +1764,10 @@ impl<'tcx> HVisitor<'tcx> for CallVisitor<'tcx> {
     fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
         if let ExprKind::Call(callee, _) = expr.kind
             && let ExprKind::Path(QPath::Resolved(_, path)) = callee.kind
-                && let Res::Def(DefKind::Fn, def_id) = path.res {
-                    self.callees.insert(def_id);
-                }
+            && let Res::Def(DefKind::Fn, def_id) = path.res
+        {
+            self.callees.insert(def_id);
+        }
         rustc_hir::intravisit::walk_expr(self, expr);
     }
 }
@@ -1797,9 +1803,10 @@ impl<'tcx> HVisitor<'tcx> for FnPtrVisitor<'tcx> {
             ExprKind::Path(QPath::Resolved(_, path)) => {
                 if !self.callees.contains(&expr.hir_id)
                     && let Res::Def(def_kind, def_id) = path.res
-                        && def_kind.is_fn_like() {
-                            self.fn_ptrs.insert(def_id);
-                        }
+                    && def_kind.is_fn_like()
+                {
+                    self.fn_ptrs.insert(def_id);
+                }
             }
             _ => {}
         }
@@ -1876,9 +1883,10 @@ impl<'tcx> GlobalVisitor<'tcx> {
 impl<'tcx> MVisitor<'tcx> for GlobalVisitor<'tcx> {
     fn visit_const_operand(&mut self, constant: &ConstOperand<'tcx>, _location: Location) {
         if let Const::Val(ConstValue::Scalar(Scalar::Ptr(ptr, _)), _) = constant.const_
-            && let GlobalAlloc::Static(def_id) = self.tcx.global_alloc(ptr.provenance.alloc_id()) {
-                self.globals.insert(def_id);
-            }
+            && let GlobalAlloc::Static(def_id) = self.tcx.global_alloc(ptr.provenance.alloc_id())
+        {
+            self.globals.insert(def_id);
+        }
     }
 
     fn visit_statement(&mut self, stmt: &Statement<'tcx>, location: Location) {

--- a/src/outparam_replacer/ai/analysis.rs
+++ b/src/outparam_replacer/ai/analysis.rs
@@ -40,7 +40,7 @@ use super::{
     semantics::{CallKind, TransferedTerminator},
 };
 use crate::{
-    compile_util, graph_util,
+    graph_util, ir_util,
     points_to::andersen::{self, Loc},
     ty_shape,
 };
@@ -217,7 +217,7 @@ pub fn analyze(
         callees.retain(|callee| funcs.contains(callee));
     }
 
-    let sccs = graph_util::sccs_copied::<DefId, true>(&call_graph);
+    let sccs = graph_util::sccs_copied::<DefId, false>(&call_graph);
     let transitive = graph_util::reflexive_transitive_closure(&call_graph);
     let po: Vec<_> = sccs.post_order().collect();
 
@@ -572,7 +572,7 @@ pub fn analyze(
             let f = tcx.def_path(*def_id).to_string_no_crate_verbose();
             let body = tcx.optimized_mir(*def_id);
             let blocks = body.basic_blocks.len();
-            let stmts = compile_util::body_size(body);
+            let stmts = ir_util::body_size(body);
             println!("{:?} {} {} {:.3}", f, blocks, stmts, *t as f32 / 1000.0);
         }
     }

--- a/src/outparam_replacer/ai/analysis.rs
+++ b/src/outparam_replacer/ai/analysis.rs
@@ -9,24 +9,24 @@ use rustc_const_eval::interpret::{GlobalAlloc, Scalar};
 use rustc_data_structures::graph::Successors;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::{
+    Expr, ExprKind, HirId, QPath,
     def::{DefKind, Res},
     intravisit::Visitor as HVisitor,
-    Expr, ExprKind, HirId, QPath,
 };
-use rustc_index::{bit_set::DenseBitSet, IndexVec};
+use rustc_index::{IndexVec, bit_set::DenseBitSet};
 use rustc_middle::{
     hir::nested_filter,
     mir::{
-        visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor as MVisitor},
         BasicBlock, Body, Const, ConstOperand, ConstValue, Local, Location, Rvalue, Statement,
         StatementKind, Terminator, TerminatorKind,
+        visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor as MVisitor},
     },
     ty::{AdtKind, Ty, TyCtxt, TyKind},
 };
 use rustc_mir_dataflow::Analysis as _;
 use rustc_span::{
-    def_id::{DefId, LocalDefId},
     Span,
+    def_id::{DefId, LocalDefId},
 };
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -34,14 +34,13 @@ use typed_arena::Arena;
 
 use super::{
     domains::*,
-    semantics::{CallKind, TransferedTerminator},
     pre_analysis::{self, PreAnalysisContext},
+    semantics::{CallKind, TransferedTerminator},
 };
-
 use crate::{
+    graph_util,
     points_to::andersen::{self, Loc},
     ty_shape,
-    graph_util,
 };
 
 // TODO: Remove span translation
@@ -218,9 +217,7 @@ pub fn analyze(
 
     let sccs = graph_util::sccs_copied::<DefId, true>(&call_graph);
     let transitive = graph_util::reflexive_transitive_closure(&call_graph);
-    let po: Vec<_> = sccs
-        .post_order()
-        .collect();
+    let po: Vec<_> = sccs.post_order().collect();
 
     let mut visitor = FnPtrVisitor::new(tcx);
     let mut global_visitor = GlobalVisitor::new(tcx);
@@ -554,7 +551,6 @@ pub fn analyze(
         }
     }
 
-
     if config.max_loop_head_states <= 1 {
         wbrs.clear();
         rcfws.clear();
@@ -629,7 +625,6 @@ fn exists_assign0(body: &Body<'_>, bb: BasicBlock) -> Option<(Span, Location)> {
     }
     None
 }
-
 
 pub struct Analyzer<'a, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
@@ -1402,12 +1397,12 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
                                 })
                                 .unwrap_or(&bot);
 
-                            let mut joined = if loop_heads.contains(location) && !self.config.no_widening
-                            {
-                                next_state.widen(new_next_state)
-                            } else {
-                                next_state.join(new_next_state)
-                            };
+                            let mut joined =
+                                if loop_heads.contains(location) && !self.config.no_widening {
+                                    next_state.widen(new_next_state)
+                                } else {
+                                    next_state.join(new_next_state)
+                                };
                             if location.statement_index == 0 {
                                 joined.local.clear_dead_locals(dead_locals);
                             }
@@ -1521,7 +1516,6 @@ impl<'a> WorkList<'a> {
     }
 }
 
-
 // structs and functions used computing the FuncInfos
 #[derive(Debug, Clone)]
 struct FuncInfo {
@@ -1610,7 +1604,6 @@ impl TypeInfo {
         }
     }
 }
-
 
 fn get_param_tys<'tcx>(
     body: &Body<'tcx>,
@@ -1746,7 +1739,6 @@ fn get_dead_locals<'tcx>(
         })
         .collect()
 }
-
 
 // MIR, HIR Visitors
 struct CallVisitor<'tcx> {

--- a/src/outparam_replacer/ai/domains.rs
+++ b/src/outparam_replacer/ai/domains.rs
@@ -1,4 +1,3 @@
-
 use std::{
     collections::{BTreeMap, BTreeSet},
     ops::Deref,
@@ -8,7 +7,7 @@ use std::{
 use lazy_static::lazy_static;
 use rustc_abi::FieldIdx;
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_index::{bit_set::DenseBitSet, IndexVec};
+use rustc_index::{IndexVec, bit_set::DenseBitSet};
 use rustc_middle::mir::Local;
 use rustc_span::def_id::DefId;
 use serde::{Deserialize, Serialize};
@@ -477,11 +476,7 @@ impl AbsValue {
 
     #[inline]
     pub fn alpha_bool(b: bool) -> Self {
-        if b {
-            V_TRUE.clone()
-        } else {
-            V_FALSE.clone()
-        }
+        if b { V_TRUE.clone() } else { V_FALSE.clone() }
     }
 
     pub fn alpha_list(l: Vec<AbsValue>) -> Self {
@@ -2388,11 +2383,7 @@ impl AbsBool {
     }
 
     fn alpha(b: bool) -> Self {
-        if b {
-            Self::True
-        } else {
-            Self::False
-        }
+        if b { Self::True } else { Self::False }
     }
 
     pub fn gamma(self) -> Vec<bool> {

--- a/src/outparam_replacer/ai/domains.rs
+++ b/src/outparam_replacer/ai/domains.rs
@@ -2822,9 +2822,10 @@ impl AbsPtr {
     pub fn get_arg(&self) -> Option<ArgIdx> {
         if let Self::Set(ptrs) = self
             && ptrs.len() == 1
-                && let AbsBase::Arg(i) = &ptrs.first().unwrap().base {
-                    return Some(*i);
-                }
+            && let AbsBase::Arg(i) = &ptrs.first().unwrap().base
+        {
+            return Some(*i);
+        }
         None
     }
 

--- a/src/outparam_replacer/ai/domains.rs
+++ b/src/outparam_replacer/ai/domains.rs
@@ -1492,7 +1492,7 @@ impl std::fmt::Debug for AbsInt {
                         if i != 0 {
                             write!(f, ", ")?;
                         }
-                        write!(f, "{}", n)?;
+                        write!(f, "{n}")?;
                     }
                     write!(f, "}}_i")
                 }
@@ -1803,7 +1803,7 @@ impl std::fmt::Debug for AbsUint {
                         if i != 0 {
                             write!(f, ", ")?;
                         }
-                        write!(f, "{}", n)?;
+                        write!(f, "{n}")?;
                     }
                     write!(f, "}}_u")
                 }
@@ -2517,7 +2517,7 @@ impl std::fmt::Debug for AbsList {
                     if i != 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{:?}", v)?;
+                    write!(f, "{v:?}")?;
                 }
                 write!(f, "]")
             }
@@ -2610,7 +2610,7 @@ impl std::fmt::Debug for AbsPlace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.base)?;
         for elem in &self.projections {
-            write!(f, "{:?}", elem)?;
+            write!(f, "{elem:?}")?;
         }
         Ok(())
     }
@@ -2675,7 +2675,7 @@ impl std::fmt::Debug for AbsProjElem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Field(i) => write!(f, ".{}", i.index()),
-            Self::Index(i) => write!(f, "[{:?}]", i),
+            Self::Index(i) => write!(f, "[{i:?}]"),
         }
     }
 }
@@ -2699,7 +2699,7 @@ impl std::fmt::Debug for AbsPtr {
                         if i != 0 {
                             write!(f, ", ")?;
                         }
-                        write!(f, "{:?}", ptr)?;
+                        write!(f, "{ptr:?}")?;
                     }
                     write!(f, "}}")
                 }
@@ -2820,13 +2820,11 @@ impl AbsPtr {
     }
 
     pub fn get_arg(&self) -> Option<ArgIdx> {
-        if let Self::Set(ptrs) = self {
-            if ptrs.len() == 1 {
-                if let AbsBase::Arg(i) = &ptrs.first().unwrap().base {
+        if let Self::Set(ptrs) = self
+            && ptrs.len() == 1
+                && let AbsBase::Arg(i) = &ptrs.first().unwrap().base {
                     return Some(*i);
                 }
-            }
-        }
         None
     }
 
@@ -2875,7 +2873,7 @@ impl std::fmt::Debug for AbsOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Top => write!(f, "⊤_o"),
-            Self::Some(v) => write!(f, "Some({:?})", v),
+            Self::Some(v) => write!(f, "Some({v:?})"),
             Self::None => write!(f, "None"),
             Self::Bot => write!(f, "⊥_o"),
         }
@@ -2954,7 +2952,7 @@ impl std::fmt::Debug for AbsFn {
                         if i != 0 {
                             write!(f, ", ")?;
                         }
-                        write!(f, "{:?}", n)?;
+                        write!(f, "{n:?}")?;
                     }
                     write!(f, "}}")
                 }
@@ -3101,7 +3099,7 @@ impl std::fmt::Debug for MustPathSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MustPathSet::All => write!(f, "All"),
-            MustPathSet::Set(s) => write!(f, "{:?}", s),
+            MustPathSet::Set(s) => write!(f, "{s:?}"),
         }
     }
 }
@@ -3474,7 +3472,7 @@ impl std::fmt::Debug for MustLocalSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MustLocalSet::All => write!(f, "All"),
-            MustLocalSet::Set(s) => write!(f, "{:?}", s),
+            MustLocalSet::Set(s) => write!(f, "{s:?}"),
         }
     }
 }

--- a/src/outparam_replacer/ai/domains.rs
+++ b/src/outparam_replacer/ai/domains.rs
@@ -1,1 +1,3579 @@
 
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Deref,
+    sync::Arc,
+};
+
+use lazy_static::lazy_static;
+use rustc_abi::FieldIdx;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_index::{bit_set::DenseBitSet, IndexVec};
+use rustc_middle::mir::Local;
+use rustc_span::def_id::DefId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+pub struct AbsState {
+    pub local: AbsLocal,
+    pub args: AbsArgs,
+    pub excludes: MayPathSet,
+    pub null_excludes: MayPathSet,
+    pub reads: MayPathSet,
+    pub writes: MustPathSet,
+    pub nulls: AbsNulls,
+    pub nonnulls: MustLocalSet,
+}
+
+impl AbsState {
+    #[inline]
+    pub fn bot() -> Self {
+        Self {
+            local: AbsLocal::bot(),
+            args: AbsArgs::bot(),
+            excludes: MayPathSet::bot(),
+            null_excludes: MayPathSet::bot(),
+            reads: MayPathSet::bot(),
+            writes: MustPathSet::bot(),
+            nulls: AbsNulls::bot(),
+            nonnulls: MustLocalSet::bot(),
+        }
+    }
+
+    pub fn join(&self, other: &Self) -> Self {
+        Self {
+            local: self.local.join(&other.local),
+            args: self.args.join(&other.args),
+            excludes: self.excludes.join(&other.excludes),
+            null_excludes: self.null_excludes.join(&other.null_excludes),
+            reads: self.reads.join(&other.reads),
+            writes: self.writes.join(&other.writes),
+            nulls: self.nulls.join(&other.nulls),
+            nonnulls: self.nonnulls.join(&other.nonnulls),
+        }
+    }
+
+    pub fn widen(&self, other: &Self) -> Self {
+        Self {
+            local: self.local.widen(&other.local),
+            args: self.args.widen(&other.args),
+            excludes: self.excludes.widen(&other.excludes),
+            null_excludes: self.null_excludes.widen(&other.null_excludes),
+            reads: self.reads.widen(&other.reads),
+            writes: self.writes.widen(&other.writes),
+            nulls: self.nulls.widen(&other.nulls),
+            nonnulls: self.nonnulls.widen(&other.nonnulls),
+        }
+    }
+
+    pub fn ord(&self, other: &Self) -> bool {
+        self.local.ord(&other.local)
+            && self.args.ord(&other.args)
+            && self.excludes.ord(&other.excludes)
+            && self.null_excludes.ord(&other.null_excludes)
+            && self.reads.ord(&other.reads)
+            && self.writes.ord(&other.writes)
+            && self.nulls.ord(&other.nulls)
+            && self.nonnulls.ord(&other.nonnulls)
+    }
+
+    pub fn get(&self, base: AbsBase) -> Option<&AbsValue> {
+        match base {
+            AbsBase::Local(i) => self.local.0.get(i),
+            AbsBase::Arg(i) => self.args.0.get(i),
+            AbsBase::Heap => Some(&V_TOP),
+            AbsBase::Null => None,
+        }
+    }
+
+    pub fn get_mut(&mut self, base: AbsBase) -> Option<&mut AbsValue> {
+        match base {
+            AbsBase::Local(i) => self.local.0.get_mut(i),
+            AbsBase::Arg(i) => self.args.0.get_mut(i),
+            AbsBase::Heap => None,
+            AbsBase::Null => None,
+        }
+    }
+
+    pub fn add_excludes<I: Iterator<Item = AbsPath>>(&mut self, paths: I) {
+        for path in paths {
+            self.excludes.insert(path);
+        }
+    }
+
+    pub fn add_null_excludes<I: Iterator<Item = AbsPath>>(&mut self, paths: I) {
+        for path in paths {
+            self.null_excludes.insert(path);
+        }
+    }
+
+    pub fn add_reads<I: Iterator<Item = AbsPath>>(&mut self, paths: I) {
+        for path in paths {
+            if !self.writes.contains(&path) {
+                self.reads.insert(path);
+            }
+        }
+    }
+
+    pub fn add_writes<I: Iterator<Item = AbsPath>>(
+        &mut self,
+        paths: I,
+        ptr_params_inv: &FxHashMap<Local, ArgIdx>,
+    ) -> (BTreeSet<AbsPath>, BTreeSet<Local>) {
+        let mut res = BTreeSet::new();
+        let mut nonnull_cands = BTreeSet::new();
+        let mut locals = self.writes.iter().map(|p| p.base).collect::<FxHashSet<_>>();
+
+        for path in paths {
+            if !self.reads.contains(&path) && !self.excludes.contains(&path) {
+                let l = path.base;
+                let arg = ptr_params_inv.get(&l).unwrap();
+                if !locals.contains(&l) && self.nulls.is_top(*arg) {
+                    nonnull_cands.insert(l);
+                    locals.insert(l);
+                }
+                self.writes.insert(path.clone());
+                res.insert(path);
+            }
+        }
+
+        (res, nonnull_cands)
+    }
+
+    pub fn add_null(&mut self, path: AbsPath, arg: ArgIdx, n: AbsNull) {
+        if !self.reads.contains(&path) && !self.excludes.contains(&path) {
+            self.nulls.set(arg, n);
+        }
+    }
+
+    pub fn add_nonnulls<I: Iterator<Item = Local>>(&mut self, locals: I) {
+        self.nonnulls.extend(locals);
+    }
+}
+
+rustc_index::newtype_index! {
+    #[orderable]
+    #[debug_format = "arg{}"]
+    pub struct ArgIdx {}
+}
+
+#[derive(Clone)]
+pub struct AbsArgs(IndexVec<ArgIdx, AbsValue>);
+
+impl std::fmt::Debug for AbsArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl AbsArgs {
+    #[inline]
+    fn bot() -> Self {
+        Self(IndexVec::new())
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        let indices = if self.0.len() > other.0.len() {
+            self.0.indices()
+        } else {
+            other.0.indices()
+        };
+        Self(
+            indices
+                .map(|i| match (self.0.get(i), other.0.get(i)) {
+                    (Some(v1), Some(v2)) => v1.join(v2),
+                    (Some(v), None) | (None, Some(v)) => v.clone(),
+                    _ => unreachable!(),
+                })
+                .collect(),
+        )
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        let indices = if self.0.len() > other.0.len() {
+            self.0.indices()
+        } else {
+            other.0.indices()
+        };
+        Self(
+            indices
+                .map(|i| match (self.0.get(i), other.0.get(i)) {
+                    (Some(v1), Some(v2)) => v1.widen(v2),
+                    (Some(v), None) | (None, Some(v)) => v.clone(),
+                    _ => unreachable!(),
+                })
+                .collect(),
+        )
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        self.0.len() <= other.0.len() && self.0.iter().zip(other.0.iter()).all(|(x, y)| x.ord(y))
+    }
+
+    pub fn push(&mut self, v: AbsValue) -> ArgIdx {
+        let idx = self.0.next_index();
+        self.0.push(v);
+        idx
+    }
+
+    pub fn get(&self, i: ArgIdx) -> &AbsValue {
+        &self.0[i]
+    }
+
+    pub fn get_mut(&mut self, i: ArgIdx) -> &mut AbsValue {
+        &mut self.0[i]
+    }
+
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn next_index(&self) -> ArgIdx {
+        self.0.next_index()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &AbsValue> {
+        self.0.iter()
+    }
+
+    pub fn iter_enumerated(&self) -> impl Iterator<Item = (ArgIdx, &AbsValue)> {
+        self.0.iter_enumerated()
+    }
+}
+
+#[derive(Clone)]
+pub struct AbsLocal(IndexVec<Local, AbsValue>);
+
+impl std::fmt::Debug for AbsLocal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl AbsLocal {
+    #[inline]
+    fn bot() -> Self {
+        Self(IndexVec::new())
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        let indices = if self.0.len() > other.0.len() {
+            self.0.indices()
+        } else {
+            other.0.indices()
+        };
+        Self(
+            indices
+                .map(|i| match (self.0.get(i), other.0.get(i)) {
+                    (Some(v1), Some(v2)) => v1.join(v2),
+                    (Some(v), None) | (None, Some(v)) => v.clone(),
+                    _ => unreachable!(),
+                })
+                .collect(),
+        )
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        let indices = if self.0.len() > other.0.len() {
+            self.0.indices()
+        } else {
+            other.0.indices()
+        };
+        Self(
+            indices
+                .map(|i| match (self.0.get(i), other.0.get(i)) {
+                    (Some(v1), Some(v2)) => v1.widen(v2),
+                    (Some(v), None) | (None, Some(v)) => v.clone(),
+                    _ => unreachable!(),
+                })
+                .collect(),
+        )
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        let mut indices = if self.0.len() > other.0.len() {
+            self.0.indices()
+        } else {
+            other.0.indices()
+        };
+        indices.all(|i| {
+            let v1 = self.0.get(i).unwrap_or(&V_BOT);
+            let v2 = other.0.get(i).unwrap_or(&V_BOT);
+            v1.ord(v2)
+        })
+    }
+
+    pub fn get(&self, i: Local) -> &AbsValue {
+        self.0.get(i).unwrap_or(&V_BOT)
+    }
+
+    pub fn get_mut(&mut self, i: Local) -> &mut AbsValue {
+        while self.0.next_index() <= i {
+            self.0.push(AbsValue::bot());
+        }
+        &mut self.0[i]
+    }
+
+    pub fn set(&mut self, i: Local, v: AbsValue) {
+        while self.0.next_index() < i {
+            self.0.push(AbsValue::bot());
+        }
+        if self.0.next_index() == i {
+            self.0.push(v);
+        } else {
+            self.0[i] = v;
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &AbsValue> {
+        self.0.iter()
+    }
+
+    pub fn clear_dead_locals(&mut self, dead_locals: &DenseBitSet<Local>) {
+        for l in dead_locals.iter() {
+            if l >= self.0.next_index() {
+                break;
+            }
+            self.0[l] = AbsValue::bot();
+        }
+    }
+}
+
+lazy_static! {
+    static ref V_BOT: AbsValue = AbsValue::new(AbsVal::bot());
+    static ref V_TOP: AbsValue = AbsValue::new(AbsVal::top());
+    static ref V_TOP_INT: AbsValue = AbsValue::new(AbsVal::top_int());
+    static ref V_TOP_UINT: AbsValue = AbsValue::new(AbsVal::top_uint());
+    static ref V_TOP_FLOAT: AbsValue = AbsValue::new(AbsVal::top_float());
+    static ref V_TOP_BOOL: AbsValue = AbsValue::new(AbsVal::top_bool());
+    static ref V_TOP_LIST: AbsValue = AbsValue::new(AbsVal::top_list());
+    static ref V_TOP_PTR: AbsValue = AbsValue::new(AbsVal::top_ptr());
+    static ref V_TOP_OPTION: AbsValue = AbsValue::new(AbsVal::top_option());
+    static ref V_TOP_FN: AbsValue = AbsValue::new(AbsVal::top_fn());
+    static ref V_TRUE: AbsValue = AbsValue::new(AbsVal::alpha_bool(true));
+    static ref V_FALSE: AbsValue = AbsValue::new(AbsVal::alpha_bool(false));
+    static ref V_HEAP: AbsValue = AbsValue::new(AbsVal::heap());
+    static ref V_NULL: AbsValue = AbsValue::new(AbsVal::null());
+    static ref V_HEAP_OR_NULL: AbsValue = AbsValue::new(AbsVal::heap_or_null());
+    static ref V_NONE: AbsValue = AbsValue::new(AbsVal::none());
+}
+
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct AbsValue(Arc<AbsVal>);
+
+impl std::fmt::Debug for AbsValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Deref for AbsValue {
+    type Target = AbsVal;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AbsValue {
+    #[inline]
+    fn new(val: AbsVal) -> Self {
+        Self(Arc::new(val))
+    }
+
+    #[inline]
+    pub fn bot() -> Self {
+        V_BOT.clone()
+    }
+
+    #[inline]
+    pub fn top() -> Self {
+        V_TOP.clone()
+    }
+
+    #[inline]
+    pub fn top_int() -> Self {
+        V_TOP_INT.clone()
+    }
+
+    #[inline]
+    pub fn top_uint() -> Self {
+        V_TOP_UINT.clone()
+    }
+
+    #[inline]
+    pub fn top_float() -> Self {
+        V_TOP_FLOAT.clone()
+    }
+
+    #[inline]
+    pub fn top_bool() -> Self {
+        V_TOP_BOOL.clone()
+    }
+
+    #[inline]
+    pub fn top_list() -> Self {
+        V_TOP_LIST.clone()
+    }
+
+    #[inline]
+    pub fn top_ptr() -> Self {
+        V_TOP_PTR.clone()
+    }
+
+    #[inline]
+    pub fn top_option() -> Self {
+        V_TOP_OPTION.clone()
+    }
+
+    #[inline]
+    pub fn top_fn() -> Self {
+        V_TOP_FN.clone()
+    }
+
+    #[inline]
+    pub fn bool_true() -> Self {
+        V_TRUE.clone()
+    }
+
+    #[inline]
+    pub fn bool_false() -> Self {
+        V_FALSE.clone()
+    }
+
+    #[inline]
+    pub fn heap() -> Self {
+        V_HEAP.clone()
+    }
+
+    #[inline]
+    pub fn null() -> Self {
+        V_NULL.clone()
+    }
+
+    #[inline]
+    pub fn heap_or_null() -> Self {
+        V_HEAP_OR_NULL.clone()
+    }
+
+    #[inline]
+    pub fn none() -> Self {
+        V_NONE.clone()
+    }
+
+    pub fn alpha_int(n: i128) -> Self {
+        Self::new(AbsVal::alpha_int(n))
+    }
+
+    pub fn alpha_uint(n: u128) -> Self {
+        Self::new(AbsVal::alpha_uint(n))
+    }
+
+    pub fn alpha_float(f: f64) -> Self {
+        Self::new(AbsVal::alpha_float(f))
+    }
+
+    #[inline]
+    pub fn alpha_bool(b: bool) -> Self {
+        if b {
+            V_TRUE.clone()
+        } else {
+            V_FALSE.clone()
+        }
+    }
+
+    pub fn alpha_list(l: Vec<AbsValue>) -> Self {
+        Self::new(AbsVal::alpha_list(l))
+    }
+
+    pub fn alpha_ptr(p: AbsPlace) -> Self {
+        Self::new(AbsVal::alpha_ptr(p))
+    }
+
+    pub fn alpha_fn(f: DefId) -> Self {
+        Self::new(AbsVal::alpha_fn(f))
+    }
+
+    pub fn int(intv: AbsInt) -> Self {
+        if intv.is_top() {
+            V_TOP_INT.clone()
+        } else if intv.is_bot() {
+            V_BOT.clone()
+        } else {
+            Self::new(AbsVal::int(intv))
+        }
+    }
+
+    pub fn uint(uintv: AbsUint) -> Self {
+        if uintv.is_top() {
+            V_TOP_UINT.clone()
+        } else if uintv.is_bot() {
+            V_BOT.clone()
+        } else {
+            Self::new(AbsVal::uint(uintv))
+        }
+    }
+
+    pub fn float(floatv: AbsFloat) -> Self {
+        if floatv.is_top() {
+            V_TOP_FLOAT.clone()
+        } else if floatv.is_bot() {
+            V_BOT.clone()
+        } else {
+            Self::new(AbsVal::float(floatv))
+        }
+    }
+
+    #[inline]
+    pub fn boolean(boolv: AbsBool) -> Self {
+        match boolv {
+            AbsBool::Top => V_TOP_BOOL.clone(),
+            AbsBool::True => V_TRUE.clone(),
+            AbsBool::False => V_FALSE.clone(),
+            AbsBool::Bot => V_BOT.clone(),
+        }
+    }
+
+    pub fn list(listv: AbsList) -> Self {
+        if listv.is_top() {
+            V_TOP.clone()
+        } else if listv.is_bot() {
+            V_BOT.clone()
+        } else {
+            Self::new(AbsVal::list(listv))
+        }
+    }
+
+    pub fn ptr(ptrv: AbsPtr) -> Self {
+        if ptrv.is_top() {
+            V_TOP_PTR.clone()
+        } else if ptrv.is_bot() {
+            V_BOT.clone()
+        } else {
+            Self::new(AbsVal::ptr(ptrv))
+        }
+    }
+
+    pub fn option(optionv: AbsOption) -> Self {
+        match optionv {
+            AbsOption::Top => V_TOP_OPTION.clone(),
+            AbsOption::None => V_NONE.clone(),
+            AbsOption::Some(v) => Self::some(v),
+            AbsOption::Bot => V_BOT.clone(),
+        }
+    }
+
+    pub fn func(fnv: AbsFn) -> Self {
+        if fnv.is_top() {
+            V_TOP_FN.clone()
+        } else if fnv.is_bot() {
+            V_BOT.clone()
+        } else {
+            Self::new(AbsVal::func(fnv))
+        }
+    }
+
+    pub fn some(v: AbsValue) -> Self {
+        Self::new(AbsVal::some(v))
+    }
+
+    pub fn arg(i: ArgIdx) -> Self {
+        Self::ptr(AbsPtr::arg(i))
+    }
+
+    #[inline]
+    fn iub(iub: Iub) -> Self {
+        match (iub.0.is_bot(), iub.1.is_bot(), iub.2.is_bot()) {
+            (_, true, true) => Self::int(iub.0),
+            (true, _, true) => Self::uint(iub.1),
+            (true, true, _) => Self::boolean(iub.2),
+            _ => Self::new(AbsVal::iub(iub)),
+        }
+    }
+
+    #[inline]
+    fn iuf(iuf: Iuf) -> Self {
+        match (iuf.0.is_bot(), iuf.1.is_bot(), iuf.2.is_bot()) {
+            (_, true, true) => Self::int(iuf.0),
+            (true, _, true) => Self::uint(iuf.1),
+            (true, true, _) => Self::float(iuf.2),
+            _ => Self::new(AbsVal::iuf(iuf)),
+        }
+    }
+
+    pub fn not(&self) -> Self {
+        Self::iub(self.0.not())
+    }
+
+    pub fn neg(&self) -> Self {
+        Self::iuf(self.0.neg())
+    }
+
+    pub fn to_i8(&self) -> Self {
+        Self::int(self.0.to_i8())
+    }
+
+    pub fn to_i16(&self) -> Self {
+        Self::int(self.0.to_i16())
+    }
+
+    pub fn to_i32(&self) -> Self {
+        Self::int(self.0.to_i32())
+    }
+
+    pub fn to_i64(&self) -> Self {
+        Self::int(self.0.to_i64())
+    }
+
+    pub fn to_i128(&self) -> Self {
+        Self::int(self.0.to_i128())
+    }
+
+    pub fn to_u8(&self) -> Self {
+        Self::uint(self.0.to_u8())
+    }
+
+    pub fn to_u16(&self) -> Self {
+        Self::uint(self.0.to_u16())
+    }
+
+    pub fn to_u32(&self) -> Self {
+        Self::uint(self.0.to_u32())
+    }
+
+    pub fn to_u64(&self) -> Self {
+        Self::uint(self.0.to_u64())
+    }
+
+    pub fn to_u128(&self) -> Self {
+        Self::uint(self.0.to_u128())
+    }
+
+    pub fn to_f32(&self) -> Self {
+        Self::float(self.0.to_f32())
+    }
+
+    pub fn to_f64(&self) -> Self {
+        Self::float(self.0.to_f64())
+    }
+
+    pub fn add(&self, other: &Self) -> Self {
+        Self::iuf(self.0.add(&other.0))
+    }
+
+    pub fn sub(&self, other: &Self) -> Self {
+        Self::iuf(self.0.sub(&other.0))
+    }
+
+    pub fn mul(&self, other: &Self) -> Self {
+        Self::iuf(self.0.mul(&other.0))
+    }
+
+    pub fn div(&self, other: &Self) -> Self {
+        Self::iuf(self.0.div(&other.0))
+    }
+
+    pub fn rem(&self, other: &Self) -> Self {
+        Self::iuf(self.0.rem(&other.0))
+    }
+
+    pub fn bit_xor(&self, other: &Self) -> Self {
+        Self::iub(self.0.bit_xor(&other.0))
+    }
+
+    pub fn bit_and(&self, other: &Self) -> Self {
+        Self::iub(self.0.bit_and(&other.0))
+    }
+
+    pub fn bit_or(&self, other: &Self) -> Self {
+        Self::iub(self.0.bit_or(&other.0))
+    }
+
+    pub fn shl(&self, other: &Self) -> Self {
+        Self::iub(self.0.shl(&other.0))
+    }
+
+    pub fn shr(&self, other: &Self) -> Self {
+        Self::iub(self.0.shr(&other.0))
+    }
+
+    pub fn eq(&self, other: &Self) -> Self {
+        Self::boolean(self.0.eq(&other.0))
+    }
+
+    pub fn le(&self, other: &Self) -> Self {
+        Self::boolean(self.0.le(&other.0))
+    }
+
+    pub fn lt(&self, other: &Self) -> Self {
+        Self::boolean(self.0.lt(&other.0))
+    }
+
+    pub fn ne(&self, other: &Self) -> Self {
+        Self::boolean(self.0.ne(&other.0))
+    }
+
+    pub fn ge(&self, other: &Self) -> Self {
+        Self::boolean(self.0.ge(&other.0))
+    }
+
+    pub fn gt(&self, other: &Self) -> Self {
+        Self::boolean(self.0.gt(&other.0))
+    }
+
+    pub fn join(&self, other: &Self) -> Self {
+        if self.is_top() || other.is_top() {
+            Self::top()
+        } else if Arc::ptr_eq(&self.0, &other.0) || other.is_bot() {
+            self.clone()
+        } else if self.is_bot() {
+            other.clone()
+        } else {
+            let intv = self.intv.join(&other.intv);
+            let uintv = self.uintv.join(&other.uintv);
+            let floatv = self.floatv.join(&other.floatv);
+            let boolv = self.boolv.join(other.boolv);
+            let listv = self.listv.join(&other.listv);
+            let ptrv = self.ptrv.join(&other.ptrv);
+            let optionv = self.optionv.join(&other.optionv);
+            let fnv = self.fnv.join(&other.fnv);
+            let is_bots = (
+                intv.is_bot(),
+                uintv.is_bot(),
+                floatv.is_bot(),
+                boolv.is_bot(),
+                listv.is_bot(),
+                ptrv.is_bot(),
+                optionv.is_bot(),
+                fnv.is_bot(),
+            );
+            match is_bots {
+                (_, true, true, true, true, true, true, true) => Self::int(intv),
+                (true, _, true, true, true, true, true, true) => Self::uint(uintv),
+                (true, true, _, true, true, true, true, true) => Self::float(floatv),
+                (true, true, true, _, true, true, true, true) => Self::boolean(boolv),
+                (true, true, true, true, _, true, true, true) => Self::list(listv),
+                (true, true, true, true, true, _, true, true) => Self::ptr(ptrv),
+                (true, true, true, true, true, true, _, true) => Self::option(optionv),
+                (true, true, true, true, true, true, true, _) => Self::func(fnv),
+                _ => Self::new(AbsVal {
+                    intv,
+                    uintv,
+                    floatv,
+                    boolv,
+                    listv,
+                    ptrv,
+                    optionv,
+                    fnv,
+                }),
+            }
+        }
+    }
+
+    pub fn widen(&self, other: &Self) -> Self {
+        if self.is_top() || other.is_top() {
+            Self::top()
+        } else if Arc::ptr_eq(&self.0, &other.0) || other.is_bot() {
+            self.clone()
+        } else if self.is_bot() {
+            other.clone()
+        } else {
+            let intv = self.intv.widen(&other.intv);
+            let uintv = self.uintv.widen(&other.uintv);
+            let floatv = self.floatv.widen(&other.floatv);
+            let boolv = self.boolv.widen(other.boolv);
+            let listv = self.listv.widen(&other.listv);
+            let ptrv = self.ptrv.widen(&other.ptrv);
+            let optionv = self.optionv.widen(&other.optionv);
+            let fnv = self.fnv.widen(&other.fnv);
+            let is_bots = (
+                intv.is_bot(),
+                uintv.is_bot(),
+                floatv.is_bot(),
+                boolv.is_bot(),
+                listv.is_bot(),
+                ptrv.is_bot(),
+                optionv.is_bot(),
+                fnv.is_bot(),
+            );
+            match is_bots {
+                (_, true, true, true, true, true, true, true) => Self::int(intv),
+                (true, _, true, true, true, true, true, true) => Self::uint(uintv),
+                (true, true, _, true, true, true, true, true) => Self::float(floatv),
+                (true, true, true, _, true, true, true, true) => Self::boolean(boolv),
+                (true, true, true, true, _, true, true, true) => Self::list(listv),
+                (true, true, true, true, true, _, true, true) => Self::ptr(ptrv),
+                (true, true, true, true, true, true, _, true) => Self::option(optionv),
+                (true, true, true, true, true, true, true, _) => Self::func(fnv),
+                _ => Self::new(AbsVal {
+                    intv,
+                    uintv,
+                    floatv,
+                    boolv,
+                    listv,
+                    ptrv,
+                    optionv,
+                    fnv,
+                }),
+            }
+        }
+    }
+
+    pub fn subst(&self, map: &BTreeMap<ArgIdx, AbsPtr>) -> Self {
+        Self::new(self.0.subst(map))
+    }
+
+    pub fn make_mut(this: &mut Self) -> &mut AbsVal {
+        Arc::make_mut(&mut this.0)
+    }
+}
+
+#[derive(Clone)]
+pub struct AbsVal {
+    pub intv: AbsInt,
+    pub uintv: AbsUint,
+    pub floatv: AbsFloat,
+    pub boolv: AbsBool,
+    pub listv: AbsList,
+    pub ptrv: AbsPtr,
+    pub optionv: AbsOption,
+    pub fnv: AbsFn,
+}
+
+impl std::fmt::Debug for AbsVal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_top() {
+            return write!(f, "⊤");
+        }
+
+        let mut not_bot = false;
+        if !self.intv.is_bot() {
+            write!(f, "{:?}", self.intv)?;
+            not_bot = true;
+        }
+        if !self.uintv.is_bot() {
+            if not_bot {
+                write!(f, " | ")?;
+            }
+            write!(f, "{:?}", self.uintv)?;
+            not_bot = true;
+        }
+        if !self.floatv.is_bot() {
+            if not_bot {
+                write!(f, " | ")?;
+            }
+            write!(f, "{:?}", self.floatv)?;
+            not_bot = true;
+        }
+        if !self.boolv.is_bot() {
+            if not_bot {
+                write!(f, " | ")?;
+            }
+            write!(f, "{:?}", self.boolv)?;
+            not_bot = true;
+        }
+        if !self.listv.is_bot() {
+            if not_bot {
+                write!(f, " | ")?;
+            }
+            write!(f, "{:?}", self.listv)?;
+            not_bot = true;
+        }
+        if !self.ptrv.is_bot() {
+            if not_bot {
+                write!(f, " | ")?;
+            }
+            write!(f, "{:?}", self.ptrv)?;
+            not_bot = true;
+        }
+        if !self.optionv.is_bot() {
+            if not_bot {
+                write!(f, " | ")?;
+            }
+            write!(f, "{:?}", self.optionv)?;
+            not_bot = true;
+        }
+        if !self.fnv.is_bot() {
+            if not_bot {
+                write!(f, " | ")?;
+            }
+            write!(f, "{:?}", self.fnv)?;
+            not_bot = true;
+        }
+        if !not_bot {
+            write!(f, "⊥")?;
+        }
+        Ok(())
+    }
+}
+
+type Iub = (AbsInt, AbsUint, AbsBool);
+type Iuf = (AbsInt, AbsUint, AbsFloat);
+
+impl AbsVal {
+    #[inline]
+    fn top() -> Self {
+        Self {
+            intv: AbsInt::top(),
+            uintv: AbsUint::top(),
+            floatv: AbsFloat::top(),
+            boolv: AbsBool::top(),
+            listv: AbsList::top(),
+            ptrv: AbsPtr::top(),
+            optionv: AbsOption::top(),
+            fnv: AbsFn::top(),
+        }
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self {
+            intv: AbsInt::bot(),
+            uintv: AbsUint::bot(),
+            floatv: AbsFloat::bot(),
+            boolv: AbsBool::bot(),
+            listv: AbsList::bot(),
+            ptrv: AbsPtr::bot(),
+            optionv: AbsOption::bot(),
+            fnv: AbsFn::bot(),
+        }
+    }
+
+    #[inline]
+    pub fn ord(&self, other: &Self) -> bool {
+        self.intv.ord(&other.intv)
+            && self.uintv.ord(&other.uintv)
+            && self.floatv.ord(&other.floatv)
+            && self.boolv.ord(other.boolv)
+            && self.listv.ord(&other.listv)
+            && self.ptrv.ord(&other.ptrv)
+            && self.optionv.ord(&other.optionv)
+            && self.fnv.ord(&other.fnv)
+    }
+
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        self.intv.is_top()
+            && self.uintv.is_top()
+            && self.floatv.is_top()
+            && self.boolv.is_top()
+            && self.listv.is_top()
+            && self.ptrv.is_top()
+            && self.optionv.is_top()
+            && self.fnv.is_top()
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        self.intv.is_bot()
+            && self.uintv.is_bot()
+            && self.floatv.is_bot()
+            && self.boolv.is_bot()
+            && self.listv.is_bot()
+            && self.ptrv.is_bot()
+            && self.optionv.is_bot()
+            && self.fnv.is_bot()
+    }
+
+    #[inline]
+    fn top_int() -> Self {
+        Self {
+            intv: AbsInt::top(),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn top_uint() -> Self {
+        Self {
+            uintv: AbsUint::top(),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn top_float() -> Self {
+        Self {
+            floatv: AbsFloat::top(),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn top_bool() -> Self {
+        Self {
+            boolv: AbsBool::top(),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn top_list() -> Self {
+        Self {
+            listv: AbsList::top(),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn top_ptr() -> Self {
+        Self {
+            ptrv: AbsPtr::top(),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn top_option() -> Self {
+        Self {
+            optionv: AbsOption::top(),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn top_fn() -> Self {
+        Self {
+            fnv: AbsFn::top(),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn heap() -> Self {
+        Self::ptr(AbsPtr::heap())
+    }
+
+    #[inline]
+    fn null() -> Self {
+        Self::ptr(AbsPtr::null())
+    }
+
+    #[inline]
+    fn heap_or_null() -> Self {
+        Self::ptr(AbsPtr::heap_or_null())
+    }
+
+    #[inline]
+    fn alpha_int(n: i128) -> Self {
+        Self {
+            intv: AbsInt::alpha(n),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn alpha_uint(n: u128) -> Self {
+        Self {
+            uintv: AbsUint::alpha(n),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn alpha_float(f: f64) -> Self {
+        Self {
+            floatv: AbsFloat::alpha(f),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn alpha_bool(b: bool) -> Self {
+        Self {
+            boolv: AbsBool::alpha(b),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn alpha_list(l: Vec<AbsValue>) -> Self {
+        Self {
+            listv: AbsList::List(l),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn alpha_ptr(p: AbsPlace) -> Self {
+        Self {
+            ptrv: AbsPtr::alpha(p),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn alpha_fn(f: DefId) -> Self {
+        Self {
+            fnv: AbsFn::alpha(f),
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn int(intv: AbsInt) -> Self {
+        Self {
+            intv,
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn uint(uintv: AbsUint) -> Self {
+        Self {
+            uintv,
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn float(floatv: AbsFloat) -> Self {
+        Self {
+            floatv,
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn list(listv: AbsList) -> Self {
+        Self {
+            listv,
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn ptr(ptrv: AbsPtr) -> Self {
+        Self {
+            ptrv,
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn option(optionv: AbsOption) -> Self {
+        Self {
+            optionv,
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn none() -> Self {
+        Self::option(AbsOption::None)
+    }
+
+    #[inline]
+    fn some(v: AbsValue) -> Self {
+        Self::option(AbsOption::Some(v))
+    }
+
+    #[inline]
+    fn func(fnv: AbsFn) -> Self {
+        Self { fnv, ..Self::bot() }
+    }
+
+    #[inline]
+    fn iub(iub: Iub) -> Self {
+        let (intv, uintv, boolv) = iub;
+        Self {
+            intv,
+            uintv,
+            boolv,
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn iuf(iuf: Iuf) -> Self {
+        let (intv, uintv, floatv) = iuf;
+        Self {
+            intv,
+            uintv,
+            floatv,
+            ..Self::bot()
+        }
+    }
+
+    #[inline]
+    fn not(&self) -> Iub {
+        (self.intv.not(), self.uintv.not(), self.boolv.not())
+    }
+
+    #[inline]
+    fn neg(&self) -> Iuf {
+        (self.intv.neg(), AbsUint::bot(), self.floatv.neg())
+    }
+
+    #[inline]
+    fn to_i8(&self) -> AbsInt {
+        self.intv
+            .to_i8()
+            .join(&self.uintv.to_i8())
+            .join(&self.floatv.to_i8())
+            .join(&self.boolv.to_int())
+    }
+
+    #[inline]
+    fn to_i16(&self) -> AbsInt {
+        self.intv
+            .to_i16()
+            .join(&self.uintv.to_i16())
+            .join(&self.floatv.to_i16())
+            .join(&self.boolv.to_int())
+    }
+
+    #[inline]
+    fn to_i32(&self) -> AbsInt {
+        self.intv
+            .to_i32()
+            .join(&self.uintv.to_i32())
+            .join(&self.floatv.to_i32())
+            .join(&self.boolv.to_int())
+    }
+
+    #[inline]
+    fn to_i64(&self) -> AbsInt {
+        self.intv
+            .to_i64()
+            .join(&self.uintv.to_i64())
+            .join(&self.floatv.to_i64())
+            .join(&self.boolv.to_int())
+    }
+
+    #[inline]
+    fn to_i128(&self) -> AbsInt {
+        self.intv
+            .join(&self.uintv.to_i128())
+            .join(&self.floatv.to_i128())
+            .join(&self.boolv.to_int())
+    }
+
+    #[inline]
+    fn to_u8(&self) -> AbsUint {
+        self.intv
+            .to_u8()
+            .join(&self.uintv.to_u8())
+            .join(&self.floatv.to_u8())
+            .join(&self.boolv.to_uint())
+    }
+
+    #[inline]
+    fn to_u16(&self) -> AbsUint {
+        self.intv
+            .to_u16()
+            .join(&self.uintv.to_u16())
+            .join(&self.floatv.to_u16())
+            .join(&self.boolv.to_uint())
+    }
+
+    #[inline]
+    fn to_u32(&self) -> AbsUint {
+        self.intv
+            .to_u32()
+            .join(&self.uintv.to_u32())
+            .join(&self.floatv.to_u32())
+            .join(&self.boolv.to_uint())
+    }
+
+    #[inline]
+    fn to_u64(&self) -> AbsUint {
+        self.intv
+            .to_u64()
+            .join(&self.uintv.to_u64())
+            .join(&self.floatv.to_u64())
+            .join(&self.boolv.to_uint())
+    }
+
+    #[inline]
+    fn to_u128(&self) -> AbsUint {
+        self.intv
+            .to_u128()
+            .join(&self.uintv)
+            .join(&self.floatv.to_u128())
+            .join(&self.boolv.to_uint())
+    }
+
+    #[inline]
+    fn to_f32(&self) -> AbsFloat {
+        self.intv
+            .to_f32()
+            .join(&self.uintv.to_f32())
+            .join(&self.floatv.to_f32())
+    }
+
+    #[inline]
+    fn to_f64(&self) -> AbsFloat {
+        self.intv
+            .to_f64()
+            .join(&self.uintv.to_f64())
+            .join(&self.floatv)
+    }
+
+    #[inline]
+    fn add(&self, other: &Self) -> Iuf {
+        (
+            self.intv.add(&other.intv),
+            self.uintv.add(&other.uintv),
+            self.floatv.add(&other.floatv),
+        )
+    }
+
+    #[inline]
+    fn sub(&self, other: &Self) -> Iuf {
+        (
+            self.intv.sub(&other.intv),
+            self.uintv.sub(&other.uintv),
+            self.floatv.sub(&other.floatv),
+        )
+    }
+
+    #[inline]
+    fn mul(&self, other: &Self) -> Iuf {
+        (
+            self.intv.mul(&other.intv),
+            self.uintv.mul(&other.uintv),
+            self.floatv.mul(&other.floatv),
+        )
+    }
+
+    #[inline]
+    fn div(&self, other: &Self) -> Iuf {
+        (
+            self.intv.div(&other.intv),
+            self.uintv.div(&other.uintv),
+            self.floatv.div(&other.floatv),
+        )
+    }
+
+    #[inline]
+    fn rem(&self, other: &Self) -> Iuf {
+        (
+            self.intv.rem(&other.intv),
+            self.uintv.rem(&other.uintv),
+            self.floatv.rem(&other.floatv),
+        )
+    }
+
+    #[inline]
+    fn bit_xor(&self, other: &Self) -> Iub {
+        (
+            self.intv.bit_xor(&other.intv),
+            self.uintv.bit_xor(&other.uintv),
+            self.boolv.bit_xor(other.boolv),
+        )
+    }
+
+    #[inline]
+    fn bit_and(&self, other: &Self) -> Iub {
+        (
+            self.intv.bit_and(&other.intv),
+            self.uintv.bit_and(&other.uintv),
+            self.boolv.bit_and(other.boolv),
+        )
+    }
+
+    #[inline]
+    fn bit_or(&self, other: &Self) -> Iub {
+        (
+            self.intv.bit_or(&other.intv),
+            self.uintv.bit_or(&other.uintv),
+            self.boolv.bit_or(other.boolv),
+        )
+    }
+
+    #[inline]
+    fn shl(&self, other: &Self) -> Iub {
+        (
+            self.intv
+                .shl(&other.intv)
+                .join(&self.intv.shlu(&other.uintv)),
+            self.uintv
+                .shl(&other.uintv)
+                .join(&self.uintv.shli(&other.intv)),
+            AbsBool::bot(),
+        )
+    }
+
+    #[inline]
+    fn shr(&self, other: &Self) -> Iub {
+        (
+            self.intv
+                .shr(&other.intv)
+                .join(&self.intv.shru(&other.uintv)),
+            self.uintv
+                .shr(&other.uintv)
+                .join(&self.uintv.shri(&other.intv)),
+            AbsBool::bot(),
+        )
+    }
+
+    #[inline]
+    fn eq(&self, other: &Self) -> AbsBool {
+        self.intv
+            .eq(&other.intv)
+            .join(self.uintv.eq(&other.uintv))
+            .join(self.floatv.eq(&other.floatv))
+            .join(self.boolv.eq(other.boolv))
+            .join(self.ptrv.compare(&other.ptrv))
+    }
+
+    #[inline]
+    fn lt(&self, other: &Self) -> AbsBool {
+        self.intv
+            .lt(&other.intv)
+            .join(self.uintv.lt(&other.uintv))
+            .join(self.floatv.lt(&other.floatv))
+            .join(self.ptrv.compare(&other.ptrv))
+    }
+
+    #[inline]
+    fn le(&self, other: &Self) -> AbsBool {
+        self.intv
+            .le(&other.intv)
+            .join(self.uintv.le(&other.uintv))
+            .join(self.floatv.le(&other.floatv))
+            .join(self.ptrv.compare(&other.ptrv))
+    }
+
+    #[inline]
+    fn ne(&self, other: &Self) -> AbsBool {
+        self.intv
+            .ne(&other.intv)
+            .join(self.uintv.ne(&other.uintv))
+            .join(self.floatv.ne(&other.floatv))
+            .join(self.boolv.ne(other.boolv))
+            .join(self.ptrv.compare(&other.ptrv))
+    }
+
+    #[inline]
+    fn ge(&self, other: &Self) -> AbsBool {
+        self.intv
+            .ge(&other.intv)
+            .join(self.uintv.ge(&other.uintv))
+            .join(self.floatv.ge(&other.floatv))
+            .join(self.ptrv.compare(&other.ptrv))
+    }
+
+    #[inline]
+    fn gt(&self, other: &Self) -> AbsBool {
+        self.intv
+            .gt(&other.intv)
+            .join(self.uintv.gt(&other.uintv))
+            .join(self.floatv.gt(&other.floatv))
+            .join(self.ptrv.compare(&other.ptrv))
+    }
+
+    #[inline]
+    fn subst(&self, map: &BTreeMap<ArgIdx, AbsPtr>) -> Self {
+        Self {
+            ptrv: self.ptrv.subst(map),
+            listv: self.listv.subst(map),
+            ..self.clone()
+        }
+    }
+}
+
+const MAX_SIZE: usize = 11;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum AbsInt {
+    Top,
+    Set(BTreeSet<i128>),
+}
+
+impl std::fmt::Debug for AbsInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Top => write!(f, "⊤_i"),
+            Self::Set(s) => match s.len() {
+                0 => write!(f, "⊥_i"),
+                1 => write!(f, "{}_i", s.first().unwrap()),
+                _ => {
+                    write!(f, "{{")?;
+                    for (i, n) in s.iter().enumerate() {
+                        if i != 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", n)?;
+                    }
+                    write!(f, "}}_i")
+                }
+            },
+        }
+    }
+}
+
+impl AbsInt {
+    #[inline]
+    fn top() -> Self {
+        Self::Top
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::alphas(BTreeSet::new())
+    }
+
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        matches!(self, Self::Top)
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        if let Self::Set(s) = self {
+            s.is_empty()
+        } else {
+            false
+        }
+    }
+
+    fn alpha(n: i128) -> Self {
+        Self::alphas([n].into_iter().collect())
+    }
+
+    fn alphas(set: BTreeSet<i128>) -> Self {
+        if set.len() > MAX_SIZE {
+            Self::Top
+        } else {
+            Self::Set(set)
+        }
+    }
+
+    pub fn gamma(&self) -> Option<&BTreeSet<i128>> {
+        if let Self::Set(s) = self {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => Self::alphas(s1.union(s2).cloned().collect()),
+        }
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                if s2.is_subset(s1) {
+                    self.clone()
+                } else if s1.is_empty() {
+                    other.clone()
+                } else {
+                    Self::Top
+                }
+            }
+        }
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        match (self, other) {
+            (_, Self::Top) => true,
+            (Self::Top, _) => false,
+            (Self::Set(s1), Self::Set(s2)) => s1.is_subset(s2),
+        }
+    }
+
+    fn unary<F: Fn(i128) -> i128>(&self, f: F) -> Self {
+        match self {
+            Self::Top => Self::Top,
+            Self::Set(s) => Self::alphas(s.iter().map(|n| f(*n)).collect()),
+        }
+    }
+
+    fn not(&self) -> Self {
+        self.unary(|n| !n)
+    }
+
+    fn neg(&self) -> Self {
+        self.unary(|n| -n)
+    }
+
+    fn to_i8(&self) -> Self {
+        self.unary(|n| n as i8 as i128)
+    }
+
+    fn to_i16(&self) -> Self {
+        self.unary(|n| n as i16 as i128)
+    }
+
+    fn to_i32(&self) -> Self {
+        self.unary(|n| n as i32 as i128)
+    }
+
+    fn to_i64(&self) -> Self {
+        self.unary(|n| n as i64 as i128)
+    }
+
+    fn unaryu<F: Fn(i128) -> u128>(&self, f: F) -> AbsUint {
+        match self {
+            Self::Top => AbsUint::Top,
+            Self::Set(s) => AbsUint::alphas(s.iter().map(|n| f(*n)).collect()),
+        }
+    }
+
+    fn to_u8(&self) -> AbsUint {
+        self.unaryu(|n| n as u8 as u128)
+    }
+
+    fn to_u16(&self) -> AbsUint {
+        self.unaryu(|n| n as u16 as u128)
+    }
+
+    fn to_u32(&self) -> AbsUint {
+        self.unaryu(|n| n as u32 as u128)
+    }
+
+    pub fn to_u64(&self) -> AbsUint {
+        self.unaryu(|n| n as u64 as u128)
+    }
+
+    fn to_u128(&self) -> AbsUint {
+        self.unaryu(|n| n as u128)
+    }
+
+    fn unaryf<F: Fn(i128) -> f64>(&self, f: F) -> AbsFloat {
+        match self {
+            Self::Top => AbsFloat::Top,
+            Self::Set(s) => AbsFloat::alphas(s.iter().map(|n| f(*n)).collect()),
+        }
+    }
+
+    fn to_f32(&self) -> AbsFloat {
+        self.unaryf(|n| n as f32 as f64)
+    }
+
+    fn to_f64(&self) -> AbsFloat {
+        self.unaryf(|n| n as f64)
+    }
+
+    fn binary<F: Fn(i128, i128) -> i128>(&self, other: &Self, f: F) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        set.insert(f(*n1, *n2));
+                    }
+                }
+                Self::alphas(set)
+            }
+        }
+    }
+
+    pub fn add(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 + n2)
+    }
+
+    fn sub(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 - n2)
+    }
+
+    fn mul(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 * n2)
+    }
+
+    fn binary_nz<F: Fn(i128, i128) -> i128>(&self, other: &Self, f: F) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        if *n2 != 0 {
+                            set.insert(f(*n1, *n2));
+                        }
+                    }
+                }
+                Self::alphas(set)
+            }
+        }
+    }
+
+    fn div(&self, other: &Self) -> Self {
+        self.binary_nz(other, |n1, n2| n1 / n2)
+    }
+
+    fn rem(&self, other: &Self) -> Self {
+        self.binary_nz(other, |n1, n2| n1 % n2)
+    }
+
+    fn bit_xor(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 ^ n2)
+    }
+
+    fn bit_and(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 & n2)
+    }
+
+    fn bit_or(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 | n2)
+    }
+
+    fn shl(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 << n2)
+    }
+
+    fn shr(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 >> n2)
+    }
+
+    fn binaryu<F: Fn(i128, u128) -> i128>(&self, other: &AbsUint, f: F) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, AbsUint::Top) => Self::Top,
+            (Self::Set(s1), AbsUint::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        set.insert(f(*n1, *n2));
+                    }
+                }
+                Self::alphas(set)
+            }
+        }
+    }
+
+    fn shlu(&self, other: &AbsUint) -> Self {
+        self.binaryu(other, |n1, n2| n1 << n2)
+    }
+
+    fn shru(&self, other: &AbsUint) -> Self {
+        self.binaryu(other, |n1, n2| n1 >> n2)
+    }
+
+    fn binaryb<F: Fn(i128, i128) -> bool>(&self, other: &Self, f: F) -> AbsBool {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => AbsBool::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        set.insert(f(*n1, *n2));
+                    }
+                }
+                AbsBool::alphas(set)
+            }
+        }
+    }
+
+    fn eq(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 == n2)
+    }
+
+    fn lt(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 < n2)
+    }
+
+    fn le(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 <= n2)
+    }
+
+    fn ne(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 != n2)
+    }
+
+    fn ge(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 >= n2)
+    }
+
+    fn gt(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 > n2)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum AbsUint {
+    Top,
+    Set(BTreeSet<u128>),
+}
+
+impl std::fmt::Debug for AbsUint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Top => write!(f, "⊤_u"),
+            Self::Set(s) => match s.len() {
+                0 => write!(f, "⊥_u"),
+                1 => write!(f, "{}_u", s.first().unwrap()),
+                _ => {
+                    write!(f, "{{")?;
+                    for (i, n) in s.iter().enumerate() {
+                        if i != 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", n)?;
+                    }
+                    write!(f, "}}_u")
+                }
+            },
+        }
+    }
+}
+
+impl AbsUint {
+    #[inline]
+    fn top() -> Self {
+        Self::Top
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::alphas(BTreeSet::new())
+    }
+
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        matches!(self, Self::Top)
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        if let Self::Set(s) = self {
+            s.is_empty()
+        } else {
+            false
+        }
+    }
+
+    pub fn alpha(n: u128) -> Self {
+        Self::alphas([n].into_iter().collect())
+    }
+
+    fn alphas(set: BTreeSet<u128>) -> Self {
+        if set.len() > MAX_SIZE {
+            Self::Top
+        } else {
+            Self::Set(set)
+        }
+    }
+
+    pub fn gamma(&self) -> Option<&BTreeSet<u128>> {
+        if let Self::Set(s) = self {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => Self::alphas(s1.union(s2).cloned().collect()),
+        }
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                if s2.is_subset(s1) {
+                    self.clone()
+                } else if s1.is_empty() {
+                    other.clone()
+                } else {
+                    Self::Top
+                }
+            }
+        }
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        match (self, other) {
+            (_, Self::Top) => true,
+            (Self::Top, _) => false,
+            (Self::Set(s1), Self::Set(s2)) => s1.is_subset(s2),
+        }
+    }
+
+    fn unary<F: Fn(u128) -> u128>(&self, f: F) -> Self {
+        match self {
+            Self::Top => Self::Top,
+            Self::Set(s) => Self::alphas(s.iter().map(|n| f(*n)).collect()),
+        }
+    }
+
+    fn not(&self) -> Self {
+        self.unary(|n| !n)
+    }
+
+    fn to_u8(&self) -> Self {
+        self.unary(|n| n as u8 as u128)
+    }
+
+    fn to_u16(&self) -> Self {
+        self.unary(|n| n as u16 as u128)
+    }
+
+    fn to_u32(&self) -> Self {
+        self.unary(|n| n as u32 as u128)
+    }
+
+    fn to_u64(&self) -> Self {
+        self.unary(|n| n as u64 as u128)
+    }
+
+    fn unaryi<F: Fn(u128) -> i128>(&self, f: F) -> AbsInt {
+        match self {
+            Self::Top => AbsInt::Top,
+            Self::Set(s) => AbsInt::alphas(s.iter().map(|n| f(*n)).collect()),
+        }
+    }
+
+    fn to_i8(&self) -> AbsInt {
+        self.unaryi(|n| n as i8 as i128)
+    }
+
+    fn to_i16(&self) -> AbsInt {
+        self.unaryi(|n| n as i16 as i128)
+    }
+
+    fn to_i32(&self) -> AbsInt {
+        self.unaryi(|n| n as i32 as i128)
+    }
+
+    pub fn to_i64(&self) -> AbsInt {
+        self.unaryi(|n| n as i64 as i128)
+    }
+
+    fn to_i128(&self) -> AbsInt {
+        self.unaryi(|n| n as i128)
+    }
+
+    fn unaryf<F: Fn(u128) -> f64>(&self, f: F) -> AbsFloat {
+        match self {
+            Self::Top => AbsFloat::Top,
+            Self::Set(s) => AbsFloat::alphas(s.iter().map(|n| f(*n)).collect()),
+        }
+    }
+
+    fn to_f32(&self) -> AbsFloat {
+        self.unaryf(|n| n as f32 as f64)
+    }
+
+    fn to_f64(&self) -> AbsFloat {
+        self.unaryf(|n| n as f64)
+    }
+
+    fn binary<F: Fn(u128, u128) -> u128>(&self, other: &Self, f: F) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        set.insert(f(*n1, *n2));
+                    }
+                }
+                Self::alphas(set)
+            }
+        }
+    }
+
+    fn add(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 + n2)
+    }
+
+    fn sub(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 - n2)
+    }
+
+    fn mul(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 * n2)
+    }
+
+    fn binary_nz<F: Fn(u128, u128) -> u128>(&self, other: &Self, f: F) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        if *n2 != 0 {
+                            set.insert(f(*n1, *n2));
+                        }
+                    }
+                }
+                Self::alphas(set)
+            }
+        }
+    }
+
+    fn div(&self, other: &Self) -> Self {
+        self.binary_nz(other, |n1, n2| n1 / n2)
+    }
+
+    fn rem(&self, other: &Self) -> Self {
+        self.binary_nz(other, |n1, n2| n1 % n2)
+    }
+
+    fn bit_xor(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 ^ n2)
+    }
+
+    fn bit_and(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 & n2)
+    }
+
+    fn bit_or(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 | n2)
+    }
+
+    fn shl(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 << n2)
+    }
+
+    fn shr(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 >> n2)
+    }
+
+    fn binaryi<F: Fn(u128, i128) -> u128>(&self, other: &AbsInt, f: F) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, AbsInt::Top) => Self::Top,
+            (Self::Set(s1), AbsInt::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        set.insert(f(*n1, *n2));
+                    }
+                }
+                Self::alphas(set)
+            }
+        }
+    }
+
+    fn shli(&self, other: &AbsInt) -> Self {
+        self.binaryi(other, |n1, n2| n1 << n2)
+    }
+
+    fn shri(&self, other: &AbsInt) -> Self {
+        self.binaryi(other, |n1, n2| n1 >> n2)
+    }
+
+    fn binaryb<F: Fn(u128, u128) -> bool>(&self, other: &Self, f: F) -> AbsBool {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => AbsBool::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        set.insert(f(*n1, *n2));
+                    }
+                }
+                AbsBool::alphas(set)
+            }
+        }
+    }
+
+    fn eq(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 == n2)
+    }
+
+    fn lt(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 < n2)
+    }
+
+    fn le(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 <= n2)
+    }
+
+    fn ne(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 != n2)
+    }
+
+    fn ge(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 >= n2)
+    }
+
+    fn gt(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 > n2)
+    }
+}
+
+#[derive(Clone)]
+pub enum AbsFloat {
+    Top,
+    Set(BTreeSet<u64>),
+}
+
+impl std::fmt::Debug for AbsFloat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Top => write!(f, "⊤_f"),
+            Self::Set(s) => match s.len() {
+                0 => write!(f, "⊥_f"),
+                1 => write!(f, "{}_f", f64::from_bits(*s.first().unwrap())),
+                _ => {
+                    write!(f, "{{")?;
+                    for (i, n) in s.iter().enumerate() {
+                        if i != 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", f64::from_bits(*n))?;
+                    }
+                    write!(f, "}}_f")
+                }
+            },
+        }
+    }
+}
+
+impl AbsFloat {
+    #[inline]
+    fn top() -> Self {
+        Self::Top
+    }
+
+    fn new(set: BTreeSet<u64>) -> Self {
+        if set.len() > MAX_SIZE {
+            Self::Top
+        } else {
+            Self::Set(set)
+        }
+    }
+
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        matches!(self, Self::Top)
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::new(BTreeSet::new())
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        if let Self::Set(s) = self {
+            s.is_empty()
+        } else {
+            false
+        }
+    }
+
+    fn alpha(n: f64) -> Self {
+        Self::new([n.to_bits()].into_iter().collect())
+    }
+
+    fn alphas(v: Vec<f64>) -> Self {
+        Self::new(v.into_iter().map(|n| n.to_bits()).collect())
+    }
+
+    pub fn gamma(&self) -> Option<Vec<f64>> {
+        if let Self::Set(s) = self {
+            Some(s.iter().map(|n| f64::from_bits(*n)).collect())
+        } else {
+            None
+        }
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => Self::new(s1.union(s2).cloned().collect()),
+        }
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                if s2.is_subset(s1) {
+                    self.clone()
+                } else if s1.is_empty() {
+                    other.clone()
+                } else {
+                    Self::Top
+                }
+            }
+        }
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        match (self, other) {
+            (_, Self::Top) => true,
+            (Self::Top, _) => false,
+            (Self::Set(s1), Self::Set(s2)) => s1.is_subset(s2),
+        }
+    }
+
+    fn unary<F: Fn(f64) -> f64>(&self, f: F) -> Self {
+        match self {
+            Self::Top => Self::Top,
+            Self::Set(s) => Self::new(s.iter().map(|n| f(f64::from_bits(*n)).to_bits()).collect()),
+        }
+    }
+
+    fn neg(&self) -> Self {
+        self.unary(|n| -n)
+    }
+
+    fn to_f32(&self) -> Self {
+        self.unary(|n| n as f32 as f64)
+    }
+
+    fn unaryi<F: Fn(f64) -> i128>(&self, f: F) -> AbsInt {
+        match self {
+            Self::Top => AbsInt::Top,
+            Self::Set(s) => AbsInt::alphas(s.iter().map(|n| f(f64::from_bits(*n))).collect()),
+        }
+    }
+
+    fn to_i8(&self) -> AbsInt {
+        self.unaryi(|n| n as i8 as i128)
+    }
+
+    fn to_i16(&self) -> AbsInt {
+        self.unaryi(|n| n as i16 as i128)
+    }
+
+    fn to_i32(&self) -> AbsInt {
+        self.unaryi(|n| n as i32 as i128)
+    }
+
+    fn to_i64(&self) -> AbsInt {
+        self.unaryi(|n| n as i64 as i128)
+    }
+
+    fn to_i128(&self) -> AbsInt {
+        self.unaryi(|n| n as i128)
+    }
+
+    fn unaryu<F: Fn(f64) -> u128>(&self, f: F) -> AbsUint {
+        match self {
+            Self::Top => AbsUint::Top,
+            Self::Set(s) => AbsUint::alphas(s.iter().map(|n| f(f64::from_bits(*n))).collect()),
+        }
+    }
+
+    fn to_u8(&self) -> AbsUint {
+        self.unaryu(|n| n as u8 as u128)
+    }
+
+    fn to_u16(&self) -> AbsUint {
+        self.unaryu(|n| n as u16 as u128)
+    }
+
+    fn to_u32(&self) -> AbsUint {
+        self.unaryu(|n| n as u32 as u128)
+    }
+
+    fn to_u64(&self) -> AbsUint {
+        self.unaryu(|n| n as u64 as u128)
+    }
+
+    fn to_u128(&self) -> AbsUint {
+        self.unaryu(|n| n as u128)
+    }
+
+    fn binary<F: Fn(f64, f64) -> f64>(&self, other: &Self, f: F) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        set.insert(f(f64::from_bits(*n1), f64::from_bits(*n2)).to_bits());
+                    }
+                }
+                Self::new(set)
+            }
+        }
+    }
+
+    fn add(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 + n2)
+    }
+
+    fn sub(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 - n2)
+    }
+
+    fn mul(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 * n2)
+    }
+
+    fn div(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 / n2)
+    }
+
+    fn rem(&self, other: &Self) -> Self {
+        self.binary(other, |n1, n2| n1 % n2)
+    }
+
+    fn binaryb<F: Fn(f64, f64) -> bool>(&self, other: &Self, f: F) -> AbsBool {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => AbsBool::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                let mut set = BTreeSet::new();
+                for n1 in s1 {
+                    for n2 in s2 {
+                        set.insert(f(f64::from_bits(*n1), f64::from_bits(*n2)));
+                    }
+                }
+                AbsBool::alphas(set)
+            }
+        }
+    }
+
+    fn eq(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 == n2)
+    }
+
+    fn lt(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 < n2)
+    }
+
+    fn le(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 <= n2)
+    }
+
+    fn ne(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 != n2)
+    }
+
+    fn ge(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 >= n2)
+    }
+
+    fn gt(&self, other: &Self) -> AbsBool {
+        self.binaryb(other, |n1, n2| n1 > n2)
+    }
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub enum AbsBool {
+    Top,
+    True,
+    False,
+    Bot,
+}
+
+impl std::fmt::Debug for AbsBool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Top => write!(f, "⊤_b"),
+            Self::True => write!(f, "#t"),
+            Self::False => write!(f, "#f"),
+            Self::Bot => write!(f, "⊥_b"),
+        }
+    }
+}
+
+impl AbsBool {
+    #[inline]
+    fn top() -> Self {
+        Self::Top
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::Bot
+    }
+
+    #[inline]
+    pub fn is_top(self) -> bool {
+        matches!(self, Self::Top)
+    }
+
+    #[inline]
+    pub fn is_bot(self) -> bool {
+        matches!(self, Self::Bot)
+    }
+
+    fn alpha(b: bool) -> Self {
+        if b {
+            Self::True
+        } else {
+            Self::False
+        }
+    }
+
+    pub fn gamma(self) -> Vec<bool> {
+        match self {
+            Self::Top => vec![true, false],
+            Self::True => vec![true],
+            Self::False => vec![false],
+            Self::Bot => vec![],
+        }
+    }
+
+    pub fn alphas(set: BTreeSet<bool>) -> Self {
+        if set.len() == 2 {
+            Self::Top
+        } else if set.contains(&true) {
+            Self::True
+        } else if set.contains(&false) {
+            Self::False
+        } else {
+            Self::Bot
+        }
+    }
+
+    fn join(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::True, Self::True) => Self::True,
+            (Self::False, Self::False) => Self::False,
+            (Self::Bot, v) | (v, Self::Bot) => v,
+            _ => Self::Top,
+        }
+    }
+
+    fn widen(self, other: Self) -> Self {
+        self.join(other)
+    }
+
+    fn ord(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (_, Self::Top) | (Self::Bot, _) | (Self::True, Self::True) | (Self::False, Self::False)
+        )
+    }
+
+    fn not(self) -> Self {
+        match self {
+            Self::Top => Self::Top,
+            Self::True => Self::False,
+            Self::False => Self::True,
+            Self::Bot => Self::Bot,
+        }
+    }
+
+    fn to_int(self) -> AbsInt {
+        match self {
+            Self::Top => AbsInt::alphas((0..=1).collect()),
+            Self::True => AbsInt::alpha(1),
+            Self::False => AbsInt::alpha(0),
+            Self::Bot => AbsInt::bot(),
+        }
+    }
+
+    fn to_uint(self) -> AbsUint {
+        match self {
+            Self::Top => AbsUint::alphas((0..=1).collect()),
+            Self::True => AbsUint::alpha(1),
+            Self::False => AbsUint::alpha(0),
+            Self::Bot => AbsUint::bot(),
+        }
+    }
+
+    fn eq(self, other: Self) -> AbsBool {
+        match (self, other) {
+            (Self::Bot, _) | (_, Self::Bot) => Self::Bot,
+            (Self::True, Self::True) | (Self::False, Self::False) => Self::True,
+            (Self::True, Self::False) | (Self::False, Self::True) => Self::False,
+            _ => Self::Top,
+        }
+    }
+
+    fn ne(self, other: Self) -> AbsBool {
+        match (self, other) {
+            (Self::Bot, _) | (_, Self::Bot) => Self::Bot,
+            (Self::True, Self::True) | (Self::False, Self::False) => Self::False,
+            (Self::True, Self::False) | (Self::False, Self::True) => Self::True,
+            _ => Self::Top,
+        }
+    }
+
+    fn bit_xor(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Bot, _) | (_, Self::Bot) => Self::Bot,
+            (Self::True, Self::True) | (Self::False, Self::False) => Self::False,
+            (Self::True, Self::False) | (Self::False, Self::True) => Self::True,
+            _ => Self::Top,
+        }
+    }
+
+    fn bit_and(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Bot, _) | (_, Self::Bot) => Self::Bot,
+            (Self::False, _) | (_, Self::False) => Self::False,
+            (Self::True, Self::True) => Self::True,
+            _ => Self::Top,
+        }
+    }
+
+    fn bit_or(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Bot, _) | (_, Self::Bot) => Self::Bot,
+            (Self::True, _) | (_, Self::True) => Self::True,
+            (Self::False, Self::False) => Self::False,
+            _ => Self::Top,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum AbsList {
+    Top,
+    List(Vec<AbsValue>),
+    Bot,
+}
+
+impl std::fmt::Debug for AbsList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Top => write!(f, "⊤_l"),
+            Self::List(l) => {
+                write!(f, "[")?;
+                for (i, v) in l.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{:?}", v)?;
+                }
+                write!(f, "]")
+            }
+            Self::Bot => write!(f, "⊥_l"),
+        }
+    }
+}
+
+impl AbsList {
+    #[inline]
+    fn top() -> Self {
+        Self::Top
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::Bot
+    }
+
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        matches!(self, Self::Top)
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        matches!(self, Self::Bot)
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Bot, v) | (v, Self::Bot) => v.clone(),
+            (Self::List(l1), Self::List(l2)) if l1.len() == l2.len() => Self::List(
+                l1.iter()
+                    .zip(l2.iter())
+                    .map(|(v1, v2)| v1.join(v2))
+                    .collect(),
+            ),
+            _ => Self::Top,
+        }
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Bot, v) | (v, Self::Bot) => v.clone(),
+            (Self::List(l1), Self::List(l2)) if l1.len() == l2.len() => Self::List(
+                l1.iter()
+                    .zip(l2.iter())
+                    .map(|(v1, v2)| v1.widen(v2))
+                    .collect(),
+            ),
+            _ => Self::Top,
+        }
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        match (self, other) {
+            (_, Self::Top) | (Self::Bot, _) => true,
+            (Self::List(l1), Self::List(l2)) if l1.len() == l2.len() => {
+                l1.iter().zip(l2.iter()).all(|(v1, v2)| v1.ord(v2))
+            }
+            _ => false,
+        }
+    }
+
+    pub fn get_mut(&mut self, i: usize) -> Option<&mut AbsValue> {
+        if let Self::List(l) = self {
+            l.get_mut(i)
+        } else {
+            None
+        }
+    }
+
+    fn subst(&self, map: &BTreeMap<ArgIdx, AbsPtr>) -> Self {
+        match self {
+            Self::Top => Self::Top,
+            Self::List(l) => Self::List(l.iter().map(|v| v.subst(map)).collect()),
+            Self::Bot => Self::Bot,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AbsPlace {
+    pub base: AbsBase,
+    pub projections: Vec<AbsProjElem>,
+}
+
+impl std::fmt::Debug for AbsPlace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.base)?;
+        for elem in &self.projections {
+            write!(f, "{:?}", elem)?;
+        }
+        Ok(())
+    }
+}
+
+impl AbsPlace {
+    #[inline]
+    fn heap() -> Self {
+        Self {
+            base: AbsBase::Heap,
+            projections: Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn null() -> Self {
+        Self {
+            base: AbsBase::Null,
+            projections: Vec::new(),
+        }
+    }
+
+    fn arg(i: ArgIdx) -> Self {
+        Self {
+            base: AbsBase::Arg(i),
+            projections: Vec::new(),
+        }
+    }
+
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        self.base == AbsBase::Null
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AbsBase {
+    Local(Local),
+    Arg(ArgIdx),
+    Heap,
+    Null,
+}
+
+impl std::fmt::Debug for AbsBase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Local(i) => write!(f, "_{}", i.index()),
+            Self::Arg(i) => write!(f, "A{}", i.index()),
+            Self::Heap => write!(f, "H"),
+            Self::Null => write!(f, "null"),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AbsProjElem {
+    Field(FieldIdx),
+    Index(AbsUint),
+}
+
+impl std::fmt::Debug for AbsProjElem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Field(i) => write!(f, ".{}", i.index()),
+            Self::Index(i) => write!(f, "[{:?}]", i),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum AbsPtr {
+    Top,
+    Set(BTreeSet<AbsPlace>),
+}
+
+impl std::fmt::Debug for AbsPtr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Top => write!(f, "⊤_p"),
+            Self::Set(s) => match s.len() {
+                0 => write!(f, "⊥_p"),
+                1 => write!(f, "{:?}", s.first().unwrap()),
+                _ => {
+                    write!(f, "{{")?;
+                    for (i, ptr) in s.iter().enumerate() {
+                        if i != 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{:?}", ptr)?;
+                    }
+                    write!(f, "}}")
+                }
+            },
+        }
+    }
+}
+
+impl AbsPtr {
+    #[inline]
+    pub fn top() -> Self {
+        Self::Top
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::Set(BTreeSet::new())
+    }
+
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        matches!(self, Self::Top)
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        if let Self::Set(s) = self {
+            s.is_empty()
+        } else {
+            false
+        }
+    }
+
+    fn alpha(n: AbsPlace) -> Self {
+        Self::alphas([n].into_iter().collect())
+    }
+
+    pub fn alphas(set: BTreeSet<AbsPlace>) -> Self {
+        if set.len() > MAX_SIZE {
+            Self::Top
+        } else {
+            Self::Set(set)
+        }
+    }
+
+    pub fn gamma(&self) -> Option<&BTreeSet<AbsPlace>> {
+        if let Self::Set(s) = self {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => Self::alphas(s1.union(s2).cloned().collect()),
+        }
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                if s2.is_subset(s1) {
+                    self.clone()
+                } else if s1.is_empty() {
+                    other.clone()
+                } else {
+                    Self::Top
+                }
+            }
+        }
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        match (self, other) {
+            (_, Self::Top) => true,
+            (Self::Top, _) => false,
+            (Self::Set(s1), Self::Set(s2)) => s1.is_subset(s2),
+        }
+    }
+
+    fn compare(&self, other: &Self) -> AbsBool {
+        match (self, other) {
+            (Self::Set(s), _) | (_, Self::Set(s)) if s.is_empty() => AbsBool::Bot,
+            _ => AbsBool::Top,
+        }
+    }
+
+    #[inline]
+    fn heap() -> Self {
+        Self::alpha(AbsPlace::heap())
+    }
+
+    #[inline]
+    fn null() -> Self {
+        Self::alpha(AbsPlace::null())
+    }
+
+    #[inline]
+    fn heap_or_null() -> Self {
+        Self::alphas([AbsPlace::heap(), AbsPlace::null()].into_iter().collect())
+    }
+
+    #[inline]
+    pub fn arg(i: ArgIdx) -> Self {
+        Self::alpha(AbsPlace::arg(i))
+    }
+
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        let Self::Set(ptrs) = self else { return false };
+        if ptrs.len() != 1 {
+            return false;
+        }
+        matches!(ptrs.first().unwrap().base, AbsBase::Null)
+    }
+
+    pub fn get_arg(&self) -> Option<ArgIdx> {
+        if let Self::Set(ptrs) = self {
+            if ptrs.len() == 1 {
+                if let AbsBase::Arg(i) = &ptrs.first().unwrap().base {
+                    return Some(*i);
+                }
+            }
+        }
+        None
+    }
+
+    fn subst(&self, map: &BTreeMap<ArgIdx, Self>) -> Self {
+        if let Self::Set(ptrs) = self {
+            ptrs.iter()
+                .map(|place| {
+                    let alloc = match &place.base {
+                        AbsBase::Local(_) => return Self::bot(),
+                        AbsBase::Arg(i) => i,
+                        AbsBase::Heap => return Self::heap(),
+                        AbsBase::Null => return Self::null(),
+                    };
+                    let ptrs = if let AbsPtr::Set(ptrs) = &map[alloc] {
+                        ptrs
+                    } else {
+                        return AbsPtr::Top;
+                    };
+                    Self::Set(
+                        ptrs.iter()
+                            .cloned()
+                            .map(|mut new_place| {
+                                new_place.projections.extend(place.projections.clone());
+                                new_place
+                            })
+                            .collect(),
+                    )
+                })
+                .reduce(|ptr1, ptr2| ptr1.join(&ptr2))
+                .unwrap_or(AbsPtr::bot())
+        } else {
+            AbsPtr::Top
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum AbsOption {
+    Top,
+    Some(AbsValue),
+    None,
+    Bot,
+}
+
+impl std::fmt::Debug for AbsOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Top => write!(f, "⊤_o"),
+            Self::Some(v) => write!(f, "Some({:?})", v),
+            Self::None => write!(f, "None"),
+            Self::Bot => write!(f, "⊥_o"),
+        }
+    }
+}
+
+impl AbsOption {
+    #[inline]
+    fn top() -> Self {
+        Self::Top
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::Bot
+    }
+
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        matches!(self, Self::Top)
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        matches!(self, Self::Bot)
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Bot, v) | (v, Self::Bot) => v.clone(),
+            (Self::None, Self::None) => Self::None,
+            (Self::Some(v1), Self::Some(v2)) => Self::Some(v1.join(v2)),
+            _ => Self::Top,
+        }
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Bot, v) | (v, Self::Bot) => v.clone(),
+            (Self::None, Self::None) => Self::None,
+            (Self::Some(v1), Self::Some(v2)) => Self::Some(v1.widen(v2)),
+            _ => Self::Top,
+        }
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        match (self, other) {
+            (_, Self::Top) | (Self::Bot, _) | (Self::None, Self::None) => true,
+            (Self::Some(v1), Self::Some(v2)) => v1.ord(v2),
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+#[derive(Clone)]
+pub enum AbsFn {
+    Top,
+    Set(FxHashSet<DefId>),
+}
+
+impl std::fmt::Debug for AbsFn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Top => write!(f, "⊤_fn"),
+            Self::Set(s) => match s.len() {
+                0 => write!(f, "⊥_fn"),
+                1 => write!(f, "{:?}", s.iter().next().unwrap()),
+                _ => {
+                    write!(f, "{{")?;
+                    for (i, n) in s.iter().enumerate() {
+                        if i != 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{:?}", n)?;
+                    }
+                    write!(f, "}}")
+                }
+            },
+        }
+    }
+}
+
+impl AbsFn {
+    #[inline]
+    fn top() -> Self {
+        Self::Top
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::Set(FxHashSet::default())
+    }
+
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        matches!(self, Self::Top)
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        if let Self::Set(s) = self {
+            s.is_empty()
+        } else {
+            false
+        }
+    }
+
+    fn alpha(n: DefId) -> Self {
+        Self::alphas([n].into_iter().collect())
+    }
+
+    fn alphas(set: FxHashSet<DefId>) -> Self {
+        if set.len() > MAX_SIZE {
+            Self::Top
+        } else {
+            Self::Set(set)
+        }
+    }
+
+    pub fn gamma(&self) -> Option<&FxHashSet<DefId>> {
+        if let Self::Set(s) = self {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => Self::alphas(s1.union(s2).cloned().collect()),
+        }
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, _) | (_, Self::Top) => Self::Top,
+            (Self::Set(s1), Self::Set(s2)) => {
+                if s2.is_subset(s1) {
+                    self.clone()
+                } else if s1.is_empty() {
+                    other.clone()
+                } else {
+                    Self::Top
+                }
+            }
+        }
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        match (self, other) {
+            (_, Self::Top) => true,
+            (Self::Top, _) => false,
+            (Self::Set(s1), Self::Set(s2)) => s1.is_subset(s2),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AbsPath {
+    pub base: Local,
+    pub projections: Vec<FieldIdx>,
+}
+
+impl std::fmt::Debug for AbsPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.base.index())?;
+        for idx in self.projections.iter() {
+            write!(f, ".{}", idx.index())?;
+        }
+        Ok(())
+    }
+}
+
+impl AbsPath {
+    pub fn new(base: Local, projections: Vec<FieldIdx>) -> Self {
+        Self { base, projections }
+    }
+
+    pub fn from_place(
+        place: &AbsPlace,
+        ptr_params: &IndexVec<ArgIdx, Local>,
+    ) -> Option<(Self, bool)> {
+        let arg = if let AbsBase::Arg(arg) = place.base {
+            arg
+        } else {
+            return None;
+        };
+        let param = ptr_params[arg];
+        let mut projections = vec![];
+        let mut array_access = false;
+        for proj in place.projections.iter() {
+            match proj {
+                AbsProjElem::Field(idx) => projections.push(*idx),
+                AbsProjElem::Index(_) => {
+                    array_access = true;
+                    break;
+                }
+            }
+        }
+        Some((Self::new(param, projections), array_access))
+    }
+
+    pub fn as_vec(&self) -> Vec<usize> {
+        let mut v = vec![self.base.index()];
+        v.extend(self.projections.iter().map(|idx| idx.index()));
+        v
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MustPathSet {
+    All,
+    Set(BTreeSet<AbsPath>),
+}
+
+impl std::fmt::Debug for MustPathSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MustPathSet::All => write!(f, "All"),
+            MustPathSet::Set(s) => write!(f, "{:?}", s),
+        }
+    }
+}
+
+impl MustPathSet {
+    #[inline]
+    pub fn top() -> Self {
+        Self::Set(BTreeSet::new())
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::All
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        matches!(self, Self::All)
+    }
+
+    pub fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (s, Self::All) | (Self::All, s) => s.clone(),
+            (Self::Set(s1), Self::Set(s2)) => Self::Set(s1.intersection(s2).cloned().collect()),
+        }
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        self.join(other)
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::All, _) => true,
+            (_, Self::All) => false,
+            (Self::Set(s1), Self::Set(s2)) => s2.is_subset(s1),
+        }
+    }
+
+    #[inline]
+    pub fn insert(&mut self, place: AbsPath) {
+        if let Self::Set(set) = self {
+            set.insert(place);
+        }
+    }
+
+    #[inline]
+    pub fn remove(&mut self, base: &BTreeSet<Local>) {
+        if let Self::Set(set) = self {
+            set.retain(|p| !base.contains(&p.base));
+        }
+    }
+
+    #[inline]
+    pub fn contains(&self, place: &AbsPath) -> bool {
+        match self {
+            Self::All => true,
+            Self::Set(set) => set.contains(place),
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::All => false,
+            Self::Set(set) => set.is_empty(),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::All => panic!(),
+            Self::Set(set) => set.len(),
+        }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &AbsPath> {
+        match self {
+            Self::All => panic!(),
+            Self::Set(set) => set.iter(),
+        }
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> BTreeSet<AbsPath> {
+        match self {
+            Self::All => panic!(),
+            Self::Set(set) => set,
+        }
+    }
+
+    #[inline]
+    pub fn as_set(&self) -> &BTreeSet<AbsPath> {
+        match self {
+            Self::All => panic!(),
+            Self::Set(set) => set,
+        }
+    }
+
+    #[inline]
+    pub fn as_vec(&self) -> Vec<&AbsPath> {
+        match self {
+            Self::All => panic!(),
+            Self::Set(set) => set.iter().collect(),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MayPathSet(BTreeSet<AbsPath>);
+
+impl std::fmt::Debug for MayPathSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl MayPathSet {
+    #[inline]
+    fn bot() -> Self {
+        Self(BTreeSet::new())
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        Self(self.0.union(&other.0).cloned().collect())
+    }
+
+    #[inline]
+    fn widen(&self, other: &Self) -> Self {
+        self.join(other)
+    }
+
+    #[inline]
+    fn ord(&self, other: &Self) -> bool {
+        self.0.is_subset(&other.0)
+    }
+
+    #[inline]
+    pub fn insert(&mut self, place: AbsPath) {
+        self.0.insert(place);
+    }
+
+    #[inline]
+    pub fn remove(&mut self, base: &BTreeSet<Local>) {
+        self.0.retain(|p| !base.contains(&p.base));
+    }
+
+    #[inline]
+    pub fn contains(&self, place: &AbsPath) -> bool {
+        self.0.contains(place)
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &AbsPath> {
+        self.0.iter()
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> BTreeSet<AbsPath> {
+        self.0
+    }
+
+    #[inline]
+    pub fn as_set(&self) -> &BTreeSet<AbsPath> {
+        &self.0
+    }
+
+    #[inline]
+    pub fn as_vec(&self) -> Vec<&AbsPath> {
+        self.0.iter().collect()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AbsNull {
+    Top,
+    Null,
+    Nonnull,
+}
+
+impl std::fmt::Debug for AbsNull {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Top => write!(f, "⊤"),
+            Self::Null => write!(f, "null"),
+            Self::Nonnull => write!(f, "nonnull"),
+        }
+    }
+}
+
+impl AbsNull {
+    fn top() -> Self {
+        Self::Top
+    }
+
+    pub fn null() -> Self {
+        Self::Null
+    }
+
+    pub fn nonnull() -> Self {
+        Self::Nonnull
+    }
+
+    fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Null, Self::Null) => Self::Null,
+            (Self::Nonnull, Self::Nonnull) => Self::Nonnull,
+            _ => Self::Top,
+        }
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (_, Self::Top) | (Self::Null, Self::Null) | (Self::Nonnull, Self::Nonnull)
+        )
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        self.join(other)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct AbsNulls(IndexVec<ArgIdx, AbsNull>);
+
+impl PartialOrd for AbsNulls {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AbsNulls {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.raw.cmp(&other.0.raw)
+    }
+}
+
+impl std::fmt::Debug for AbsNulls {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl AbsNulls {
+    #[inline]
+    pub fn bot() -> Self {
+        Self(IndexVec::new())
+    }
+
+    pub fn join(&self, other: &Self) -> Self {
+        let indices = if self.0.len() > other.0.len() {
+            self.0.indices()
+        } else {
+            other.0.indices()
+        };
+        Self(
+            indices
+                .map(|i| match (self.0.get(i), other.0.get(i)) {
+                    (Some(n1), Some(n2)) => n1.join(n2),
+                    (Some(n), None) | (None, Some(n)) => *n,
+                    (None, None) => unreachable!(),
+                })
+                .collect(),
+        )
+    }
+
+    pub fn widen(&self, other: &Self) -> Self {
+        let indices = if self.0.len() > other.0.len() {
+            self.0.indices()
+        } else {
+            other.0.indices()
+        };
+        Self(
+            indices
+                .map(|i| match (self.0.get(i), other.0.get(i)) {
+                    (Some(n1), Some(n2)) => n1.widen(n2),
+                    (Some(n), None) | (None, Some(n)) => *n,
+                    (None, None) => unreachable!(),
+                })
+                .collect(),
+        )
+    }
+
+    pub fn ord(&self, other: &Self) -> bool {
+        self.0.len() <= other.0.len()
+            && self.0.iter().zip(other.0.iter()).all(|(n1, n2)| n1.ord(n2))
+    }
+
+    pub fn push_top(&mut self) {
+        self.0.push(AbsNull::top());
+    }
+
+    pub fn get(&self, arg: ArgIdx) -> &AbsNull {
+        &self.0[arg]
+    }
+
+    pub fn set(&mut self, arg: ArgIdx, n: AbsNull) {
+        while self.0.next_index() < arg {
+            self.0.push(AbsNull::top());
+        }
+        if self.0.next_index() == arg {
+            self.0.push(n);
+        } else {
+            self.0[arg] = n;
+        }
+    }
+
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn next_index(&self) -> ArgIdx {
+        self.0.next_index()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &AbsNull> {
+        self.0.iter()
+    }
+
+    pub fn iter_enumerated(&self) -> impl Iterator<Item = (ArgIdx, &AbsNull)> {
+        self.0.iter_enumerated()
+    }
+
+    pub fn is_null(&self, arg: ArgIdx) -> bool {
+        if let Some(n) = self.0.get(arg) {
+            matches!(n, AbsNull::Null)
+        } else {
+            false
+        }
+    }
+
+    pub fn is_nonnull(&self, arg: ArgIdx) -> bool {
+        if let Some(n) = self.0.get(arg) {
+            matches!(n, AbsNull::Nonnull)
+        } else {
+            false
+        }
+    }
+
+    pub fn is_top(&self, arg: ArgIdx) -> bool {
+        if let Some(n) = self.0.get(arg) {
+            matches!(n, AbsNull::Top)
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum MustLocalSet {
+    All,
+    Set(BTreeSet<Local>),
+}
+
+impl std::fmt::Debug for MustLocalSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MustLocalSet::All => write!(f, "All"),
+            MustLocalSet::Set(s) => write!(f, "{:?}", s),
+        }
+    }
+}
+
+impl MustLocalSet {
+    #[inline]
+    pub fn top() -> Self {
+        Self::Set(BTreeSet::new())
+    }
+
+    #[inline]
+    fn bot() -> Self {
+        Self::All
+    }
+
+    #[inline]
+    pub fn is_bot(&self) -> bool {
+        matches!(self, Self::All)
+    }
+
+    pub fn join(&self, other: &Self) -> Self {
+        match (self, other) {
+            (s, Self::All) | (Self::All, s) => s.clone(),
+            (Self::Set(s1), Self::Set(s2)) => Self::Set(s1.intersection(s2).cloned().collect()),
+        }
+    }
+
+    fn widen(&self, other: &Self) -> Self {
+        self.join(other)
+    }
+
+    fn ord(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::All, _) => true,
+            (_, Self::All) => false,
+            (Self::Set(s1), Self::Set(s2)) => s2.is_subset(s1),
+        }
+    }
+
+    #[inline]
+    pub fn insert(&mut self, l: Local) {
+        if let Self::Set(set) = self {
+            set.insert(l);
+        }
+    }
+
+    #[inline]
+    pub fn extend(&mut self, locals: impl IntoIterator<Item = Local>) {
+        if let Self::Set(set) = self {
+            set.extend(locals);
+        }
+    }
+
+    #[inline]
+    pub fn contains(&self, l: Local) -> bool {
+        match self {
+            Self::All => true,
+            Self::Set(set) => set.contains(&l),
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::All => false,
+            Self::Set(set) => set.is_empty(),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::All => panic!(),
+            Self::Set(set) => set.len(),
+        }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &Local> {
+        match self {
+            Self::All => panic!(),
+            Self::Set(set) => set.iter(),
+        }
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> BTreeSet<Local> {
+        match self {
+            Self::All => panic!(),
+            Self::Set(set) => set,
+        }
+    }
+}

--- a/src/outparam_replacer/ai/domains.rs
+++ b/src/outparam_replacer/ai/domains.rs
@@ -1593,7 +1593,7 @@ impl AbsInt {
     }
 
     fn neg(&self) -> Self {
-        self.unary(|n| -n)
+        self.unary(|n| n.wrapping_neg())
     }
 
     fn to_i8(&self) -> Self {
@@ -1670,15 +1670,15 @@ impl AbsInt {
     }
 
     pub fn add(&self, other: &Self) -> Self {
-        self.binary(other, |n1, n2| n1 + n2)
+        self.binary(other, |n1, n2| n1.wrapping_add(n2))
     }
 
     fn sub(&self, other: &Self) -> Self {
-        self.binary(other, |n1, n2| n1 - n2)
+        self.binary(other, |n1, n2| n1.wrapping_sub(n2))
     }
 
     fn mul(&self, other: &Self) -> Self {
-        self.binary(other, |n1, n2| n1 * n2)
+        self.binary(other, |n1, n2| n1.wrapping_mul(n2))
     }
 
     fn binary_nz<F: Fn(i128, i128) -> i128>(&self, other: &Self, f: F) -> Self {
@@ -1699,11 +1699,11 @@ impl AbsInt {
     }
 
     fn div(&self, other: &Self) -> Self {
-        self.binary_nz(other, |n1, n2| n1 / n2)
+        self.binary_nz(other, |n1, n2| n1.wrapping_div(n2))
     }
 
     fn rem(&self, other: &Self) -> Self {
-        self.binary_nz(other, |n1, n2| n1 % n2)
+        self.binary_nz(other, |n1, n2| n1.wrapping_rem(n2))
     }
 
     fn bit_xor(&self, other: &Self) -> Self {
@@ -1977,15 +1977,15 @@ impl AbsUint {
     }
 
     fn add(&self, other: &Self) -> Self {
-        self.binary(other, |n1, n2| n1 + n2)
+        self.binary(other, |n1, n2| n1.wrapping_add(n2))
     }
 
     fn sub(&self, other: &Self) -> Self {
-        self.binary(other, |n1, n2| n1 - n2)
+        self.binary(other, |n1, n2| n1.wrapping_sub(n2))
     }
 
     fn mul(&self, other: &Self) -> Self {
-        self.binary(other, |n1, n2| n1 * n2)
+        self.binary(other, |n1, n2| n1.wrapping_mul(n2))
     }
 
     fn binary_nz<F: Fn(u128, u128) -> u128>(&self, other: &Self, f: F) -> Self {
@@ -2006,11 +2006,11 @@ impl AbsUint {
     }
 
     fn div(&self, other: &Self) -> Self {
-        self.binary_nz(other, |n1, n2| n1 / n2)
+        self.binary_nz(other, |n1, n2| n1.wrapping_div(n2))
     }
 
     fn rem(&self, other: &Self) -> Self {
-        self.binary_nz(other, |n1, n2| n1 % n2)
+        self.binary_nz(other, |n1, n2| n1.wrapping_rem(n2))
     }
 
     fn bit_xor(&self, other: &Self) -> Self {

--- a/src/outparam_replacer/ai/mod.rs
+++ b/src/outparam_replacer/ai/mod.rs
@@ -1,3 +1,4 @@
+mod pre_analysis;
 pub mod analysis;
 pub mod domains;
 pub mod semantics;

--- a/src/outparam_replacer/ai/mod.rs
+++ b/src/outparam_replacer/ai/mod.rs
@@ -1,4 +1,4 @@
-mod pre_analysis;
 pub mod analysis;
 pub mod domains;
+mod pre_analysis;
 pub mod semantics;

--- a/src/outparam_replacer/ai/pre_analysis.rs
+++ b/src/outparam_replacer/ai/pre_analysis.rs
@@ -1,16 +1,13 @@
-use rustc_hash::{FxHashMap, FxHashSet};
-
 use etrace::some_or;
+use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_index::{IndexVec, bit_set::ChunkedBitSet};
 use rustc_middle::{
-  mir::{Local},
-  ty::{Ty, TyCtxt, TyKind, TypingEnv},
+    mir::Local,
+    ty::{Ty, TyCtxt, TyKind, TypingEnv},
 };
-use rustc_span::{
-    def_id::{DefId, LocalDefId},
-};
+use rustc_span::def_id::{DefId, LocalDefId};
 
-use crate::points_to::andersen::{Loc, LocNode, Solutions, PreAnalysisData};
+use crate::points_to::andersen::{Loc, LocNode, PreAnalysisData, Solutions};
 
 /// Preprocess points-to analysis to use for the output parameter detection
 #[derive(Debug)]

--- a/src/outparam_replacer/ai/pre_analysis.rs
+++ b/src/outparam_replacer/ai/pre_analysis.rs
@@ -1,0 +1,255 @@
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use etrace::some_or;
+use rustc_index::{IndexVec, bit_set::ChunkedBitSet};
+use rustc_middle::{
+  mir::{Local},
+  ty::{Ty, TyCtxt, TyKind, TypingEnv},
+};
+use rustc_span::{
+    def_id::{DefId, LocalDefId},
+};
+
+use crate::points_to::andersen::{Loc, LocNode, Solutions, PreAnalysisData};
+
+/// Preprocess points-to analysis to use for the output parameter detection
+#[derive(Debug)]
+pub struct AliasResults {
+    /// set of parameters that may alias each other
+    pub aliases: FxHashMap<DefId, FxHashSet<Local>>,
+    /// maps a location to the set of parameters that may point to it
+    pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>,
+    /// maps a Loc to its end Loc
+    pub ends: IndexVec<Loc, Loc>,
+    /// maps a static item to the corresponding Loc
+    pub globals: FxHashMap<LocalDefId, Loc>,
+    /// maps (function, local) to the corresponding node
+    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>,
+    /// set of Locs of global variables
+    pub non_fn_globals: ChunkedBitSet<Loc>,
+    /// maps a Loc to the corresponding local
+    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>,
+}
+
+fn check_type_inner<'tcx>(
+    pre: &PreAnalysisData<'tcx>,
+    ty1: &Ty<'tcx>,
+    ty2: &Ty<'tcx>,
+    index1: Loc,
+    index2: Loc,
+    tcx: TyCtxt<'tcx>,
+) -> bool {
+    if ty1 == ty2 {
+        return true;
+    }
+    let typing_env1 = TypingEnv::post_analysis(tcx, pre.index_info.get_owner(index1).to_def_id());
+    let typing_env2 = TypingEnv::post_analysis(tcx, pre.index_info.get_owner(index2).to_def_id());
+    let is_sized1 = ty1.is_sized(tcx, typing_env1);
+    let is_sized2 = ty2.is_sized(tcx, typing_env2);
+    if !is_sized1 || !is_sized2 {
+        return true;
+    }
+
+    let layout1 = tcx.layout_of(typing_env1.as_query_input(*ty1)).unwrap();
+    let layout2 = tcx.layout_of(typing_env2.as_query_input(*ty2)).unwrap();
+
+    layout1.size.bytes() == layout2.size.bytes()
+}
+
+// Filter out the cases where the sizes of types of two global indices are not compatible
+fn check_type_deref<'tcx>(
+    pre: &PreAnalysisData<'tcx>,
+    index1: Loc,
+    index2: Loc,
+    tcx: TyCtxt<'tcx>,
+) -> bool {
+    let ty1 = pre.index_info.get_ty(index1);
+    let ty2 = pre.index_info.get_ty(index2);
+
+    match (ty1.kind(), ty2.kind()) {
+        (TyKind::RawPtr(ty1, _), TyKind::RawPtr(ty2, _))
+        | (TyKind::RawPtr(ty1, _), TyKind::Ref(_, ty2, _)) => {
+            check_type_inner(pre, ty1, ty2, index1, index2, tcx)
+        }
+        (_, _) => false,
+    }
+}
+
+fn check_type<'tcx>(
+    pre: &PreAnalysisData<'tcx>,
+    index1: Loc,
+    index2: Loc,
+    tcx: TyCtxt<'tcx>,
+) -> bool {
+    let ty1 = pre.index_info.get_ty(index1);
+    let ty2 = pre.index_info.get_ty(index2);
+
+    if let TyKind::RawPtr(inner_ty1, _) = ty1.kind() {
+        check_type_inner(pre, inner_ty1, &ty2, index1, index2, tcx)
+    } else {
+        false
+    }
+}
+
+fn collect_param_alias<'tcx>(
+    pre: &PreAnalysisData<'tcx>,
+    solutions: &Solutions,
+    locals: &ChunkedBitSet<Loc>,
+    args: &[Option<Loc>],
+    params: &[(Loc, Local)],
+    fun_alias: &mut FxHashSet<Local>,
+    tcx: TyCtxt<'tcx>,
+) {
+    for (skip, (_, i1)) in params.iter().enumerate() {
+        for (_, i2) in params.iter().skip(skip + 1) {
+            let index1 = args[i1.index() - 1].unwrap();
+            let index2 = args[i2.index() - 1].unwrap();
+            if (fun_alias.contains(i1) && fun_alias.contains(i2))
+                || !check_type_deref(pre, index1, index2, tcx)
+            {
+                continue;
+            }
+
+            let mut sol1 = solutions[index1].clone();
+
+            sol1.intersect(&solutions[index2]);
+            sol1.subtract(locals);
+
+            if !sol1.is_empty() {
+                fun_alias.insert(*i1);
+                fun_alias.insert(*i2);
+            }
+        }
+    }
+}
+
+// Computes the aliasing information for the function parameters
+pub fn compute_alias<'tcx>(
+    pre: PreAnalysisData<'tcx>,
+    solutions: &Solutions,
+    inputs_map: &FxHashMap<DefId, usize>,
+    tcx: TyCtxt<'tcx>,
+    check_global_alias: bool,
+    check_param_alias: bool,
+) -> AliasResults {
+    let mut aliases: FxHashMap<_, FxHashSet<Local>> = FxHashMap::default();
+    let mut inv_params: FxHashMap<_, FxHashMap<_, FxHashSet<Local>>> = FxHashMap::default();
+    let mut index_locals: FxHashMap<_, FxHashMap<Loc, Local>> = FxHashMap::default();
+    let non_fn_globals = pre.non_fn_globals.iter().fold(
+        ChunkedBitSet::new_empty(pre.index_info.len()),
+        |mut acc, g| {
+            acc.insert(*g);
+            acc
+        },
+    );
+
+    for (def_id, inputs) in inputs_map {
+        let body = tcx.optimized_mir(def_id);
+        let local_def_id = some_or!(def_id.as_local(), continue);
+        let mut params = vec![];
+        let mut locals = ChunkedBitSet::new_empty(pre.index_info.len());
+        let mut index_local = FxHashMap::default();
+
+        // Aliases of the function parameters
+        let mut fun_alias = FxHashSet::default();
+        // Map of location to set of parameters that may point to the location
+        let mut inv_param: FxHashMap<_, FxHashSet<_>> = FxHashMap::default();
+
+        for (local, decl) in body.local_decls.iter_enumerated() {
+            let g_index = pre.var_nodes[&(local_def_id, local)].index;
+            let g_index_end = pre.index_info.ends[g_index];
+            index_local.extend((g_index..=g_index_end).map(|loc| (loc, local)));
+
+            if (1..=*inputs).contains(&local.index()) {
+                let ty = decl.ty;
+                let TyKind::RawPtr(..) = ty.kind() else {
+                    continue;
+                };
+                params.push((g_index, local));
+            }
+            locals.insert(g_index);
+        }
+
+        if check_param_alias && pre.call_args.contains_key(&local_def_id) {
+            let call_args = pre.call_args.get(&local_def_id).unwrap();
+
+            for args in call_args {
+                if fun_alias.len() == params.len() {
+                    break;
+                }
+                collect_param_alias(&pre, solutions, &locals, args, &params, &mut fun_alias, tcx)
+            }
+        }
+
+        if check_global_alias {
+            for (index, p) in params {
+                let mut sol = solutions[index].clone();
+                sol.subtract(&locals);
+                sol.intersect(&non_fn_globals);
+
+                for s in sol.iter() {
+                    if check_type(&pre, index, s, tcx) {
+                        inv_param.entry(s).or_default().insert(p);
+                    }
+                }
+            }
+        }
+
+        aliases.insert(*def_id, fun_alias);
+        inv_params.insert(*def_id, inv_param);
+        index_locals.insert(*def_id, index_local);
+    }
+
+    AliasResults {
+        aliases,
+        inv_params,
+        ends: pre.index_info.ends,
+        globals: pre.globals,
+        var_nodes: pre.var_nodes,
+        non_fn_globals,
+        index_locals,
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PreAnalysisContext<'a> {
+    /// the function being analyzed
+    pub local_def_id: LocalDefId,
+    /// set of parameters that may alias each other
+    pub alias: &'a FxHashSet<Local>,
+    /// a location to the set of parameters that may point to it
+    pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>,
+    /// maps a Loc to its end Loc
+    pub ends: &'a IndexVec<Loc, Loc>,
+    // maps a Loc to the corresponding local in the function
+    pub index_local_map: &'a FxHashMap<Loc, Local>,
+    /// set of Locs of global variables
+    pub globals: &'a ChunkedBitSet<Loc>,
+    /// the solutions of the may-points-to analysis
+    pub solutions: &'a Solutions,
+    /// maps (function, local) to the corresponding node
+    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>,
+}
+
+impl<'a> PreAnalysisContext<'a> {
+    pub fn new(def_id: DefId, pre_data: &'a AliasResults, solutions: &'a Solutions) -> Self {
+        Self {
+            local_def_id: def_id.as_local().unwrap(),
+            alias: pre_data.aliases.get(&def_id).unwrap(),
+            inv_param: pre_data.inv_params.get(&def_id).unwrap(),
+            ends: &pre_data.ends,
+            index_local_map: pre_data.index_locals.get(&def_id).unwrap(),
+            globals: &pre_data.non_fn_globals,
+            var_nodes: &pre_data.var_nodes,
+            solutions,
+        }
+    }
+
+    pub fn check_index_global(&self, index: Loc) -> FxHashSet<Local> {
+        if self.inv_param.contains_key(&index) {
+            let params = self.inv_param.get(&index).unwrap();
+            return params.clone();
+        }
+        FxHashSet::default()
+    }
+}

--- a/src/outparam_replacer/ai/semantics.rs
+++ b/src/outparam_replacer/ai/semantics.rs
@@ -1,1 +1,1425 @@
 
+use std::collections::{BTreeMap, BTreeSet};
+
+use etrace::some_or;
+use rustc_abi::{FieldIdx, Size, VariantIdx};
+use rustc_const_eval::interpret::{AllocRange, GlobalAlloc, Scalar};
+use rustc_hir as hir;
+use rustc_middle::{
+    mir::{
+        AggregateKind, BinOp, CastKind, Const, ConstOperand, ConstValue, Local, Location, Operand,
+        Place, PlaceElem, ProjectionElem, Rvalue, Statement, StatementKind, Terminator,
+        TerminatorKind, UnOp,
+    },
+    ty::{adjustment::PointerCoercion, AdtKind, Ty, TyKind},
+};
+use rustc_span::def_id::DefId;
+use rustc_type_ir::{FloatTy, IntTy, UintTy};
+
+use super::{analysis::FunctionSummary, domains::*};
+
+pub struct TransferedTerminator {
+    pub next_states: Vec<AbsState>,
+    pub next_locations: Vec<Location>,
+    pub writes: BTreeSet<AbsPath>,
+    pub call_info: Vec<CallKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CallKind {
+    IntraEffect,
+    IntraPure,
+    Method,
+    RustEffect(Option<Vec<AbsBase>>),
+    RustPure,
+    CEffect,
+    CPure,
+    TOP,
+}
+
+impl TransferedTerminator {
+    #[inline]
+    fn new(
+        next_states: Vec<AbsState>,
+        next_locations: Vec<Location>,
+        writes: BTreeSet<AbsPath>,
+        call_info: Vec<CallKind>,
+    ) -> Self {
+        Self {
+            next_states,
+            next_locations,
+            writes,
+            call_info,
+        }
+    }
+
+    #[inline]
+    fn empty() -> Self {
+        Self::new(vec![], vec![], BTreeSet::new(), vec![])
+    }
+
+    #[inline]
+    fn state_location(st: AbsState, loc: Location) -> Self {
+        Self::new(vec![st], vec![loc], BTreeSet::new(), vec![])
+    }
+
+    #[inline]
+    fn state_locations(st: AbsState, locs: Vec<Location>) -> Self {
+        Self::new(vec![st], locs, BTreeSet::new(), vec![])
+    }
+}
+
+#[allow(clippy::only_used_in_recursion)]
+impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
+    pub fn transfer_statement(
+        &mut self,
+        stmt: &Statement<'tcx>,
+        state: &AbsState,
+    ) -> (AbsState, BTreeSet<AbsPath>) {
+        if let StatementKind::Assign(box (place, rvalue)) = &stmt.kind {
+            let (new_v, reads, cmps) = self.transfer_rvalue(rvalue, state);
+            let (mut new_state, writes) = self.assign(place, new_v, state);
+            new_state.add_excludes(cmps.into_iter());
+            new_state.add_reads(reads.into_iter());
+            let (writes, nonnulls) = new_state.add_writes(writes.into_iter(), &self.ptr_params_inv);
+            if !self.is_merged {
+                new_state.add_nonnulls(nonnulls.into_iter());
+            }
+            (new_state, writes)
+        } else {
+            (state.clone(), BTreeSet::new())
+        }
+    }
+
+    pub fn transfer_terminator(
+        &mut self,
+        terminator: &Terminator<'tcx>,
+        state: &AbsState,
+        location: Location,
+    ) -> TransferedTerminator {
+        match &terminator.kind {
+            TerminatorKind::Goto { target } => {
+                TransferedTerminator::state_location(state.clone(), target.start_location())
+            }
+            TerminatorKind::SwitchInt { discr, targets } => {
+                let (v, reads) = self.transfer_operand(discr, state);
+                let mut new_state = state.clone();
+                new_state.add_reads(reads.into_iter());
+                let locations = if v.intv.is_bot() && v.uintv.is_bot() {
+                    v.boolv
+                        .gamma()
+                        .into_iter()
+                        .map(|b| targets.target_for_value(b as _).start_location())
+                        .collect()
+                } else if !v.intv.is_bot() && !v.intv.is_top() {
+                    v.intv
+                        .gamma()
+                        .unwrap()
+                        .iter()
+                        .map(|b| targets.target_for_value(*b as _).start_location())
+                        .collect()
+                } else if !v.uintv.is_bot() && !v.uintv.is_top() {
+                    v.uintv
+                        .gamma()
+                        .unwrap()
+                        .iter()
+                        .map(|u| targets.target_for_value(*u).start_location())
+                        .collect()
+                } else {
+                    targets
+                        .all_targets()
+                        .iter()
+                        .map(|target| target.start_location())
+                        .collect()
+                };
+                TransferedTerminator::state_locations(new_state, locations)
+            }
+            TerminatorKind::UnwindResume => TransferedTerminator::empty(),
+            TerminatorKind::UnwindTerminate(_) => TransferedTerminator::empty(),
+            TerminatorKind::Return => TransferedTerminator::empty(),
+            TerminatorKind::Unreachable => TransferedTerminator::empty(),
+            TerminatorKind::Drop { target, .. } => {
+                TransferedTerminator::state_location(state.clone(), target.start_location())
+            }
+            TerminatorKind::Call {
+                func,
+                args,
+                destination,
+                target,
+                ..
+            } => {
+                let (func, mut reads) = self.transfer_operand(func, state);
+                let (args, readss): (Vec<_>, Vec<_>) = args
+                    .iter()
+                    .map(|arg| self.transfer_operand(&arg.node, state))
+                    .unzip();
+                for reads2 in readss {
+                    reads.extend(reads2);
+                }
+
+                let (new_states, writes, call_info) = if let Some(fns) = func.fnv.gamma() {
+                    let mut new_states_map: BTreeMap<_, Vec<_>> = BTreeMap::new();
+                    let mut ret_writes = BTreeSet::new();
+                    let mut call_info = vec![];
+                    for def_id in fns {
+                        let (states, writes, call_kind) = self.transfer_call(
+                            *def_id,
+                            &args,
+                            destination,
+                            location,
+                            state.clone(),
+                            reads.clone(),
+                        );
+                        ret_writes.extend(writes);
+                        call_info.push(call_kind);
+
+                        for state in states {
+                            let wn = (state.writes.clone(), state.nulls.clone());
+                            new_states_map.entry(wn).or_default().push(state);
+                        }
+                    }
+                    let new_states = new_states_map
+                        .into_values()
+                        .map(|states| states.into_iter().reduce(|a, b| a.join(&b)).unwrap())
+                        .collect();
+                    (new_states, ret_writes, call_info)
+                } else {
+                    let (mut new_state, writes) = self.assign(destination, AbsValue::top(), state);
+                    let reads2 = args
+                        .iter()
+                        .flat_map(|arg| self.get_read_paths_of_ptr(&arg.ptrv, &[]));
+                    reads.extend(reads2);
+                    new_state.add_reads(reads.into_iter());
+                    let (writes, nonnulls) =
+                        new_state.add_writes(writes.into_iter(), &self.ptr_params_inv);
+                    if !self.is_merged {
+                        new_state.add_nonnulls(nonnulls.into_iter());
+                    }
+                    for arg in &args {
+                        self.indirect_assign(&arg.ptrv, &AbsValue::top(), &[], &mut new_state);
+                    }
+                    (vec![new_state], writes, vec![])
+                };
+                let locations = if new_states.is_empty() {
+                    vec![]
+                } else {
+                    target
+                        .as_ref()
+                        .map(|target| vec![target.start_location()])
+                        .unwrap_or(vec![])
+                };
+                TransferedTerminator::new(new_states, locations, writes, call_info)
+            }
+            TerminatorKind::TailCall { .. } => todo!("{:?}", terminator.kind),
+            TerminatorKind::Assert { cond, target, .. } => {
+                let (_, reads) = self.transfer_operand(cond, state);
+                let mut new_state = state.clone();
+                new_state.add_reads(reads.into_iter());
+                TransferedTerminator::state_location(new_state, target.start_location())
+            }
+            TerminatorKind::Yield { .. } => unreachable!("{:?}", terminator.kind),
+            TerminatorKind::CoroutineDrop => unreachable!("{:?}", terminator.kind),
+            TerminatorKind::FalseEdge { .. } => unreachable!("{:?}", terminator.kind),
+            TerminatorKind::FalseUnwind { .. } => unreachable!("{:?}", terminator.kind),
+            TerminatorKind::InlineAsm { targets, .. } => {
+                let locations = targets
+                    .iter()
+                    .map(|target| target.start_location())
+                    .collect();
+                TransferedTerminator::state_locations(state.clone(), locations)
+            }
+        }
+    }
+
+    fn transfer_call(
+        &mut self,
+        callee: DefId,
+        args: &[AbsValue],
+        dst: &Place<'tcx>,
+        location: Location,
+        mut state: AbsState,
+        mut reads: Vec<AbsPath>,
+    ) -> (Vec<AbsState>, BTreeSet<AbsPath>, CallKind) {
+        let mut offsets = vec![];
+        let mut writes = vec![];
+        let name = self.def_id_to_string(callee);
+        let (vs, nulls, call_kind) = if callee.is_local() {
+            if let Some(summary) = self.summaries.get(&callee) {
+                return self
+                    .transfer_intra_call(callee, summary, args, dst, state, location, reads);
+            } else if name.contains("{extern#0}") {
+                self.transfer_c_call(callee, args, &mut state, &mut reads)
+            } else if name.contains("{impl#") {
+                (
+                    vec![self.transfer_method_call(callee, args, &mut reads)],
+                    vec![],
+                    CallKind::Method,
+                )
+            } else {
+                (vec![AbsValue::top()], vec![], CallKind::TOP)
+            }
+        } else {
+            self.transfer_rust_call(
+                callee,
+                args,
+                &mut state,
+                &mut offsets,
+                &mut reads,
+                &mut writes,
+            )
+        };
+        let (mut new_states, writess): (Vec<_>, Vec<_>) = vs
+            .into_iter()
+            .map(|v| {
+                let (mut new_state, writes_ret) = self.assign(dst, v, &state);
+                new_state.add_excludes(offsets.iter().cloned());
+                new_state.add_reads(reads.iter().cloned());
+                let (writes, nonnulls) = new_state.add_writes(
+                    writes.iter().cloned().chain(writes_ret),
+                    &self.ptr_params_inv,
+                );
+                if !self.is_merged {
+                    new_state.add_nonnulls(nonnulls.into_iter());
+                }
+                (new_state, writes)
+            })
+            .unzip();
+
+        if !nulls.is_empty() {
+            assert!(new_states.len() == nulls.len());
+            for (state, (i, arg, n)) in new_states.iter_mut().zip(nulls) {
+                match n {
+                    AbsNull::Top => unreachable!(),
+                    AbsNull::Null | AbsNull::Nonnull => {
+                        let path = AbsPath::new(i, vec![]);
+                        state.add_null(path, arg, n);
+                    }
+                }
+            }
+        }
+
+        let writes = writess.into_iter().flatten().collect();
+        (new_states, writes, call_kind)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn transfer_intra_call(
+        &mut self,
+        callee: DefId,
+        summary: &FunctionSummary,
+        args: &[AbsValue],
+        dst: &Place<'tcx>,
+        state: AbsState,
+        location: Location,
+        mut reads: Vec<AbsPath>,
+    ) -> (Vec<AbsState>, BTreeSet<AbsPath>, CallKind) {
+        let call_kind = if summary.has_side_effects {
+            CallKind::IntraEffect
+        } else {
+            CallKind::IntraPure
+        };
+        if summary.return_states.is_empty() {
+            return (vec![], BTreeSet::new(), call_kind);
+        }
+
+        let mut ptr_maps = BTreeMap::new();
+        for (param, arg) in summary.init_state.local.iter().skip(1).zip(args.iter()) {
+            if let Some(idx) = param.ptrv.get_arg() {
+                ptr_maps.insert(idx, arg.ptrv.clone());
+            }
+        }
+
+        let sig = self.tcx.fn_sig(callee).skip_binder();
+        let inputs = sig.inputs().skip_binder();
+        for arg in args.iter().skip(inputs.len()) {
+            let reads2 = self.get_read_paths_of_ptr(&arg.ptrv, &[]);
+            reads.extend(reads2);
+        }
+
+        let mut states = vec![];
+        let mut ret_writes = BTreeSet::new();
+        for return_state in summary.return_states.values() {
+            let mut state = state.clone();
+            let ret_v = return_state.local.get(Local::ZERO);
+            for (p, a) in &ptr_maps {
+                let v = return_state.args.get(*p).subst(&ptr_maps);
+                self.indirect_assign(a, &v, &[], &mut state);
+            }
+            let ret_v = ret_v.subst(&ptr_maps);
+            let (mut state, writes) = self.assign(dst, ret_v, &state);
+            let callee_null_excludes: Vec<_> = return_state
+                .null_excludes
+                .iter()
+                .flat_map(|exclude| self.get_caller_path(exclude, args))
+                .collect();
+            let callee_excludes: Vec<_> = return_state
+                .excludes
+                .iter()
+                .flat_map(|exclude| self.get_caller_path(exclude, args))
+                .collect();
+            let callee_reads: Vec<_> = return_state
+                .reads
+                .iter()
+                .flat_map(|read| self.get_caller_path(read, args))
+                .collect();
+            let mut callee_writes = vec![];
+            let mut callee_nonnulls = BTreeSet::new();
+            for write in return_state.writes.iter() {
+                let idx = write.base.index() - 1;
+                let AbsPtr::Set(ptrs) = &args[idx].ptrv else {
+                    continue;
+                };
+                if ptrs.len() != 1 {
+                    continue;
+                }
+                let ptr = ptrs.first().unwrap();
+                let (mut path, array_access) =
+                    some_or!(AbsPath::from_place(ptr, &self.ptr_params), continue);
+                if array_access {
+                    continue;
+                }
+                if return_state.nonnulls.contains(write.base) {
+                    callee_nonnulls.insert(path.base);
+                }
+
+                path.projections.extend(write.projections.clone());
+                callee_writes.push(path.clone());
+                self.call_args
+                    .entry(location)
+                    .or_default()
+                    .insert(path.base.index() - 1, idx);
+            }
+            state.add_excludes(callee_excludes.into_iter());
+            state.add_null_excludes(callee_null_excludes.into_iter());
+            state.add_reads(reads.clone().into_iter());
+            state.add_reads(callee_reads.into_iter());
+
+            let (callee_writes, callee_nonnull_cands) =
+                state.add_writes(callee_writes.into_iter(), &self.ptr_params_inv);
+            let (writes, nonnulls) = state.add_writes(writes.into_iter(), &self.ptr_params_inv);
+
+            if !self.is_merged {
+                state.add_nonnulls(nonnulls.into_iter());
+                state.add_nonnulls(callee_nonnull_cands.intersection(&callee_nonnulls).cloned());
+            }
+
+            ret_writes.extend(callee_writes.into_iter().chain(writes));
+            states.push(state)
+        }
+        (states, ret_writes, call_kind)
+    }
+
+    fn transfer_method_call(
+        &self,
+        callee: DefId,
+        args: &[AbsValue],
+        reads: &mut Vec<AbsPath>,
+    ) -> AbsValue {
+        let node = self.tcx.hir_get_if_local(callee).unwrap();
+        if let hir::Node::ImplItem(item) = node {
+            let span_str = self.span_to_string(item.span);
+            assert_eq!(span_str, "BitfieldStruct", "{:?} {}", callee, span_str);
+            let reads2 = self.get_read_paths_of_ptr(&args[0].ptrv, &[]);
+            reads.extend(reads2);
+            if let hir::ImplItemKind::Fn(sig, _) = &item.kind {
+                match &sig.decl.output {
+                    hir::FnRetTy::Return(ty) => {
+                        if let hir::TyKind::Path(hir::QPath::Resolved(_, path)) = &ty.kind {
+                            if let hir::def::Res::Def(_, def_id) = path.res {
+                                let ty = self.def_id_to_string(def_id);
+                                let ty = ty.split("::").last().unwrap();
+                                let v = match ty {
+                                    "c_int" => AbsValue::top_int(),
+                                    "c_uint" => AbsValue::top_uint(),
+                                    _ => AbsValue::top(),
+                                };
+                                return v;
+                            }
+                        }
+                    }
+                    hir::FnRetTy::DefaultReturn(_) => {
+                        let name = item.ident.name.to_ident_string();
+                        assert!(name.starts_with("set_"), "{:?}", callee);
+                        return AbsValue::bot();
+                    }
+                }
+            }
+        }
+        unreachable!("{:?}", callee)
+    }
+
+    fn transfer_c_call(
+        &mut self,
+        callee: DefId,
+        args: &[AbsValue],
+        state: &mut AbsState,
+        reads: &mut Vec<AbsPath>,
+    ) -> (Vec<AbsValue>, Vec<(Local, ArgIdx, AbsNull)>, CallKind) {
+        let name = self.def_id_to_string(callee);
+        let mut segs: Vec<_> = name.split("::").collect();
+        let segs0 = segs.pop().unwrap_or_default();
+
+        let call_kind = match segs0 {
+            "__ctype_toupper_loc"
+            | "towlower"
+            | "towupper"
+            | "gettimeofday"
+            | "strlen"
+            | "strspn"
+            | "strerror"
+            | "__errno_location" => CallKind::CPure,
+            _ => CallKind::CEffect,
+        };
+
+        let sig = self.tcx.fn_sig(callee).skip_binder();
+        let inputs = sig.inputs().skip_binder();
+        let output = sig.output().skip_binder();
+
+        let ptr_args: Vec<_> = inputs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, ty)| {
+                if let TyKind::RawPtr(ty, _) = ty.kind() {
+                    if let TyKind::Adt(adt, _) = ty.kind() {
+                        if self.def_id_to_string(adt.did()).ends_with("::_IO_FILE") {
+                            return None;
+                        }
+                    }
+                    return Some(i);
+                }
+                None
+            })
+            .collect();
+        for arg in ptr_args.iter() {
+            let reads2 = self.get_read_paths_of_ptr(&args[*arg].ptrv, &[]);
+            reads.extend(reads2);
+        }
+
+        for arg in args.iter().skip(inputs.len()) {
+            let reads2 = self.get_read_paths_of_ptr(&arg.ptrv, &[]);
+            reads.extend(reads2);
+        }
+
+        let reads2 = args.iter().flat_map(|arg| {
+            let (v, _) = self.read_ptr(&arg.ptrv, &[], state);
+            self.get_read_paths_of_ptr(&v.ptrv, &[])
+        });
+        reads.extend(reads2);
+
+        for arg in ptr_args {
+            self.indirect_assign(&args[arg].ptrv, &AbsValue::top(), &[], state);
+        }
+
+        let v = if output.is_primitive() || output.is_unit() || output.is_never() {
+            self.top_value_of_ty(&output)
+        } else if output.is_raw_ptr() {
+            AbsValue::heap_or_null()
+        } else {
+            AbsValue::top()
+        };
+
+        (vec![v], vec![], call_kind)
+    }
+
+    fn transfer_rust_call(
+        &self,
+        callee: DefId,
+        args: &[AbsValue],
+        state: &mut AbsState,
+        offsets: &mut Vec<AbsPath>,
+        reads: &mut Vec<AbsPath>,
+        writes: &mut Vec<AbsPath>,
+    ) -> (Vec<AbsValue>, Vec<(Local, ArgIdx, AbsNull)>, CallKind) {
+        let name = self.def_id_to_string(callee);
+        let mut call_kind = CallKind::RustPure;
+        let mut segs: Vec<_> = name.split("::").collect();
+        let segs0 = segs.pop().unwrap_or_default();
+        let segs1 = segs.pop().unwrap_or_default();
+        let segs2 = segs.pop().unwrap_or_default();
+        let segs3 = segs.pop().unwrap_or_default();
+        let v = match (segs3, segs2, segs1, segs0) {
+            ("", "slice", _, "as_mut_ptr" | "as_ptr") => {
+                let ptr = if let Some(ptrs) = args[0].ptrv.gamma() {
+                    AbsPtr::alphas(
+                        ptrs.iter()
+                            .cloned()
+                            .map(|mut ptr| {
+                                let zero = AbsUint::alpha(0);
+                                ptr.projections.push(AbsProjElem::Index(zero));
+                                ptr
+                            })
+                            .collect(),
+                    )
+                } else {
+                    AbsPtr::top()
+                };
+                AbsValue::ptr(ptr)
+            }
+            ("ptr", "mut_ptr" | "const_ptr", _, "offset") => {
+                let offsets2 = self.get_read_paths_of_ptr(&args[0].ptrv, &[]);
+                offsets.extend(offsets2);
+                let ptr = if let Some(ptrs) = args[0].ptrv.gamma() {
+                    AbsPtr::alphas(
+                        ptrs.iter()
+                            .cloned()
+                            .map(|mut ptr| {
+                                let last = ptr.projections.last_mut();
+                                if let Some(AbsProjElem::Index(i)) = last {
+                                    *i = i.to_i64().add(&args[1].intv).to_u64();
+                                }
+                                ptr
+                            })
+                            .collect(),
+                    )
+                } else {
+                    AbsPtr::top()
+                };
+                AbsValue::ptr(ptr)
+            }
+            ("ptr", "mut_ptr" | "const_ptr", _, "is_null") => {
+                if let Some(ptrs) = args[0].ptrv.gamma() {
+                    let t = ptrs.iter().any(|p| p.is_null());
+                    let f = ptrs.iter().any(|p| !p.is_null());
+                    let args: BTreeSet<_> = ptrs
+                        .iter()
+                        .filter_map(|p| {
+                            if !p.projections.is_empty() {
+                                return None;
+                            }
+                            let (path, _) = AbsPath::from_place(p, &self.ptr_params)?;
+                            Some(path.base)
+                        })
+                        .collect();
+                    if args.len() == 1 && !t {
+                        let i = *args.first().unwrap();
+                        let arg = *self.ptr_params_inv.get(&i).unwrap();
+                        match state.nulls.get(arg) {
+                            AbsNull::Null => AbsValue::bool_true(),
+                            AbsNull::Nonnull => AbsValue::bool_false(),
+                            AbsNull::Top => {
+                                return (
+                                    vec![AbsValue::bool_true(), AbsValue::bool_false()],
+                                    vec![(i, arg, AbsNull::null()), (i, arg, AbsNull::nonnull())],
+                                    call_kind,
+                                );
+                            }
+                        }
+                    } else {
+                        match (t, f) {
+                            (true, true) => AbsValue::top_bool(),
+                            (true, false) => AbsValue::bool_true(),
+                            (false, true) => AbsValue::bool_false(),
+                            (false, false) => AbsValue::bot(),
+                        }
+                    }
+                } else {
+                    AbsValue::top_bool()
+                }
+            }
+            ("ptr", "mut_ptr" | "const_ptr", _, "offset_from") => AbsValue::top_int(),
+            ("", "", "ptr", "write_volatile") => {
+                self.indirect_assign(&args[0].ptrv, &args[1], &[], state);
+                let writes2 = self.get_write_paths_of_ptr(&args[0].ptrv, &[]);
+                writes.extend(writes2);
+                let bases = self
+                    .get_write_bases_of_ptr(&args[0].ptrv)
+                    .unwrap_or_default();
+                call_kind = CallKind::RustEffect(Some(bases));
+                AbsValue::top()
+            }
+            ("", "", "ptr", "read_volatile")
+            | ("", "clone", "Clone", "clone")
+            | ("", "", "ptr", "read") => {
+                let (v, reads2) = self.read_ptr(&args[0].ptrv, &[], state);
+                reads.extend(reads2);
+                v
+            }
+            ("", "option", _, "is_some") => {
+                let (v, reads2) = self.read_ptr(&args[0].ptrv, &[], state);
+                reads.extend(reads2);
+                match v.optionv {
+                    AbsOption::Top => AbsValue::top_bool(),
+                    AbsOption::Some(_) => AbsValue::bool_true(),
+                    AbsOption::None => AbsValue::bool_false(),
+                    AbsOption::Bot => AbsValue::bot(),
+                }
+            }
+            ("", "option", _, "is_none") => {
+                let (v, reads2) = self.read_ptr(&args[0].ptrv, &[], state);
+                reads.extend(reads2);
+                match v.optionv {
+                    AbsOption::Top => AbsValue::top_bool(),
+                    AbsOption::Some(_) => AbsValue::bool_false(),
+                    AbsOption::None => AbsValue::bool_true(),
+                    AbsOption::Bot => AbsValue::bot(),
+                }
+            }
+            ("", "option", _, "unwrap") => match &args[0].optionv {
+                AbsOption::Top => AbsValue::top(),
+                AbsOption::Some(v) => v.clone(),
+                _ => AbsValue::bot(),
+            },
+            ("", "cast", "ToPrimitive", "to_u64")
+            | ("", "num", _, "count_ones" | "trailing_zeros" | "leading_zeros")
+            | ("", "", "mem", "size_of" | "align_of") => AbsValue::top_uint(),
+            ("", "", "panicking", "panic" | "begin_panic" | "panic_explicit") => {
+                call_kind = CallKind::RustEffect(None);
+                AbsValue::bot()
+            }
+            ("", "vec", _, "leak")
+            | ("ops", "deref", "Deref", "deref")
+            | ("ops", "deref", "DerefMut", "deref_mut") => AbsValue::top_ptr(),
+            ("", "num", _, "overflowing_add") => {
+                AbsValue::alpha_list(vec![args[0].add(&args[1]), AbsValue::top_bool()])
+            }
+            ("", "num", _, "overflowing_sub") => {
+                AbsValue::alpha_list(vec![args[0].sub(&args[1]), AbsValue::top_bool()])
+            }
+            ("", "num", _, "overflowing_mul") => {
+                AbsValue::alpha_list(vec![args[0].mul(&args[1]), AbsValue::top_bool()])
+            }
+            ("", "num", _, "overflowing_div") => {
+                AbsValue::alpha_list(vec![args[0].div(&args[1]), AbsValue::top_bool()])
+            }
+            ("", "num", _, "overflowing_rem") => {
+                AbsValue::alpha_list(vec![args[0].rem(&args[1]), AbsValue::top_bool()])
+            }
+            ("", "num", _, "overflowing_neg") => {
+                AbsValue::alpha_list(vec![args[0].neg(), AbsValue::top_bool()])
+            }
+            ("", "num", _, "wrapping_add") => args[0].add(&args[1]),
+            ("", "num", _, "wrapping_sub") => args[0].sub(&args[1]),
+            ("", "num", _, "wrapping_mul") => args[0].mul(&args[1]),
+            ("", "num", _, "wrapping_div") => args[0].div(&args[1]),
+            ("", "num", _, "wrapping_rem") => args[0].rem(&args[1]),
+            ("", "num", _, "wrapping_neg") => args[0].neg(),
+            (_, "f64", _, m) if m.starts_with("is_") => AbsValue::top_bool(),
+            ("", "", "AsmCastTrait", "cast_out") => AbsValue::bot(),
+            ("", "unix", _, "memcpy") => {
+                let reads2 = self.get_read_paths_of_ptr(&args[1].ptrv, &[]);
+                reads.extend(reads2);
+                let writes2 = self.get_write_paths_of_ptr(&args[0].ptrv, &[]);
+                writes.extend(writes2);
+                let bases = self
+                    .get_write_bases_of_ptr(&args[0].ptrv)
+                    .unwrap_or_default();
+                call_kind = CallKind::RustEffect(Some(bases));
+                args[0].clone()
+            }
+            ("", "vec", _, "as_mut_ptr") => AbsValue::top_ptr(),
+            ("ffi", "va_list", _, "arg" | "as_va_list")
+            | ("", "", "AsmCastTrait", "cast_in")
+            | ("", "f128_t", _, "new")
+            | ("", "convert", "From", "from")
+            | ("", "convert", "TryInto", "try_into")
+            | ("", "convert", "Into", "into")
+            | ("", "", "vec", "from_elem")
+            | ("", "result", _, "unwrap")
+            | ("", "num", _, "swap_bytes")
+            | (
+                "ops",
+                "arith",
+                "Add" | "BitAnd" | "BitOr" | "BitXor" | "Div" | "Mul" | "Neg" | "Not" | "Rem"
+                | "Shl" | "Shr" | "Sub",
+                _,
+            ) => AbsValue::top(),
+            (
+                "ops",
+                "arith",
+                "AddAssign" | "BitAndAssign" | "BitOrAssign" | "BitXorAssign" | "DivAssign"
+                | "MulAssign" | "RemAssign" | "ShlAssign" | "ShrAssign" | "SubAssign",
+                _,
+            )
+            | ("", "cast", "ToPrimitive", "to_i64") => {
+                let reads0 = self.get_read_paths_of_ptr(&args[0].ptrv, &[]);
+                reads.extend(reads0);
+                AbsValue::top()
+            }
+            ("", "cmp", "PartialOrd", "lt" | "le" | "gt" | "ge")
+            | ("", "cmp", "PartialEq", "eq" | "ne") => {
+                let reads0 = self.get_read_paths_of_ptr(&args[0].ptrv, &[]);
+                let reads1 = self.get_read_paths_of_ptr(&args[1].ptrv, &[]);
+                reads.extend(reads0);
+                reads.extend(reads1);
+                AbsValue::top_bool()
+            }
+            _ => todo!("{}", name),
+        };
+        (vec![v], vec![], call_kind)
+    }
+
+    fn transfer_rvalue(
+        &self,
+        rvalue: &Rvalue<'tcx>,
+        state: &AbsState,
+    ) -> (AbsValue, Vec<AbsPath>, Vec<AbsPath>) {
+        match rvalue {
+            Rvalue::Use(operand) => {
+                let (v, reads) = self.transfer_operand(operand, state);
+                (v, reads, vec![])
+            }
+            Rvalue::Repeat(operand, len) => {
+                let (v, reads) = self.transfer_operand(operand, state);
+                let len = len.try_to_target_usize(self.tcx).unwrap();
+                (AbsValue::alpha_list(vec![v; len as usize]), reads, vec![])
+            }
+            Rvalue::Ref(_, _, place) => {
+                let v = if place.is_indirect_first_projection() {
+                    let projection = self.abstract_projection(&place.projection[1..], state);
+                    let ptr = state.local.get(place.local);
+                    if let AbsPtr::Set(ptrs) = &ptr.ptrv {
+                        AbsValue::ptr(AbsPtr::Set(
+                            ptrs.iter()
+                                .map(|ptr| {
+                                    let mut ptr_projection = ptr.projections.clone();
+                                    ptr_projection.extend(projection.clone());
+                                    AbsPlace {
+                                        base: ptr.base,
+                                        projections: ptr_projection,
+                                    }
+                                })
+                                .collect(),
+                        ))
+                    } else {
+                        AbsValue::top_ptr()
+                    }
+                } else {
+                    let place = self.abstract_place(place, state);
+                    AbsValue::alpha_ptr(place)
+                };
+                (v, vec![], vec![])
+            }
+            Rvalue::ThreadLocalRef(_) => (AbsValue::top_ptr(), vec![], vec![]),
+            Rvalue::RawPtr(_, place) => {
+                assert_eq!(place.projection.len(), 1);
+                assert!(place.is_indirect_first_projection());
+                let v = state.local.get(place.local);
+                (v.clone(), vec![], vec![])
+            }
+            Rvalue::Len(_) => unreachable!("{:?}", rvalue),
+            Rvalue::Cast(kind, operand, ty) => {
+                let (v, reads) = self.transfer_operand(operand, state);
+                let v = match kind {
+                    CastKind::PointerExposeProvenance => self.top_value_of_ty(ty),
+                    CastKind::PointerWithExposedProvenance => {
+                        let zero: BTreeSet<u128> = [0].into_iter().collect();
+                        if v.uintv.gamma().map(|s| s == &zero).unwrap_or(false) {
+                            AbsValue::null()
+                        } else {
+                            AbsValue::top_ptr()
+                        }
+                    }
+                    CastKind::PointerCoercion(coercion, _) => match coercion {
+                        PointerCoercion::ReifyFnPointer => v,
+                        PointerCoercion::UnsafeFnPointer => unreachable!("{:?}", rvalue),
+                        PointerCoercion::ClosureFnPointer(_) => unreachable!("{:?}", rvalue),
+                        PointerCoercion::MutToConstPointer => v,
+                        PointerCoercion::ArrayToPointer => {
+                            if let Some(ptrs) = v.ptrv.gamma() {
+                                AbsValue::ptr(AbsPtr::Set(
+                                    ptrs.iter()
+                                        .cloned()
+                                        .map(|mut ptr| {
+                                            let zero = AbsUint::alpha(0);
+                                            ptr.projections.push(AbsProjElem::Index(zero));
+                                            ptr
+                                        })
+                                        .collect(),
+                                ))
+                            } else {
+                                AbsValue::top_ptr()
+                            }
+                        }
+                        PointerCoercion::Unsize => v,
+                        PointerCoercion::DynStar => unreachable!("{:?}", rvalue),
+                    },
+                    CastKind::IntToInt | CastKind::FloatToInt => match ty.kind() {
+                        TyKind::Int(int_ty) => match int_ty {
+                            IntTy::Isize => v.to_i64(),
+                            IntTy::I8 => v.to_i8(),
+                            IntTy::I16 => v.to_i16(),
+                            IntTy::I32 => v.to_i32(),
+                            IntTy::I64 => v.to_i64(),
+                            IntTy::I128 => v.to_i128(),
+                        },
+                        TyKind::Uint(uint_ty) => match uint_ty {
+                            UintTy::Usize => v.to_u64(),
+                            UintTy::U8 => v.to_u8(),
+                            UintTy::U16 => v.to_u16(),
+                            UintTy::U32 => v.to_u32(),
+                            UintTy::U64 => v.to_u64(),
+                            UintTy::U128 => v.to_u128(),
+                        },
+                        _ => unreachable!("{:?}", rvalue),
+                    },
+                    CastKind::FloatToFloat | CastKind::IntToFloat => {
+                        if let TyKind::Float(float_ty) = ty.kind() {
+                            match float_ty {
+                                FloatTy::F16 => todo!("{:?}", rvalue),
+                                FloatTy::F32 => v.to_f32(),
+                                FloatTy::F64 => v.to_f64(),
+                                FloatTy::F128 => todo!("{:?}", rvalue),
+                            }
+                        } else {
+                            unreachable!("{:?}", rvalue)
+                        }
+                    }
+                    CastKind::PtrToPtr => {
+                        let void = if let TyKind::RawPtr(ty, _) = ty.kind() {
+                            ty.is_c_void(self.tcx)
+                        } else {
+                            false
+                        };
+                        if void {
+                            v
+                        } else {
+                            AbsValue::heap().join(&v)
+                        }
+                    }
+                    CastKind::FnPtrToPtr => v,
+                    CastKind::Transmute => v,
+                };
+                (v, reads, vec![])
+            }
+            Rvalue::BinaryOp(binop, box (l, r)) => {
+                let (l, mut reads_l) = self.transfer_operand(l, state);
+                let (r, reads_r) = self.transfer_operand(r, state);
+                let v = match binop {
+                    BinOp::Add => l.add(&r),
+                    BinOp::AddUnchecked => unreachable!("{:?}", rvalue),
+                    BinOp::AddWithOverflow => unreachable!("{:?}", rvalue),
+                    BinOp::Sub => l.sub(&r),
+                    BinOp::SubUnchecked => unreachable!("{:?}", rvalue),
+                    BinOp::SubWithOverflow => unreachable!("{:?}", rvalue),
+                    BinOp::Mul => l.mul(&r),
+                    BinOp::MulUnchecked => unreachable!("{:?}", rvalue),
+                    BinOp::MulWithOverflow => unreachable!("{:?}", rvalue),
+                    BinOp::Div => l.div(&r),
+                    BinOp::Rem => l.rem(&r),
+                    BinOp::BitXor => l.bit_xor(&r),
+                    BinOp::BitAnd => l.bit_and(&r),
+                    BinOp::BitOr => l.bit_or(&r),
+                    BinOp::Shl => l.shl(&r),
+                    BinOp::ShlUnchecked => unreachable!("{:?}", rvalue),
+                    BinOp::Shr => l.shr(&r),
+                    BinOp::ShrUnchecked => unreachable!("{:?}", rvalue),
+                    BinOp::Eq => l.eq(&r),
+                    BinOp::Lt => l.lt(&r),
+                    BinOp::Le => l.le(&r),
+                    BinOp::Ne => l.ne(&r),
+                    BinOp::Ge => l.ge(&r),
+                    BinOp::Gt => l.gt(&r),
+                    BinOp::Cmp => todo!("{:?}", rvalue),
+                    BinOp::Offset => todo!("{:?}", rvalue),
+                };
+                let mut cmps = vec![];
+                if matches!(
+                    binop,
+                    BinOp::Eq | BinOp::Lt | BinOp::Le | BinOp::Ne | BinOp::Ge | BinOp::Gt
+                ) && !l.ptrv.is_bot()
+                    && !r.ptrv.is_bot()
+                    && !l.ptrv.is_null()
+                    && !r.ptrv.is_null()
+                {
+                    cmps.extend(self.get_read_paths_of_ptr(&l.ptrv, &[]));
+                    cmps.extend(self.get_read_paths_of_ptr(&r.ptrv, &[]));
+                }
+                reads_l.extend(reads_r);
+                (v, reads_l, cmps)
+            }
+            Rvalue::NullaryOp(_, _) => unreachable!("{:?}", rvalue),
+            Rvalue::UnaryOp(unary, operand) => {
+                let (v, reads) = self.transfer_operand(operand, state);
+                let v = match unary {
+                    UnOp::Not => v.not(),
+                    UnOp::Neg => v.neg(),
+                    UnOp::PtrMetadata => todo!("{:?}", rvalue),
+                };
+                (v, reads, vec![])
+            }
+            Rvalue::Discriminant(_) => todo!("{:?}", rvalue),
+            Rvalue::Aggregate(box kind, fields) => match kind {
+                AggregateKind::Array(_) => {
+                    let (vs, readss): (Vec<_>, Vec<_>) = fields
+                        .iter()
+                        .map(|operand| self.transfer_operand(operand, state))
+                        .unzip();
+                    let v = AbsValue::alpha_list(vs.into_iter().collect());
+                    let reads = readss.into_iter().flatten().collect();
+                    (v, reads, vec![])
+                }
+                AggregateKind::Tuple => unreachable!("{:?}", rvalue),
+                AggregateKind::Adt(def_id, _, _, _, _) => {
+                    let adt_def = self.tcx.adt_def(def_id);
+                    match adt_def.adt_kind() {
+                        AdtKind::Struct => {
+                            let (vs, readss): (Vec<_>, Vec<_>) = fields
+                                .iter()
+                                .map(|operand| self.transfer_operand(operand, state))
+                                .unzip();
+                            let v = AbsValue::alpha_list(vs.into_iter().collect());
+                            let reads = readss.into_iter().flatten().collect();
+                            (v, reads, vec![])
+                        }
+                        AdtKind::Union => {
+                            assert_eq!(fields.len(), 1);
+                            let operand = &fields[FieldIdx::from_usize(0)];
+                            let (v, reads) = self.transfer_operand(operand, state);
+                            let variant = adt_def.variant(VariantIdx::from_usize(0));
+                            let v = AbsValue::alpha_list(
+                                variant.fields.iter().map(|_| v.clone()).collect(),
+                            );
+                            (v, reads, vec![])
+                        }
+                        AdtKind::Enum => {
+                            assert_eq!(
+                                format!("{:?}", adt_def),
+                                "std::option::Option",
+                                "{:?}",
+                                rvalue
+                            );
+                            if let Some(field) = fields.get(FieldIdx::from_usize(0)) {
+                                let (v, reads) = self.transfer_operand(field, state);
+                                if v.is_bot() {
+                                    (AbsValue::bot(), reads, vec![])
+                                } else {
+                                    (AbsValue::some(v), reads, vec![])
+                                }
+                            } else {
+                                (AbsValue::none(), vec![], vec![])
+                            }
+                        }
+                    }
+                }
+                AggregateKind::Closure(_, _) => unreachable!("{:?}", rvalue),
+                AggregateKind::Coroutine(_, _) => unreachable!("{:?}", rvalue),
+                AggregateKind::CoroutineClosure(_, _) => unreachable!("{:?}", rvalue),
+                AggregateKind::RawPtr(_, _) => todo!("{:?}", rvalue),
+            },
+            Rvalue::ShallowInitBox(_, _) => unreachable!("{:?}", rvalue),
+            Rvalue::CopyForDeref(place) => {
+                let (v, reads) = self.transfer_place(place, state);
+                (v, reads, vec![])
+            }
+            Rvalue::WrapUnsafeBinder(_, _) => unreachable!("{:?}", rvalue),
+        }
+    }
+
+    fn transfer_operand(
+        &self,
+        operand: &Operand<'tcx>,
+        state: &AbsState,
+    ) -> (AbsValue, Vec<AbsPath>) {
+        match operand {
+            Operand::Copy(place) | Operand::Move(place) => self.transfer_place(place, state),
+            Operand::Constant(box constant) => (self.transfer_constant(constant), vec![]),
+        }
+    }
+
+    fn transfer_place(&self, place: &Place<'tcx>, state: &AbsState) -> (AbsValue, Vec<AbsPath>) {
+        if place.is_indirect_first_projection() {
+            let projection = self.abstract_projection(&place.projection[1..], state);
+            let ptr = state.local.get(place.local);
+            self.read_ptr(&ptr.ptrv, &projection, state)
+        } else {
+            let v = state.local.get(place.local);
+            let projection = self.abstract_projection(place.projection, state);
+            (self.get_value(v, &projection), vec![])
+        }
+    }
+
+    fn transfer_constant(&self, constant: &ConstOperand<'tcx>) -> AbsValue {
+        match constant.const_ {
+            Const::Ty(ty, constant) => {
+                let v = constant.to_value();
+                let v = self.tcx.valtree_to_const_val(v);
+                self.transfer_const_value(&v, &ty)
+            }
+            Const::Unevaluated(constant, ty) => {
+                if ty.is_ref() {
+                    AbsValue::top()
+                } else if let Ok(v) = self.tcx.const_eval_poly(constant.def) {
+                    self.transfer_const_value(&v, &ty)
+                } else {
+                    self.top_value_of_ty(&ty)
+                }
+            }
+            Const::Val(v, ty) => self.transfer_const_value(&v, &ty),
+        }
+    }
+
+    fn transfer_const_value(&self, v: &ConstValue<'tcx>, ty: &Ty<'tcx>) -> AbsValue {
+        match v {
+            ConstValue::Scalar(s) => match s {
+                Scalar::Int(i) => match ty.kind() {
+                    TyKind::Int(int_ty) => {
+                        let v = match int_ty {
+                            IntTy::Isize => i.to_i64() as _,
+                            IntTy::I8 => i.to_i8() as _,
+                            IntTy::I16 => i.to_i16() as _,
+                            IntTy::I32 => i.to_i32() as _,
+                            IntTy::I64 => i.to_i64() as _,
+                            IntTy::I128 => i.to_i128(),
+                        };
+                        AbsValue::alpha_int(v)
+                    }
+                    TyKind::Uint(uint_ty) => {
+                        let v = match uint_ty {
+                            UintTy::Usize => i.to_u64() as _,
+                            UintTy::U8 => i.to_u8() as _,
+                            UintTy::U16 => i.to_u16() as _,
+                            UintTy::U32 => i.to_u32() as _,
+                            UintTy::U64 => i.to_u64() as _,
+                            UintTy::U128 => i.to_u128(),
+                        };
+                        AbsValue::alpha_uint(v)
+                    }
+                    TyKind::Float(float_ty) => {
+                        let v = match float_ty {
+                            FloatTy::F16 => todo!("{:?}", float_ty),
+                            FloatTy::F32 => f32::from_bits(i.to_u32()) as _,
+                            FloatTy::F64 => f64::from_bits(i.to_u64()),
+                            FloatTy::F128 => todo!("{:?}", float_ty),
+                        };
+                        AbsValue::alpha_float(v)
+                    }
+                    TyKind::Bool => AbsValue::alpha_bool(i.try_to_bool().unwrap()),
+                    TyKind::Char => AbsValue::alpha_uint(i.to_u32() as _),
+                    _ => unreachable!("{:?}", ty),
+                },
+                Scalar::Ptr(ptr, _) => {
+                    let alloc = self.tcx.global_alloc(ptr.provenance.alloc_id());
+                    match alloc {
+                        GlobalAlloc::Function { .. } => unreachable!("{:?}", alloc),
+                        GlobalAlloc::VTable(_, _) => unreachable!("{:?}", alloc),
+                        GlobalAlloc::Static(_) | GlobalAlloc::Memory(_) => AbsValue::heap(),
+                    }
+                }
+            },
+            ConstValue::ZeroSized => {
+                if let TyKind::FnDef(def_id, _) = ty.kind() {
+                    AbsValue::alpha_fn(*def_id)
+                } else {
+                    unreachable!("{:?}", v)
+                }
+            }
+            ConstValue::Slice { data, meta } => {
+                let size = Size::from_bytes(*meta);
+                let range = AllocRange {
+                    start: Size::ZERO,
+                    size,
+                };
+                let arr = data
+                    .inner()
+                    .get_bytes_strip_provenance(&self.tcx, range)
+                    .unwrap();
+                let msg = String::from_utf8(arr.to_vec()).unwrap();
+                if msg == "explicit panic" || msg == "internal error: entered unreachable code" {
+                    AbsValue::top()
+                } else {
+                    unreachable!("{:?}", msg)
+                }
+            }
+            ConstValue::Indirect { .. } => AbsValue::top(),
+        }
+    }
+
+    pub fn top_value_of_ty(&self, ty: &Ty<'tcx>) -> AbsValue {
+        match ty.kind() {
+            TyKind::Bool => AbsValue::top_bool(),
+            TyKind::Char => unreachable!("{:?}", ty),
+            TyKind::Int(_) => AbsValue::top_int(),
+            TyKind::Uint(_) => AbsValue::top_uint(),
+            TyKind::Float(_) => AbsValue::top_float(),
+            TyKind::Adt(adt, arg) => match adt.adt_kind() {
+                AdtKind::Struct | AdtKind::Union => {
+                    let variant = adt.variant(VariantIdx::from_usize(0));
+                    AbsValue::alpha_list(
+                        variant
+                            .fields
+                            .iter()
+                            .map(|field| {
+                                let ty = field.ty(self.tcx, arg);
+                                self.top_value_of_ty(&ty)
+                            })
+                            .collect(),
+                    )
+                }
+                AdtKind::Enum => {
+                    let ty = format!("{:?}", adt);
+                    match ty.as_str() {
+                        "std::option::Option" => AbsValue::top_option(),
+                        "libc::c_void" => AbsValue::top(),
+                        _ => unreachable!("{:?}", ty),
+                    }
+                }
+            },
+            TyKind::Foreign(_) => AbsValue::top(),
+            TyKind::Str => unreachable!("{:?}", ty),
+            TyKind::Array(ty, len) => {
+                let len = len.try_to_target_usize(self.tcx).unwrap();
+                if len <= 100 {
+                    AbsValue::alpha_list((0..len).map(|_| self.top_value_of_ty(ty)).collect())
+                } else {
+                    AbsValue::top_list()
+                }
+            }
+            TyKind::Pat(_, _) => unreachable!("{:?}", ty),
+            TyKind::Slice(_) => unreachable!("{:?}", ty),
+            TyKind::RawPtr(_, _) | TyKind::Ref(_, _, _) => AbsValue::heap_or_null(),
+            TyKind::FnDef(_, _) => unreachable!("{:?}", ty),
+            TyKind::FnPtr(_, _) => todo!("{:?}", ty),
+            TyKind::UnsafeBinder(_) => unreachable!("{:?}", ty),
+            TyKind::Dynamic(_, _, _) => unreachable!("{:?}", ty),
+            TyKind::Closure(_, _) => unreachable!("{:?}", ty),
+            TyKind::CoroutineClosure(_, _) => unreachable!("{:?}", ty),
+            TyKind::Coroutine(_, _) => unreachable!("{:?}", ty),
+            TyKind::CoroutineWitness(_, _) => unreachable!("{:?}", ty),
+            TyKind::Never => AbsValue::bot(),
+            TyKind::Tuple(tys) => {
+                AbsValue::alpha_list(tys.iter().map(|ty| self.top_value_of_ty(&ty)).collect())
+            }
+            TyKind::Alias(_, _) => unreachable!("{:?}", ty),
+            TyKind::Param(_) => unreachable!("{:?}", ty),
+            TyKind::Bound(_, _) => unreachable!("{:?}", ty),
+            TyKind::Placeholder(_) => unreachable!("{:?}", ty),
+            TyKind::Infer(_) => unreachable!("{:?}", ty),
+            TyKind::Error(_) => unreachable!("{:?}", ty),
+        }
+    }
+
+    fn abstract_place(&self, place: &Place<'tcx>, state: &AbsState) -> AbsPlace {
+        let base = AbsBase::Local(place.local);
+        let projection = self.abstract_projection(place.projection, state);
+        AbsPlace {
+            base,
+            projections: projection,
+        }
+    }
+
+    fn abstract_projection(
+        &self,
+        projection: &[PlaceElem<'tcx>],
+        state: &AbsState,
+    ) -> Vec<AbsProjElem> {
+        projection
+            .iter()
+            .map(|e| self.abstract_elem(e, state))
+            .collect()
+    }
+
+    fn abstract_elem(&self, elem: &PlaceElem<'tcx>, state: &AbsState) -> AbsProjElem {
+        match elem {
+            ProjectionElem::Deref => todo!("{:?}", elem),
+            ProjectionElem::Field(field, _) => AbsProjElem::Field(*field),
+            ProjectionElem::Index(idx) => AbsProjElem::Index(state.local.get(*idx).uintv.clone()),
+            ProjectionElem::ConstantIndex { .. } => unreachable!("{:?}", elem),
+            ProjectionElem::Subslice { .. } => unreachable!("{:?}", elem),
+            ProjectionElem::Downcast(_, _) => unreachable!("{:?}", elem),
+            ProjectionElem::OpaqueCast(_) => unreachable!("{:?}", elem),
+            ProjectionElem::UnwrapUnsafeBinder(_) => unreachable!("{:?}", elem),
+            ProjectionElem::Subtype(_) => unreachable!("{:?}", elem),
+        }
+    }
+
+    fn assign(
+        &mut self,
+        place: &Place<'tcx>,
+        new_v: AbsValue,
+        state: &AbsState,
+    ) -> (AbsState, Vec<AbsPath>) {
+        let mut new_state = state.clone();
+        let writes = if place.is_indirect_first_projection() {
+            let projection = self.abstract_projection(&place.projection[1..], state);
+            let ptr = state.local.get(place.local);
+            self.indirect_assigns.insert(place.local);
+            self.indirect_assign(&ptr.ptrv, &new_v, &projection, &mut new_state);
+            self.get_write_paths_of_ptr(&ptr.ptrv, &projection)
+        } else {
+            let old_v = new_state.local.get_mut(place.local);
+            let projection = self.abstract_projection(place.projection, state);
+            self.update_value(new_v, old_v, false, &projection);
+            vec![]
+        };
+        (new_state, writes)
+    }
+
+    fn indirect_assign(
+        &self,
+        ptr: &AbsPtr,
+        new_v: &AbsValue,
+        projection: &[AbsProjElem],
+        state: &mut AbsState,
+    ) {
+        if let AbsPtr::Set(ptrs) = ptr {
+            if ptrs
+                .iter()
+                .any(|ptr| matches!(ptr.base, AbsBase::Arg(_) | AbsBase::Heap))
+            {
+                let reads = self.get_read_paths_of_ptr(&new_v.ptrv, &[]);
+                state.add_excludes(reads.into_iter());
+            }
+            let weak = ptrs.len() > 1;
+            for ptr in ptrs {
+                let old_v = some_or!(state.get_mut(ptr.base), continue);
+                let mut ptr_projection = ptr.projections.clone();
+                ptr_projection.extend(projection.to_owned());
+                self.update_value(new_v.clone(), old_v, weak, &ptr_projection);
+            }
+        }
+    }
+
+    fn get_write_paths_of_ptr(&self, ptr: &AbsPtr, projection: &[AbsProjElem]) -> Vec<AbsPath> {
+        if let AbsPtr::Set(ptrs) = ptr {
+            if ptrs.len() == 1 {
+                let mut ptr = ptrs.first().unwrap().clone();
+                ptr.projections.extend(projection.to_owned());
+                if let Some((path, false)) = AbsPath::from_place(&ptr, &self.ptr_params) {
+                    return self.expands_path(&path);
+                }
+            }
+        }
+        vec![]
+    }
+
+    fn get_write_bases_of_ptr(&self, ptr: &AbsPtr) -> Option<Vec<AbsBase>> {
+        if let AbsPtr::Set(ptrs) = ptr {
+            if ptrs.len() == 1 {
+                let ptr = ptrs.first().unwrap().clone();
+                return Some(vec![ptr.base]);
+            }
+        }
+        None
+    }
+
+    fn update_value(
+        &self,
+        new_v: AbsValue,
+        old_v: &mut AbsValue,
+        weak: bool,
+        projection: &[AbsProjElem],
+    ) {
+        if let Some(first) = projection.first() {
+            match first {
+                AbsProjElem::Field(field) => {
+                    if let Some(old_v) = AbsValue::make_mut(old_v).listv.get_mut(field.index()) {
+                        self.update_value(new_v, old_v, weak, &projection[1..]);
+                    }
+                }
+                AbsProjElem::Index(idx) => {
+                    if let AbsList::List(l) = &mut AbsValue::make_mut(old_v).listv {
+                        let (indices, new_weak): (Box<dyn Iterator<Item = usize>>, _) =
+                            if let Some(indices) = idx.gamma() {
+                                (Box::new(indices.iter().map(|i| *i as _)), indices.len() > 1)
+                            } else {
+                                (Box::new(0..l.len()), l.len() > 1)
+                            };
+                        let weak = weak || new_weak;
+                        for idx in indices {
+                            if let Some(old_v) = l.get_mut(idx) {
+                                self.update_value(new_v.clone(), old_v, weak, &projection[1..]);
+                            }
+                        }
+                    }
+                }
+            }
+        } else if weak {
+            *old_v = new_v.join(old_v);
+        } else {
+            *old_v = new_v;
+        }
+    }
+
+    fn read_ptr(
+        &self,
+        ptr: &AbsPtr,
+        projection: &[AbsProjElem],
+        state: &AbsState,
+    ) -> (AbsValue, Vec<AbsPath>) {
+        let v = if let Some(ptrs) = ptr.gamma() {
+            ptrs.iter()
+                .filter_map(|ptr| {
+                    let v = state.get(ptr.base)?;
+                    let mut ptr_projection = ptr.projections.clone();
+                    ptr_projection.extend(projection.to_owned());
+                    Some(self.get_value(v, &ptr_projection))
+                })
+                .reduce(|v1, v2| v1.join(&v2))
+                .unwrap_or(AbsValue::bot())
+        } else {
+            AbsValue::top()
+        };
+        (v, self.get_read_paths_of_ptr(ptr, projection))
+    }
+
+    pub fn get_read_paths_of_ptr(&self, ptr: &AbsPtr, projection: &[AbsProjElem]) -> Vec<AbsPath> {
+        if let AbsPtr::Set(ptrs) = ptr {
+            ptrs.iter()
+                .cloned()
+                .filter_map(|mut ptr| {
+                    ptr.projections.extend(projection.to_owned());
+                    AbsPath::from_place(&ptr, &self.ptr_params).map(|(path, _)| path)
+                })
+                .flat_map(|path| self.expands_path(&path))
+                .collect()
+        } else {
+            vec![]
+        }
+    }
+
+    fn get_value(&self, v: &AbsValue, projection: &[AbsProjElem]) -> AbsValue {
+        let first = some_or!(projection.first(), return v.clone());
+        match first {
+            AbsProjElem::Field(field) => match &v.listv {
+                AbsList::Top => AbsValue::top(),
+                AbsList::List(l) => {
+                    if let Some(v) = l.get(field.index()) {
+                        self.get_value(v, &projection[1..])
+                    } else {
+                        AbsValue::bot()
+                    }
+                }
+                AbsList::Bot => AbsValue::bot(),
+            },
+            AbsProjElem::Index(idx) => match &v.listv {
+                AbsList::Top => {
+                    if idx.is_bot() {
+                        AbsValue::bot()
+                    } else {
+                        AbsValue::top()
+                    }
+                }
+                AbsList::List(l) => {
+                    let indices: Box<dyn Iterator<Item = usize>> =
+                        if let Some(indices) = idx.gamma() {
+                            Box::new(indices.iter().map(|i| *i as _))
+                        } else {
+                            Box::new(0..l.len())
+                        };
+                    indices
+                        .filter_map(|index| {
+                            l.get(index).map(|v| self.get_value(v, &projection[1..]))
+                        })
+                        .reduce(|v1, v2| v1.join(&v2))
+                        .unwrap_or(AbsValue::bot())
+                }
+                AbsList::Bot => AbsValue::bot(),
+            },
+        }
+    }
+
+    fn get_caller_path(&self, callee_path: &AbsPath, args: &[AbsValue]) -> Vec<AbsPath> {
+        let ptrs = if let AbsPtr::Set(ptrs) = &args[callee_path.base.index() - 1].ptrv {
+            ptrs
+        } else {
+            return vec![];
+        };
+        ptrs.iter()
+            .filter_map(|ptr| {
+                let (mut path, _) = AbsPath::from_place(ptr, &self.ptr_params)?;
+                path.projections.extend(callee_path.projections.clone());
+                Some(path)
+            })
+            .collect::<Vec<_>>()
+    }
+}

--- a/src/outparam_replacer/ai/semantics.rs
+++ b/src/outparam_replacer/ai/semantics.rs
@@ -1,4 +1,3 @@
-
 use std::collections::{BTreeMap, BTreeSet};
 
 use etrace::some_or;

--- a/src/outparam_replacer/ai/semantics.rs
+++ b/src/outparam_replacer/ai/semantics.rs
@@ -10,7 +10,7 @@ use rustc_middle::{
         Place, PlaceElem, ProjectionElem, Rvalue, Statement, StatementKind, Terminator,
         TerminatorKind, UnOp,
     },
-    ty::{adjustment::PointerCoercion, AdtKind, Ty, TyKind},
+    ty::{AdtKind, Ty, TyKind, adjustment::PointerCoercion},
 };
 use rustc_span::def_id::DefId;
 use rustc_type_ir::{FloatTy, IntTy, UintTy};
@@ -869,11 +869,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                         } else {
                             false
                         };
-                        if void {
-                            v
-                        } else {
-                            AbsValue::heap().join(&v)
-                        }
+                        if void { v } else { AbsValue::heap().join(&v) }
                     }
                     CastKind::FnPtrToPtr => v,
                     CastKind::Transmute => v,

--- a/src/outparam_replacer/ai/semantics.rs
+++ b/src/outparam_replacer/ai/semantics.rs
@@ -424,16 +424,17 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                 match &sig.decl.output {
                     hir::FnRetTy::Return(ty) => {
                         if let hir::TyKind::Path(hir::QPath::Resolved(_, path)) = &ty.kind
-                            && let hir::def::Res::Def(_, def_id) = path.res {
-                                let ty = self.def_id_to_string(def_id);
-                                let ty = ty.split("::").last().unwrap();
-                                let v = match ty {
-                                    "c_int" => AbsValue::top_int(),
-                                    "c_uint" => AbsValue::top_uint(),
-                                    _ => AbsValue::top(),
-                                };
-                                return v;
-                            }
+                            && let hir::def::Res::Def(_, def_id) = path.res
+                        {
+                            let ty = self.def_id_to_string(def_id);
+                            let ty = ty.split("::").last().unwrap();
+                            let v = match ty {
+                                "c_int" => AbsValue::top_int(),
+                                "c_uint" => AbsValue::top_uint(),
+                                _ => AbsValue::top(),
+                            };
+                            return v;
+                        }
                     }
                     hir::FnRetTy::DefaultReturn(_) => {
                         let name = item.ident.name.to_ident_string();
@@ -479,9 +480,10 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             .filter_map(|(i, ty)| {
                 if let TyKind::RawPtr(ty, _) = ty.kind() {
                     if let TyKind::Adt(adt, _) = ty.kind()
-                        && self.def_id_to_string(adt.did()).ends_with("::_IO_FILE") {
-                            return None;
-                        }
+                        && self.def_id_to_string(adt.did()).ends_with("::_IO_FILE")
+                    {
+                        return None;
+                    }
                     return Some(i);
                 }
                 None
@@ -1264,22 +1266,24 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
 
     fn get_write_paths_of_ptr(&self, ptr: &AbsPtr, projection: &[AbsProjElem]) -> Vec<AbsPath> {
         if let AbsPtr::Set(ptrs) = ptr
-            && ptrs.len() == 1 {
-                let mut ptr = ptrs.first().unwrap().clone();
-                ptr.projections.extend(projection.to_owned());
-                if let Some((path, false)) = AbsPath::from_place(&ptr, &self.ptr_params) {
-                    return self.expands_path(&path);
-                }
+            && ptrs.len() == 1
+        {
+            let mut ptr = ptrs.first().unwrap().clone();
+            ptr.projections.extend(projection.to_owned());
+            if let Some((path, false)) = AbsPath::from_place(&ptr, &self.ptr_params) {
+                return self.expands_path(&path);
             }
+        }
         vec![]
     }
 
     fn get_write_bases_of_ptr(&self, ptr: &AbsPtr) -> Option<Vec<AbsBase>> {
         if let AbsPtr::Set(ptrs) = ptr
-            && ptrs.len() == 1 {
-                let ptr = ptrs.first().unwrap().clone();
-                return Some(vec![ptr.base]);
-            }
+            && ptrs.len() == 1
+        {
+            let ptr = ptrs.first().unwrap().clone();
+            return Some(vec![ptr.base]);
+        }
         None
     }
 

--- a/src/outparam_replacer/mod.rs
+++ b/src/outparam_replacer/mod.rs
@@ -25,6 +25,12 @@ pub struct Config {
     pub simplify: bool,
     #[serde(default)]
     pub analysis_file: Option<PathBuf>,
+
+    // debug
+    #[serde(default)]
+    pub function_times: Option<usize>,
+    #[serde(default)]
+    pub print_functions: Vec<String>,
 }
 
 pub mod ai;


### PR DESCRIPTION
[Nopcrat](https://github.com/kaist-plrg/nopcrat)에 있는 분석 코드를 `outparam_replacer`에 추가

기존 코드와 거의 동일하나, 아래 변경 사항이 있습니다.
- Andersen 분석 결과를 처리하는 부분은 `outparam_replacer`의 `pre_analysis.rs`에 분리
- Max sensitivity (`outparam_max_loop_head_states`) 값에 0이 아닌 양수 값을 입력 받도록 수정
- `domain.rs`에서 abstract integer의 연산을 wrapping 연산으로 수정
  - 분석 대상 코드에서 wrapping 연산을 사용함에도 `domain.rs`에서는 일반 연산을 사용하여 해당 값을 계산.
  - dev 프로필에서는 wrapping이 아닌 정수 연산 전에 오버플로우 체킹을 하기 때문에 문제가 생길 수 있음.
  

테스트
- release와 dev 프로필 각각에서 벤치마크 코드 분석
- 두 프로필 모두 기존 nopcrat master 브랜치와 결과가 동일함을 확인함
