### PR TITLE
Fix edge cases in Andersen analysis, outparam, and pointer replacer

### DIFF
--- a/crates/outparam_replacer/src/transform.rs
+++ b/crates/outparam_replacer/src/transform.rs
@@ -936,46 +936,46 @@ impl MutVisitor for TransformVisitor<'_, '_> {
 
                     let ret_tys = &func.return_tys;
                     // binds return values of a call to rv___, rv___1, ...
-                    let mut bindings = vec![];
                     // assign output parameter values to arguments
                     let mut assign_ret = vec![];
                     let mut mtch_assign = None;
 
+                    let multi = ret_tys.len() > 1;
                     for (ridx, ret_ty) in ret_tys.iter_enumerated() {
                         match ret_ty {
                             ReturnTyItem::Orig => {
                                 assert!(ridx.index() == 0);
-                                bindings.push(String::from("rv___"));
                             }
                             ReturnTyItem::Type(param) => {
                                 let index = param.index;
                                 let arg = args[index.index()].as_ref();
-                                let rhs = if ridx.index() == 0 {
+                                let rhs = if multi {
+                                    format!("rv___t.{}", ridx.index())
+                                } else if ridx.index() == 0 {
                                     String::from("rv___")
                                 } else {
                                     format!("rv___{}", ridx.index())
                                 };
                                 let assign = self.get_assign(arg, true, rhs.clone(), index, loc);
                                 assign_ret.push(assign);
-                                bindings.push(rhs);
                             }
                             ReturnTyItem::Option(param) => {
                                 let index = param.index;
                                 let arg = args[index.index()].as_ref();
-                                let rhs = if ridx.index() == 0 {
+                                let rhs = if multi {
+                                    format!("rv___t.{}", ridx.index())
+                                } else if ridx.index() == 0 {
                                     String::from("rv___")
                                 } else {
                                     format!("rv___{}", ridx.index())
                                 };
                                 let assign = self.get_assign(arg, false, rhs.clone(), index, loc);
                                 assign_ret.push(assign);
-                                bindings.push(rhs);
                             }
                             ReturnTyItem::Result(param) => {
                                 assert!(ridx.index() == 0);
                                 let index = param.index;
                                 let arg = args[index.index()].as_ref();
-                                bindings.push(String::from("rv___"));
                                 mtch_assign = Some(self.get_assign(
                                     arg,
                                     true,
@@ -1000,17 +1000,17 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                         })
                         .collect();
 
-                    let binding = if bindings.len() == 1 {
-                        format!("let {} = {}", bindings[0], pprust::expr_to_string(expr))
+                    let binding = if multi {
+                        format!("let rv___t = {}", pprust::expr_to_string(expr))
                     } else {
-                        format!(
-                            "let ({}) = {}",
-                            bindings.join(", "),
-                            pprust::expr_to_string(expr)
-                        )
+                        format!("let rv___ = {}", pprust::expr_to_string(expr))
                     };
 
-                    assign_ret.push(String::from("rv___"));
+                    assign_ret.push(if multi {
+                        String::from("rv___t.0")
+                    } else {
+                        String::from("rv___")
+                    });
 
                     let new_expr = match &ret_tys[RetIdx::from_usize(0)] {
                         ReturnTyItem::Orig | ReturnTyItem::Type(_) | ReturnTyItem::Option(_) => {

--- a/crates/outparam_replacer/src/transform.rs
+++ b/crates/outparam_replacer/src/transform.rs
@@ -1259,9 +1259,7 @@ fn generate_default_init<'tcx>(ty: rustc_middle::ty::Ty<'tcx>, tcx: TyCtxt<'tcx>
         MirTyKind::Float(_) => "0.0".to_string(),
         MirTyKind::Bool => "false".to_string(),
         MirTyKind::Char => "'\\0'".to_string(),
-        MirTyKind::RawPtr(_, rustc_middle::ty::Mutability::Mut) => {
-            "0 as *mut _".to_string()
-        }
+        MirTyKind::RawPtr(_, rustc_middle::ty::Mutability::Mut) => "0 as *mut _".to_string(),
         MirTyKind::RawPtr(_, rustc_middle::ty::Mutability::Not) => "0 as *const _".to_string(),
         MirTyKind::Adt(adt_def, generic_args) if adt_def.is_struct() => {
             let variant = adt_def.variant(rustc_abi::FIRST_VARIANT);

--- a/crates/outparam_replacer/src/transform.rs
+++ b/crates/outparam_replacer/src/transform.rs
@@ -1260,9 +1260,9 @@ fn generate_default_init<'tcx>(ty: rustc_middle::ty::Ty<'tcx>, tcx: TyCtxt<'tcx>
         MirTyKind::Bool => "false".to_string(),
         MirTyKind::Char => "'\\0'".to_string(),
         MirTyKind::RawPtr(_, rustc_middle::ty::Mutability::Mut) => {
-            "std::ptr::null_mut()".to_string()
+            "0 as *mut _".to_string()
         }
-        MirTyKind::RawPtr(_, rustc_middle::ty::Mutability::Not) => "std::ptr::null()".to_string(),
+        MirTyKind::RawPtr(_, rustc_middle::ty::Mutability::Not) => "0 as *const _".to_string(),
         MirTyKind::Adt(adt_def, generic_args) if adt_def.is_struct() => {
             let variant = adt_def.variant(rustc_abi::FIRST_VARIANT);
             let mut fields = Vec::new();

--- a/crates/passes/src/unsafe_resolver/mod.rs
+++ b/crates/passes/src/unsafe_resolver/mod.rs
@@ -44,6 +44,7 @@ pub fn resolve_unsafe(config: &Config, tcx: TyCtxt<'_>) -> String {
         used_locals: FxHashSet::default(),
         item_mods: FxHashMap::default(),
         extern_c_fn_ptrs: FxHashSet::default(),
+        used_attr_items: vec![],
     };
     tcx.hir_visit_all_item_likes_in_crate(&mut visitor);
     let mut used = visitor.used;
@@ -68,6 +69,7 @@ pub fn resolve_unsafe(config: &Config, tcx: TyCtxt<'_>) -> String {
             entries.push(f);
         }
     }
+    entries.extend(visitor.used_attr_items);
 
     let used_items: FxHashSet<_> = entries
         .iter()
@@ -324,6 +326,7 @@ struct HirVisitor<'tcx> {
     used_locals: FxHashSet<HirId>,
     item_mods: FxHashMap<LocalDefId, LocalModDefId>,
     extern_c_fn_ptrs: FxHashSet<LocalDefId>,
+    used_attr_items: Vec<LocalDefId>,
 }
 
 impl HirVisitor<'_> {
@@ -446,6 +449,9 @@ impl<'tcx> intravisit::Visitor<'tcx> for HirVisitor<'tcx> {
                 self.uses.push((item.owner_id.def_id, def_ids));
             }
             _ => {}
+        }
+        if self.tcx.has_attr(item.owner_id.def_id, sym::used) {
+            self.used_attr_items.push(item.owner_id.def_id);
         }
         intravisit::walk_item(self, item)
     }

--- a/crates/passes/src/unsafe_resolver/mod.rs
+++ b/crates/passes/src/unsafe_resolver/mod.rs
@@ -65,7 +65,11 @@ pub fn resolve_unsafe(config: &Config, tcx: TyCtxt<'_>) -> String {
     let mut entries = visitor.mains;
     for f in visitor.fns {
         let name = tcx.item_name(f.to_def_id());
-        if config.c_exposed_fns.contains(name.as_str()) {
+        let has_exposed_export_name = tcx.get_attrs(f.to_def_id(), sym::export_name).any(|attr| {
+            attr.value_str()
+                .is_some_and(|s| config.c_exposed_fns.contains(s.as_str()))
+        });
+        if config.c_exposed_fns.contains(name.as_str()) || has_exposed_export_name {
             entries.push(f);
         }
     }
@@ -206,7 +210,14 @@ impl mut_visit::MutVisitor for AstVisitor<'_, '_> {
             ident, sig, body, ..
         }) = &mut item.kind
         {
-            let is_exposed_fn = self.config.c_exposed_fns.contains(ident.name.as_str());
+            let has_exposed_export_name = item.attrs.iter().any(|attr| {
+                attr.has_name(sym::export_name)
+                    && attr
+                        .value_str()
+                        .is_some_and(|s| self.config.c_exposed_fns.contains(s.as_str()))
+            });
+            let is_exposed_fn =
+                self.config.c_exposed_fns.contains(ident.name.as_str()) || has_exposed_export_name;
 
             if self.config.replace_pub
                 && item.vis.kind.is_pub()

--- a/crates/passes/src/unsafe_resolver/mod.rs
+++ b/crates/passes/src/unsafe_resolver/mod.rs
@@ -496,6 +496,21 @@ impl<'tcx> intravisit::Visitor<'tcx> for HirVisitor<'tcx> {
         {
             self.extern_c_fn_ptrs.insert(def_id);
         }
+        // Also detect implicit coercions to extern C function pointers
+        // (e.g., functions placed in static arrays of fn pointers).
+        if let hir::ExprKind::Path(ref qpath) = expr.kind
+            && let hir::QPath::Resolved(_, path) = qpath
+            && let Res::Def(_, def_id) = path.res
+            && let Some(def_id) = def_id.as_local()
+        {
+            let typeck = self.tcx.typeck(expr.hir_id.owner.def_id);
+            let adjusted_ty = typeck.expr_ty_adjusted(expr);
+            if let rustc_middle::ty::TyKind::FnPtr(_, hdr) = adjusted_ty.kind()
+                && !hdr.abi.is_rustic_abi()
+            {
+                self.extern_c_fn_ptrs.insert(def_id);
+            }
+        }
         intravisit::walk_expr(self, expr);
     }
 }

--- a/crates/passes/src/unsafe_resolver/tests.rs
+++ b/crates/passes/src/unsafe_resolver/tests.rs
@@ -373,6 +373,55 @@ fn main() {}
     run_transformation_test(code, true, &["fn main()", "#[used]", "static INIT"], &[]);
 }
 
+fn run_exposed_test(code: &str, c_exposed_fns: &[&str], includes: &[&str], excludes: &[&str]) {
+    let c_exposed_fns: FxHashSet<String> = c_exposed_fns.iter().map(|s| s.to_string()).collect();
+    let transformed = utils::compilation::run_compiler_on_str(&code, |tcx| {
+        let config = super::Config {
+            remove_unused: true,
+            remove_no_mangle: false,
+            remove_extern_c: false,
+            replace_pub: false,
+            c_exposed_fns,
+        };
+        super::resolve_unsafe(&config, tcx)
+    })
+    .unwrap();
+    utils::compilation::run_compiler_on_str(&transformed, |tcx| {
+        utils::type_check(tcx);
+    })
+    .expect(&transformed);
+    for include in includes {
+        assert!(
+            transformed.contains(include),
+            "{transformed}\ndoes not contain \"{include}\"",
+        );
+    }
+    for exclude in excludes {
+        assert!(
+            !transformed.contains(exclude),
+            "{transformed}\ncontains \"{exclude}\"",
+        );
+    }
+}
+
+#[test]
+fn test_transformation_export_name_exposed() {
+    let code = r#"
+#[export_name = "exposed"]
+fn exposed_0() {}
+fn other() {}
+fn main() {
+    exposed_0();
+}
+"#;
+    run_exposed_test(
+        code,
+        &["exposed"],
+        &["fn exposed_0()", "fn main()"],
+        &["fn other()"],
+    );
+}
+
 fn run_extern_c_test(code: &str, includes: &[&str], excludes: &[&str]) {
     let transformed = utils::compilation::run_compiler_on_str(&code, |tcx| {
         let config = super::Config {

--- a/crates/passes/src/unsafe_resolver/tests.rs
+++ b/crates/passes/src/unsafe_resolver/tests.rs
@@ -419,3 +419,17 @@ fn main() {
 "#;
     run_extern_c_test(code, &["extern \"C\" fn f"], &["extern \"C\" fn g"]);
 }
+
+#[test]
+fn test_extern_c_fn_in_static_array_preserved() {
+    let code = r#"
+extern "C" fn f() {}
+extern "C" fn g() {}
+#[used]
+static INIT_ARRAY: [extern "C" fn(); 1] = [f];
+fn main() {
+    g();
+}
+"#;
+    run_extern_c_test(code, &["extern \"C\" fn f"], &["extern \"C\" fn g"]);
+}

--- a/crates/passes/src/unsafe_resolver/tests.rs
+++ b/crates/passes/src/unsafe_resolver/tests.rs
@@ -363,6 +363,16 @@ unsafe fn g(mut x: i32) -> i32 {
     run_test(code, &["f"]);
 }
 
+#[test]
+fn test_transformation_unused_used_attr() {
+    let code = r#"
+#[used]
+static INIT: i32 = 42;
+fn main() {}
+"#;
+    run_transformation_test(code, true, &["fn main()", "#[used]", "static INIT"], &[]);
+}
+
 fn run_extern_c_test(code: &str, includes: &[&str], excludes: &[&str]) {
     let transformed = utils::compilation::run_compiler_on_str(&code, |tcx| {
         let config = super::Config {

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -287,6 +287,7 @@ impl MutVisitor for TransformVisitor<'_> {
             ExprKind::MethodCall(box MethodCall { seg, receiver, .. })
                 if seg.ident.name.as_str() == "is_null" =>
             {
+                let receiver = unwrap_paren(receiver);
                 if matches!(receiver.kind, ExprKind::Path(_, _))
                     && let Some(hir_id) = self.hir_id_of_path(receiver.id)
                     && let Some(ptr_kind) = self.ptr_kinds.get(&hir_id)
@@ -333,6 +334,22 @@ impl MutVisitor for TransformVisitor<'_> {
                         .and_then(|sd| sd.output_dec)
                         .unwrap_or(PtrKind::Raw(m.is_mut()));
                     self.transform_rhs(ret, hir_ret, kind);
+                } else if let ty::TyKind::Tuple(tys) = sig.output().kind() {
+                    let ExprKind::Tup(elems) = &mut ret.kind else {
+                        panic!("expected tuple expr for tuple return type")
+                    };
+                    let hir::ExprKind::Tup(hir_elems) = hir_ret.kind else {
+                        panic!("expected HIR tuple expr for tuple return type")
+                    };
+                    for (i, elem_ty) in tys.iter().enumerate() {
+                        if let ty::TyKind::RawPtr(_, m) = elem_ty.kind() {
+                            self.transform_rhs(
+                                &mut elems[i],
+                                &hir_elems[i],
+                                PtrKind::Raw(m.is_mut()),
+                            );
+                        }
+                    }
                 }
             }
             ExprKind::Unary(UnOp::Deref, e) => {

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -848,6 +848,25 @@ pub unsafe extern "C" fn foo() -> *mut libc::c_int {
     );
 }
 
+/// Tuple return with a pointer element: p is promoted to Option<&mut>,
+/// and the return expression must coerce the tuple element back to raw.
+#[test]
+fn test_return_tuple_with_ptr() {
+    run_test(
+        r#"
+use ::libc;
+pub unsafe extern "C" fn foo() -> (libc::c_int, *mut libc::c_int) {
+    let mut x: libc::c_int = 42 as libc::c_int;
+    let mut p: *mut libc::c_int = &mut x;
+    *p = 10 as libc::c_int;
+    return (0 as libc::c_int, p);
+}
+"#,
+        &["Option<&mut"],
+        &[],
+    );
+}
+
 /// Slice deref fallback: `*p` on a Slice variable without offset → `(p)[0]`.
 /// When p is Slice but deref doesn't match the `&arr[start..]` pattern,
 /// the else branch at line 296 produces `(*p)[0]`.

--- a/crates/points_to/src/andersen.rs
+++ b/crates/points_to/src/andersen.rs
@@ -619,24 +619,26 @@ impl<'tcx> Analyzer<'_, '_, 'tcx> {
                     }
                 }
                 AggregateKind::Adt(_, v_idx, _, _, idx) => {
-                    let TyShape::Struct(_, ts, _) = self.tss.tys[&ty] else { unreachable!() };
-                    let TyKind::Adt(adt_def, generic_args) = ty.kind() else { unreachable!() };
-                    let variant = adt_def.variant(*v_idx);
-                    for ((i, d), f) in variant.fields.iter_enumerated().zip(fs) {
-                        if let Some(r) = self.transfer_op(f, ctx) {
-                            let i = if let Some(idx) = idx { *idx } else { i };
-                            let proj = ts[i.index()].0;
-                            let ty = d.ty(self.tcx, generic_args);
-                            self.transfer_assign(l.add(proj), r, ty);
+                    if let TyShape::Struct(_, ts, _) = self.tss.tys[&ty] {
+                        let TyKind::Adt(adt_def, generic_args) = ty.kind() else { unreachable!() };
+                        let variant = adt_def.variant(*v_idx);
+                        for ((i, d), f) in variant.fields.iter_enumerated().zip(fs) {
+                            if let Some(r) = self.transfer_op(f, ctx) {
+                                let i = if let Some(idx) = idx { *idx } else { i };
+                                let proj = ts[i.index()].0;
+                                let ty = d.ty(self.tcx, generic_args);
+                                self.transfer_assign(l.add(proj), r, ty);
+                            }
                         }
                     }
                 }
                 AggregateKind::Tuple => {
-                    let TyShape::Struct(_, ts, _) = self.tss.tys[&ty] else { unreachable!() };
-                    let TyKind::Tuple(tys) = ty.kind() else { unreachable!() };
-                    for ((proj_ty, (proj, _)), f) in tys.iter().zip(ts).zip(fs) {
-                        if let Some(r) = self.transfer_op(f, ctx) {
-                            self.transfer_assign(l.add(*proj), r, proj_ty);
+                    if let TyShape::Struct(_, ts, _) = self.tss.tys[&ty] {
+                        let TyKind::Tuple(tys) = ty.kind() else { unreachable!() };
+                        for ((proj_ty, (proj, _)), f) in tys.iter().zip(ts).zip(fs) {
+                            if let Some(r) = self.transfer_op(f, ctx) {
+                                self.transfer_assign(l.add(*proj), r, proj_ty);
+                            }
                         }
                     }
                 }

--- a/crates/points_to/src/andersen.rs
+++ b/crates/points_to/src/andersen.rs
@@ -830,9 +830,7 @@ impl<'tcx> Analyzer<'_, '_, 'tcx> {
                     ty = t;
                 }
                 PlaceElem::Downcast(_, variant_idx) => {
-                    let TyKind::Adt(adt_def, _) = mir_ty.kind() else {
-                        unreachable!()
-                    };
+                    let TyKind::Adt(adt_def, _) = mir_ty.kind() else { unreachable!() };
                     variant_field_offset = adt_def
                         .variants()
                         .iter()

--- a/crates/points_to/src/andersen.rs
+++ b/crates/points_to/src/andersen.rs
@@ -813,12 +813,13 @@ impl<'tcx> Analyzer<'_, '_, 'tcx> {
 
     fn prefixed_loc(&self, place: Place<'tcx>, ctx: Context<'_, 'tcx>) -> PrefixedLoc {
         let mut index = 0;
-        let mut ty = ctx.locals[place.local].ty;
+        let mut mir_ty = ctx.locals[place.local].ty;
         let deref = place.is_indirect_first_projection();
         if deref {
-            ty = ty_shape::unwrap_ptr(ty).unwrap();
+            mir_ty = ty_shape::unwrap_ptr(mir_ty).unwrap();
         }
-        let mut ty = self.tss.tys[&ty];
+        let mut ty = self.tss.tys[&mir_ty];
+        let mut variant_field_offset = 0;
         for proj in place.projection {
             match proj {
                 PlaceElem::Deref => {}
@@ -826,11 +827,24 @@ impl<'tcx> Analyzer<'_, '_, 'tcx> {
                     let TyShape::Array(t, _) = ty else { unreachable!() };
                     ty = t;
                 }
-                PlaceElem::Field(f, _) => {
+                PlaceElem::Downcast(_, variant_idx) => {
+                    let TyKind::Adt(adt_def, _) = mir_ty.kind() else {
+                        unreachable!()
+                    };
+                    variant_field_offset = adt_def
+                        .variants()
+                        .iter()
+                        .take(variant_idx.index())
+                        .map(|v| v.fields.len())
+                        .sum();
+                }
+                PlaceElem::Field(f, field_ty) => {
                     let TyShape::Struct(_, fs, _) = ty else { unreachable!() };
-                    let (i, nested_ty) = fs[f.index()];
+                    let (i, nested_ty) = fs[variant_field_offset + f.index()];
                     index += i;
                     ty = nested_ty;
+                    mir_ty = field_ty;
+                    variant_field_offset = 0;
                 }
                 _ => unreachable!(),
             }


### PR DESCRIPTION
## Summary
- Preserve `#[used]` items in unsafe_resolver and `extern "C"` for functions implicitly coerced to extern C fn pointers
- Handle Downcast projections, zero-field aggregates, and tuple types in Andersen points-to analysis
- Handle tuple return types in pointer_replacer transform
- Replace tuple destructuring with projection in outparam call sites
- Consider `#[export_name]` when matching C-exposed functions

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)