### PR TITLE
Add crat-merge tool with cfg-aware item merging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,44 +28,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "atomic-waker"
@@ -105,15 +105,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -210,15 +210,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "crat"
@@ -229,6 +229,7 @@ dependencies = [
  "finders",
  "io_replacer",
  "lazy_static",
+ "merger",
  "outparam_replacer",
  "passes",
  "pointer_replacer",
@@ -311,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -321,33 +322,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -355,7 +356,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -394,12 +394,18 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -448,9 +454,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -461,7 +467,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -509,12 +514,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -522,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -535,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -549,15 +555,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -569,15 +575,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -611,12 +617,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -633,15 +639,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -649,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -673,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -689,10 +695,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -705,9 +713,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -721,15 +729,15 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -739,9 +747,19 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "merger"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "toml_edit",
+ "utils",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -751,9 +769,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -854,15 +872,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "outparam_replacer"
@@ -904,22 +922,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "serde",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -959,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -977,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1006,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1041,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1085,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1097,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1108,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1168,15 +1180,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
@@ -1198,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1215,24 +1227,34 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1241,14 +1263,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1307,12 +1330,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1343,9 +1366,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1403,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1413,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1428,9 +1451,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -1538,9 +1561,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1549,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1560,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1581,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -1607,9 +1630,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "union_replacer"
@@ -1697,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1710,23 +1733,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1734,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1747,18 +1766,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1794,15 +1813,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -1956,9 +1966,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -1971,15 +1981,15 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1988,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2000,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "z3"
-version = "0.19.7"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea19bb0f83371b3279afd962fd5c6525024459615598ad328eb24d1713e28dd9"
+checksum = "107cca65ed27d28b11f7c492298a51383333fd48ba6ebe49a432aba96162f678"
 dependencies = [
  "log",
  "num",
@@ -2011,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "z3-sys"
-version = "0.10.4"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18a464a6d3c31e6684906ca12e53c095ff625cd21fcbe09271a3aacb56a96f1"
+checksum = "c82b97329d02d87da6802ed9fda083f1b255d822ab13d5b1fb961196b58a69a1"
 dependencies = [
  "bindgen",
  "pkg-config",
@@ -2022,18 +2032,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2042,18 +2052,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2069,9 +2079,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2080,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2091,11 +2101,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "crates/finders",
   "crates/io_replacer",
+  "crates/merger",
   "crates/outparam_replacer",
   "crates/passes",
   "crates/pointer_replacer",
@@ -30,6 +31,7 @@ tracing = "0.1.41"
 [dependencies]
 finders = { path = "crates/finders" }
 io_replacer = { path = "crates/io_replacer" }
+merger = { path = "crates/merger" }
 outparam_replacer = { path = "crates/outparam_replacer" }
 passes = { path = "crates/passes" }
 pointer_replacer = { path = "crates/pointer_replacer" }

--- a/crat-merge
+++ b/crat-merge
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+get_path() {
+  if [ -L $1 ]; then
+    readlink -f $1
+  else
+    echo $1
+  fi
+}
+
+SCRIPT_PATH=$(get_path $0)
+SCRIPT_DIR=$(cd $(dirname $SCRIPT_PATH) && pwd)
+SCRIPT_NAME=$(basename $SCRIPT_PATH)
+SYSROOT=$(cd $SCRIPT_DIR && rustc --print sysroot)
+DIR=$SCRIPT_DIR SYSROOT=$SYSROOT LD_LIBRARY_PATH=$SYSROOT/lib \
+  $SCRIPT_DIR/target/release/$SCRIPT_NAME $@

--- a/crates/merger/Cargo.toml
+++ b/crates/merger/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "merger"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+utils = { path = "../utils" }
+serde.workspace = true
+serde_json.workspace = true
+toml_edit.workspace = true
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/crates/merger/src/cofactor.rs
+++ b/crates/merger/src/cofactor.rs
@@ -1,0 +1,670 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Expr {
+    True,
+    False,
+    Lit {
+        coord: usize,
+        values: BTreeSet<usize>,
+    },
+    Not(Box<Expr>),
+    And(Vec<Expr>),
+    Or(Vec<Expr>),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Universe {
+    domain_sizes: Vec<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct MemoKey {
+    coords: Vec<usize>,
+    bits: Vec<u64>,
+    allow_complement: bool,
+}
+
+pub(crate) struct Solver<'a> {
+    universe: &'a Universe,
+    memo: HashMap<MemoKey, Expr>,
+}
+
+impl Universe {
+    pub(crate) fn new(domain_sizes: Vec<usize>) -> Self {
+        for &size in &domain_sizes {
+            assert!(size > 0, "each coordinate domain must be non-empty");
+        }
+        Self { domain_sizes }
+    }
+
+    pub(crate) fn coordinate_count(&self) -> usize {
+        self.domain_sizes.len()
+    }
+
+    pub(crate) fn all_coordinates(&self) -> Vec<usize> {
+        (0..self.coordinate_count()).collect()
+    }
+
+    pub(crate) fn domain_size(&self, coords: &[usize]) -> usize {
+        coords.iter().fold(1usize, |acc, &coord| {
+            acc.saturating_mul(self.domain_sizes[coord])
+        })
+    }
+
+    pub(crate) fn empty_bits(&self, coords: &[usize]) -> Vec<u64> {
+        vec![0; word_len(self.domain_size(coords))]
+    }
+
+    pub(crate) fn full_bits(&self, coords: &[usize]) -> Vec<u64> {
+        let size = self.domain_size(coords);
+        let mut bits = vec![!0u64; word_len(size)];
+        clear_unused_tail_bits(&mut bits, size);
+        bits
+    }
+
+    pub(crate) fn tuple_index(&self, coords: &[usize], tuple: &[usize]) -> usize {
+        assert_eq!(coords.len(), tuple.len());
+        let mut index = 0usize;
+        for (&coord, &value) in coords.iter().zip(tuple) {
+            assert!(value < self.domain_sizes[coord]);
+            index = index * self.domain_sizes[coord] + value;
+        }
+        index
+    }
+
+    pub(crate) fn set_tuple_bit(&self, coords: &[usize], bits: &mut [u64], tuple: &[usize]) {
+        let index = self.tuple_index(coords, tuple);
+        set_bit(bits, index);
+    }
+
+    pub(crate) fn expr_size(&self, expr: &Expr) -> usize {
+        match expr {
+            Expr::True | Expr::False => 1,
+            Expr::Lit { coord, values } => self.literal_cost(*coord, values),
+            Expr::Not(expr) => 1 + self.expr_size(expr),
+            Expr::And(args) | Expr::Or(args) => {
+                1 + args.iter().map(|arg| self.expr_size(arg)).sum::<usize>()
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn evaluate(&self, expr: &Expr, tuple: &[usize]) -> bool {
+        match expr {
+            Expr::True => true,
+            Expr::False => false,
+            Expr::Lit { coord, values } => values.contains(&tuple[*coord]),
+            Expr::Not(expr) => !self.evaluate(expr, tuple),
+            Expr::And(args) => args.iter().all(|arg| self.evaluate(arg, tuple)),
+            Expr::Or(args) => args.iter().any(|arg| self.evaluate(arg, tuple)),
+        }
+    }
+
+    fn literal_cost(&self, coord: usize, values: &BTreeSet<usize>) -> usize {
+        if values.is_empty() || values.len() == self.domain_sizes[coord] || values.len() == 1 {
+            return 1;
+        }
+
+        let positive_cost = values.len() + 1;
+        let excluded = self.domain_sizes[coord] - values.len();
+        let negative_cost = match excluded {
+            0 => 1,
+            1 => 2,
+            _ => excluded + 2,
+        };
+        positive_cost.min(negative_cost)
+    }
+
+    fn canonical_expr_string(expr: &Expr) -> String {
+        match expr {
+            Expr::True => "T".to_string(),
+            Expr::False => "F".to_string(),
+            Expr::Lit { coord, values } => {
+                let values = values
+                    .iter()
+                    .map(usize::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("L{coord}[{values}]")
+            }
+            Expr::Not(expr) => format!("!{}", Self::canonical_expr_string(expr)),
+            Expr::And(args) => {
+                let args = args
+                    .iter()
+                    .map(Self::canonical_expr_string)
+                    .collect::<Vec<_>>()
+                    .join("&");
+                format!("A({args})")
+            }
+            Expr::Or(args) => {
+                let args = args
+                    .iter()
+                    .map(Self::canonical_expr_string)
+                    .collect::<Vec<_>>()
+                    .join("|");
+                format!("O({args})")
+            }
+        }
+    }
+}
+
+impl<'a> Solver<'a> {
+    pub(crate) fn new(universe: &'a Universe) -> Self {
+        Self {
+            universe,
+            memo: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn solve(&mut self, target: Vec<u64>) -> Expr {
+        let coords = self.universe.all_coordinates();
+        self.solve_subproblem(&coords, target, true)
+    }
+
+    fn solve_subproblem(
+        &mut self,
+        coords: &[usize],
+        bits: Vec<u64>,
+        allow_complement: bool,
+    ) -> Expr {
+        let key = MemoKey {
+            coords: coords.to_vec(),
+            bits: bits.clone(),
+            allow_complement,
+        };
+        if let Some(expr) = self.memo.get(&key) {
+            return expr.clone();
+        }
+
+        let domain_size = self.universe.domain_size(coords);
+        let full_bits = self.universe.full_bits(coords);
+        let expr = if is_empty(&bits) {
+            Expr::False
+        } else if bits == full_bits {
+            Expr::True
+        } else if coords.len() == 1 {
+            let values = values_from_bits(&bits, self.universe.domain_sizes[coords[0]]);
+            self.simplify(Expr::Lit {
+                coord: coords[0],
+                values,
+            })
+        } else {
+            let mut best_expr = None::<Expr>;
+            let mut best_size = usize::MAX;
+
+            for (pivot_pos, &pivot_coord) in coords.iter().enumerate() {
+                let candidate =
+                    self.build_decomposition_candidate(coords, &bits, pivot_pos, pivot_coord);
+                self.consider_candidate(candidate, &mut best_expr, &mut best_size);
+            }
+
+            if allow_complement {
+                let complement = complement_bits(&bits, domain_size);
+                let inner = self.solve_subproblem(coords, complement, false);
+                let candidate = self.simplify(Expr::Not(Box::new(inner)));
+                self.consider_candidate(candidate, &mut best_expr, &mut best_size);
+            }
+
+            best_expr.expect("non-trivial problem must have a candidate")
+        };
+
+        self.memo.insert(key, expr.clone());
+        expr
+    }
+
+    fn consider_candidate(
+        &self,
+        candidate: Expr,
+        best_expr: &mut Option<Expr>,
+        best_size: &mut usize,
+    ) {
+        let candidate_size = self.universe.expr_size(&candidate);
+        let should_replace = match best_expr {
+            None => true,
+            Some(_) if candidate_size < *best_size => true,
+            Some(existing) if candidate_size == *best_size => {
+                Universe::canonical_expr_string(&candidate)
+                    < Universe::canonical_expr_string(existing)
+            }
+            Some(_) => false,
+        };
+
+        if should_replace {
+            *best_size = candidate_size;
+            *best_expr = Some(candidate);
+        }
+    }
+
+    fn build_decomposition_candidate(
+        &mut self,
+        coords: &[usize],
+        bits: &[u64],
+        pivot_pos: usize,
+        pivot_coord: usize,
+    ) -> Expr {
+        let rest_coords = remove_at(coords, pivot_pos);
+        let full_rest = self.universe.full_bits(&rest_coords);
+        let pivot_domain_size = self.universe.domain_sizes[pivot_coord];
+        let mut groups = BTreeMap::<Vec<u64>, BTreeSet<usize>>::new();
+
+        for value in 0..pivot_domain_size {
+            let cofactor = self.compute_cofactor(coords, bits, pivot_pos, value);
+            groups.entry(cofactor).or_default().insert(value);
+        }
+
+        let mut terms = Vec::new();
+        for (cofactor, values) in groups {
+            if is_empty(&cofactor) {
+                continue;
+            }
+
+            let lit = Expr::Lit {
+                coord: pivot_coord,
+                values,
+            };
+            let term = if cofactor == full_rest {
+                lit
+            } else {
+                let sub = self.solve_subproblem(&rest_coords, cofactor, true);
+                Expr::And(vec![lit, sub])
+            };
+            terms.push(term);
+        }
+
+        if terms.is_empty() {
+            Expr::False
+        } else if terms.len() == 1 {
+            self.simplify(terms.pop().unwrap())
+        } else {
+            self.simplify(Expr::Or(terms))
+        }
+    }
+
+    fn compute_cofactor(
+        &self,
+        coords: &[usize],
+        bits: &[u64],
+        pivot_pos: usize,
+        pivot_value: usize,
+    ) -> Vec<u64> {
+        let rest_coords = remove_at(coords, pivot_pos);
+        let rest_domain_size = self.universe.domain_size(&rest_coords);
+        let mut cofactor = vec![0; word_len(rest_domain_size)];
+
+        for rest_index in 0..rest_domain_size {
+            let full_index =
+                self.extend_index(&rest_coords, rest_index, pivot_pos, coords, pivot_value);
+            if get_bit(bits, full_index) {
+                set_bit(&mut cofactor, rest_index);
+            }
+        }
+
+        cofactor
+    }
+
+    fn extend_index(
+        &self,
+        rest_coords: &[usize],
+        rest_index: usize,
+        pivot_pos: usize,
+        coords: &[usize],
+        pivot_value: usize,
+    ) -> usize {
+        let rest_tuple = self.decode_tuple(rest_coords, rest_index);
+        let mut full_tuple = Vec::with_capacity(coords.len());
+        let mut rest_iter = rest_tuple.into_iter();
+        for position in 0..coords.len() {
+            if position == pivot_pos {
+                full_tuple.push(pivot_value);
+            } else {
+                full_tuple.push(rest_iter.next().unwrap());
+            }
+        }
+        self.universe.tuple_index(coords, &full_tuple)
+    }
+
+    fn decode_tuple(&self, coords: &[usize], mut index: usize) -> Vec<usize> {
+        if coords.is_empty() {
+            return Vec::new();
+        }
+
+        let mut tuple = vec![0; coords.len()];
+        for pos in (0..coords.len()).rev() {
+            let radix = self.universe.domain_sizes[coords[pos]];
+            tuple[pos] = index % radix;
+            index /= radix;
+        }
+        tuple
+    }
+
+    fn simplify(&self, expr: Expr) -> Expr {
+        let mut current = expr;
+        loop {
+            let next = self.simplify_one_pass(current.clone());
+            if next == current {
+                return next;
+            }
+            current = next;
+        }
+    }
+
+    fn simplify_one_pass(&self, expr: Expr) -> Expr {
+        match expr {
+            Expr::True => Expr::True,
+            Expr::False => Expr::False,
+            Expr::Lit { coord, values } => {
+                if values.is_empty() {
+                    Expr::False
+                } else if values.len() == self.universe.domain_sizes[coord] {
+                    Expr::True
+                } else {
+                    Expr::Lit { coord, values }
+                }
+            }
+            Expr::Not(expr) => {
+                let expr = self.simplify_one_pass(*expr);
+                match expr {
+                    Expr::True => Expr::False,
+                    Expr::False => Expr::True,
+                    Expr::Not(inner) => *inner,
+                    Expr::Lit { coord, values } => {
+                        let complement = (0..self.universe.domain_sizes[coord])
+                            .filter(|value| !values.contains(value))
+                            .collect();
+                        self.simplify_one_pass(Expr::Lit {
+                            coord,
+                            values: complement,
+                        })
+                    }
+                    other => Expr::Not(Box::new(other)),
+                }
+            }
+            Expr::And(args) => self.simplify_variadic(args, true),
+            Expr::Or(args) => self.simplify_variadic(args, false),
+        }
+    }
+
+    fn simplify_variadic(&self, args: Vec<Expr>, is_and: bool) -> Expr {
+        let mut flat = Vec::new();
+        for arg in args {
+            let arg = self.simplify_one_pass(arg);
+            match (&arg, is_and) {
+                (Expr::False, true) => return Expr::False,
+                (Expr::True, false) => return Expr::True,
+                (Expr::True, true) | (Expr::False, false) => continue,
+                (Expr::And(inner), true) => flat.extend(inner.iter().cloned()),
+                (Expr::Or(inner), false) => flat.extend(inner.iter().cloned()),
+                _ => flat.push(arg),
+            }
+        }
+
+        let deduped = BTreeSet::<Expr>::from_iter(flat)
+            .into_iter()
+            .collect::<Vec<_>>();
+        let merged = if is_and {
+            self.merge_same_coordinate_literals_in_and(deduped)
+        } else {
+            self.merge_same_coordinate_literals_in_or(deduped)
+        };
+        self.finish_variadic(merged, is_and)
+    }
+
+    fn merge_same_coordinate_literals_in_and(&self, args: Vec<Expr>) -> Vec<Expr> {
+        let mut groups = BTreeMap::<usize, BTreeSet<usize>>::new();
+        let mut others = Vec::new();
+
+        for arg in args {
+            match arg {
+                Expr::Lit { coord, values } => {
+                    groups
+                        .entry(coord)
+                        .and_modify(|existing| {
+                            *existing = existing.intersection(&values).copied().collect();
+                        })
+                        .or_insert(values);
+                }
+                other => others.push(other),
+            }
+        }
+
+        for (coord, values) in groups {
+            let lit = self.simplify_one_pass(Expr::Lit { coord, values });
+            if lit == Expr::False {
+                return vec![Expr::False];
+            }
+            if lit != Expr::True {
+                others.push(lit);
+            }
+        }
+
+        others.sort();
+        others.dedup();
+        others
+    }
+
+    fn merge_same_coordinate_literals_in_or(&self, args: Vec<Expr>) -> Vec<Expr> {
+        let mut groups = BTreeMap::<usize, BTreeSet<usize>>::new();
+        let mut others = Vec::new();
+
+        for arg in args {
+            match arg {
+                Expr::Lit { coord, values } => {
+                    groups
+                        .entry(coord)
+                        .and_modify(|existing| existing.extend(values.iter().copied()))
+                        .or_insert(values);
+                }
+                other => others.push(other),
+            }
+        }
+
+        for (coord, values) in groups {
+            let lit = self.simplify_one_pass(Expr::Lit { coord, values });
+            if lit == Expr::True {
+                return vec![Expr::True];
+            }
+            if lit != Expr::False {
+                others.push(lit);
+            }
+        }
+
+        others.sort();
+        others.dedup();
+        others
+    }
+
+    fn finish_variadic(&self, mut args: Vec<Expr>, is_and: bool) -> Expr {
+        match args.len() {
+            0 => {
+                if is_and {
+                    Expr::True
+                } else {
+                    Expr::False
+                }
+            }
+            1 => args.pop().unwrap(),
+            _ => {
+                if is_and {
+                    Expr::And(args)
+                } else {
+                    Expr::Or(args)
+                }
+            }
+        }
+    }
+}
+
+fn remove_at(coords: &[usize], index: usize) -> Vec<usize> {
+    coords
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &coord)| (i != index).then_some(coord))
+        .collect()
+}
+
+fn word_len(bit_len: usize) -> usize {
+    bit_len.div_ceil(64)
+}
+
+fn clear_unused_tail_bits(bits: &mut [u64], bit_len: usize) {
+    let used = bit_len % 64;
+    if used != 0
+        && let Some(last) = bits.last_mut()
+    {
+        *last &= (1u64 << used) - 1;
+    }
+}
+
+fn set_bit(bits: &mut [u64], index: usize) {
+    bits[index / 64] |= 1u64 << (index % 64);
+}
+
+fn get_bit(bits: &[u64], index: usize) -> bool {
+    (bits[index / 64] & (1u64 << (index % 64))) != 0
+}
+
+fn is_empty(bits: &[u64]) -> bool {
+    bits.iter().all(|word| *word == 0)
+}
+
+fn complement_bits(bits: &[u64], bit_len: usize) -> Vec<u64> {
+    let mut complement = bits.iter().map(|word| !word).collect::<Vec<_>>();
+    clear_unused_tail_bits(&mut complement, bit_len);
+    complement
+}
+
+fn values_from_bits(bits: &[u64], value_count: usize) -> BTreeSet<usize> {
+    (0..value_count)
+        .filter(|&index| get_bit(bits, index))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::{Expr, Solver, Universe};
+
+    fn solve(universe: &Universe, tuples: &[&[usize]]) -> Expr {
+        let coords = universe.all_coordinates();
+        let mut bits = universe.empty_bits(&coords);
+        for tuple in tuples {
+            universe.set_tuple_bit(&coords, &mut bits, tuple);
+        }
+        Solver::new(universe).solve(bits)
+    }
+
+    fn assert_matches_target(universe: &Universe, expr: &Expr, expected: &[&[usize]]) {
+        let expected = expected.iter().copied().collect::<BTreeSet<_>>();
+        let coords = universe.all_coordinates();
+        let domain_size = universe.domain_size(&coords);
+
+        for index in 0..domain_size {
+            let tuple = decode_full_tuple(universe, index);
+            let actual = universe.evaluate(expr, &tuple);
+            let wanted = expected.contains(&tuple.as_slice());
+            assert_eq!(actual, wanted, "tuple {tuple:?}");
+        }
+    }
+
+    fn decode_full_tuple(universe: &Universe, mut index: usize) -> Vec<usize> {
+        let coords = universe.all_coordinates();
+        let mut tuple = vec![0; coords.len()];
+        for pos in (0..coords.len()).rev() {
+            let radix = universe.domain_size(&coords[pos..=pos]);
+            tuple[pos] = index % radix;
+            index /= radix;
+        }
+        tuple
+    }
+
+    #[test]
+    fn handles_empty_and_full_targets() {
+        let universe = Universe::new(vec![2, 2]);
+
+        let empty = solve(&universe, &[]);
+        assert_eq!(empty, Expr::False);
+
+        let full = solve(&universe, &[&[0, 0], &[0, 1], &[1, 0], &[1, 1]]);
+        assert_eq!(full, Expr::True);
+    }
+
+    #[test]
+    fn simplifies_single_coordinate_by_complement() {
+        let universe = Universe::new(vec![3]);
+        let expr = solve(&universe, &[&[0], &[2]]);
+
+        assert_eq!(
+            expr,
+            Expr::Lit {
+                coord: 0,
+                values: [0, 2].into_iter().collect()
+            }
+        );
+        assert_matches_target(&universe, &expr, &[&[0], &[2]]);
+        assert_eq!(universe.expr_size(&expr), 2);
+    }
+
+    #[test]
+    fn groups_equal_cofactors_into_single_literal() {
+        let universe = Universe::new(vec![2, 2]);
+        let expr = solve(&universe, &[&[0, 0], &[0, 1]]);
+
+        assert_eq!(
+            expr,
+            Expr::Lit {
+                coord: 0,
+                values: [0].into_iter().collect()
+            }
+        );
+        assert_matches_target(&universe, &expr, &[&[0, 0], &[0, 1]]);
+    }
+
+    #[test]
+    fn keeps_disjunction_across_values_on_one_coordinate() {
+        let universe = Universe::new(vec![3, 2]);
+        let expr = solve(&universe, &[&[0, 0], &[0, 1], &[2, 0], &[2, 1]]);
+
+        assert_eq!(
+            expr,
+            Expr::Lit {
+                coord: 0,
+                values: [0, 2].into_iter().collect()
+            }
+        );
+        assert_matches_target(&universe, &expr, &[&[0, 0], &[0, 1], &[2, 0], &[2, 1]]);
+    }
+
+    #[test]
+    fn uses_complement_when_it_is_smaller() {
+        let universe = Universe::new(vec![2, 2]);
+        let expr = solve(&universe, &[&[0, 0], &[0, 1], &[1, 0]]);
+
+        assert_eq!(
+            expr,
+            Expr::Not(Box::new(Expr::And(vec![
+                Expr::Lit {
+                    coord: 0,
+                    values: [1].into_iter().collect(),
+                },
+                Expr::Lit {
+                    coord: 1,
+                    values: [1].into_iter().collect(),
+                },
+            ])))
+        );
+        assert_matches_target(&universe, &expr, &[&[0, 0], &[0, 1], &[1, 0]]);
+    }
+
+    #[test]
+    fn solver_instances_do_not_share_memo_across_universes() {
+        let universe_a = Universe::new(vec![2, 2]);
+        let expr_a = solve(&universe_a, &[&[0, 0], &[0, 1]]);
+        assert_matches_target(&universe_a, &expr_a, &[&[0, 0], &[0, 1]]);
+
+        let universe_b = Universe::new(vec![3, 2]);
+        let expr_b = solve(&universe_b, &[&[0, 0], &[2, 1]]);
+        assert_matches_target(&universe_b, &expr_b, &[&[0, 0], &[2, 1]]);
+    }
+}

--- a/crates/merger/src/lib.rs
+++ b/crates/merger/src/lib.rs
@@ -26,6 +26,8 @@ struct RawTranslation {
 
 struct Translation {
     dir: PathBuf,
+    config: BTreeMap<String, String>,
+    feature_by_param: BTreeMap<String, String>,
     features: Vec<String>,
 }
 
@@ -107,6 +109,8 @@ fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, Strin
             return Err(format!("{dir:?} is not a directory"));
         }
 
+        let mut config = BTreeMap::new();
+        let mut feature_by_param = BTreeMap::new();
         let mut features = Vec::with_capacity(entry.config.len());
         for (param, value) in entry.config {
             let raw_value = config_value_to_string(&param, &value)?;
@@ -118,8 +122,10 @@ fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, Strin
                     ));
                 }
             } else {
-                feature_map.insert(feature.clone(), (param, raw_value));
+                feature_map.insert(feature.clone(), (param.clone(), raw_value.clone()));
             }
+            config.insert(param.clone(), raw_value);
+            feature_by_param.insert(param, feature.clone());
             features.push(feature);
         }
         if !seen_feature_sets.insert(features.clone()) {
@@ -127,7 +133,12 @@ fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, Strin
                 "duplicate configuration detected for translation directory {dir:?}"
             ));
         }
-        translations.push(Translation { dir, features });
+        translations.push(Translation {
+            dir,
+            config,
+            feature_by_param,
+            features,
+        });
     }
 
     Ok(translations)
@@ -476,6 +487,12 @@ fn merged_cfg_attribute(
         return None;
     }
 
+    if let Some(common_condition) =
+        simplified_cfg_condition(variant_indexes, translations, variants)
+    {
+        return Some(format!("#[cfg({common_condition})]"));
+    }
+
     let conditions = variant_indexes
         .iter()
         .map(|variant_index| {
@@ -485,6 +502,61 @@ fn merged_cfg_attribute(
         .collect::<Vec<_>>()
         .join(", ");
     Some(format!("#[cfg(any({conditions}))]"))
+}
+
+fn simplified_cfg_condition(
+    variant_indexes: &BTreeSet<usize>,
+    translations: &[Translation],
+    variants: &[(usize, PathBuf)],
+) -> Option<String> {
+    let mut variant_iter = variant_indexes.iter();
+    let first_variant = *variant_iter.next()?;
+    let first_translation = &translations[variants[first_variant].0];
+    let mut common_params = first_translation.config.clone();
+
+    for variant_index in variant_iter {
+        let translation = &translations[variants[*variant_index].0];
+        common_params.retain(|param, value| translation.config.get(param) == Some(value));
+    }
+
+    let filtered_count = filtered_combination_count(&common_params, translations, variants);
+    if filtered_count != variant_indexes.len() {
+        return None;
+    }
+
+    let features = common_params
+        .keys()
+        .map(|param| {
+            first_translation
+                .feature_by_param
+                .get(param)
+                .cloned()
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    Some(cfg_condition(&features))
+}
+
+fn filtered_combination_count(
+    common_params: &BTreeMap<String, String>,
+    translations: &[Translation],
+    variants: &[(usize, PathBuf)],
+) -> usize {
+    let mut values_by_param = BTreeMap::<String, BTreeSet<&str>>::new();
+    for (translation_index, _) in variants {
+        for (param, value) in &translations[*translation_index].config {
+            values_by_param
+                .entry(param.clone())
+                .or_default()
+                .insert(value.as_str());
+        }
+    }
+
+    values_by_param
+        .into_iter()
+        .filter(|(param, _)| !common_params.contains_key(param))
+        .map(|(_, values)| values.len())
+        .product()
 }
 
 fn parse_rust_file(path: &Path) -> Result<ParsedRustFile, String> {

--- a/crates/merger/src/lib.rs
+++ b/crates/merger/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use rustc_ast::AttrStyle;
+use rustc_ast::{AttrStyle, ItemKind};
 use rustc_ast_pretty::pprust;
 use serde::Deserialize;
 use serde_json::Value;
@@ -41,7 +41,36 @@ struct SharedFile {
 
 struct ParsedRustFile {
     inner_attrs: Vec<String>,
-    items: Vec<String>,
+    items: Vec<ParsedItem>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum ItemBucket {
+    Use,
+    ExternCrate,
+    ForeignMod,
+    Mod,
+    Other,
+    Global,
+    Type,
+    Trait,
+    Impl,
+    Fn,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ParsedItem {
+    text: String,
+    bucket: ItemBucket,
+    group_name: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct OrderedItem {
+    text: String,
+    bucket: ItemBucket,
+    group_name: Option<String>,
+    first_seen: usize,
 }
 
 pub fn merge(translations_json: &Path, output_root: &Path) -> Result<(), String> {
@@ -423,6 +452,7 @@ fn write_merged_rust_file(
     let mut ordered_items = Vec::new();
     let mut item_variants = BTreeMap::<String, BTreeSet<usize>>::new();
     let mut merged = String::new();
+    let mut next_first_seen = 0usize;
 
     for (variant_index, (_, path)) in variants.iter().enumerate() {
         let parsed = parse_rust_file(path)?;
@@ -438,24 +468,31 @@ fn write_merged_rust_file(
 
         let mut seen_in_variant = BTreeSet::new();
         for item in parsed.items {
-            if !seen_in_variant.insert(item.clone()) {
+            if !seen_in_variant.insert(item.text.clone()) {
                 continue;
             }
 
-            let variants_for_item = item_variants.entry(item.clone()).or_default();
+            let variants_for_item = item_variants.entry(item.text.clone()).or_default();
             if variants_for_item.is_empty() {
-                ordered_items.push(item.clone());
+                ordered_items.push(OrderedItem {
+                    text: item.text.clone(),
+                    bucket: item.bucket,
+                    group_name: item.group_name,
+                    first_seen: next_first_seen,
+                });
+                next_first_seen += 1;
             }
             variants_for_item.insert(variant_index);
         }
     }
 
-    for item in ordered_items {
-        if let Some(cfg) = merged_cfg_attribute(&item, &item_variants, translations, variants) {
+    for item in reorder_items(ordered_items) {
+        if let Some(cfg) = merged_cfg_attribute(&item.text, &item_variants, translations, variants)
+        {
             writeln!(merged, "{cfg}").unwrap();
-            writeln!(merged, "{item}").unwrap();
+            writeln!(merged, "{}", item.text).unwrap();
         } else {
-            writeln!(merged, "{item}").unwrap();
+            writeln!(merged, "{}", item.text).unwrap();
         }
     }
 
@@ -632,10 +669,85 @@ fn feature_clause(feature: &str) -> String {
     format!("feature = {feature:?}")
 }
 
+fn reorder_items(items: Vec<OrderedItem>) -> Vec<OrderedItem> {
+    let mut grouped_items = BTreeMap::<(ItemBucket, String), Vec<OrderedItem>>::new();
+    let mut ungrouped_items = Vec::new();
+
+    for item in items {
+        if should_group_bucket(item.bucket) {
+            let name = item
+                .group_name
+                .clone()
+                .expect("grouped item buckets must carry a name");
+            grouped_items
+                .entry((item.bucket, name))
+                .or_default()
+                .push(item);
+        } else {
+            ungrouped_items.push(item);
+        }
+    }
+
+    let mut group_order = grouped_items
+        .into_iter()
+        .map(|((bucket, _), mut items)| {
+            items.sort_by_key(|item| item.first_seen);
+            let first_seen = items[0].first_seen;
+            (bucket, first_seen, items)
+        })
+        .collect::<Vec<_>>();
+    group_order.sort_by_key(|(bucket, first_seen, _)| (*bucket, *first_seen));
+
+    ungrouped_items.sort_by_key(|item| (item.bucket, item.first_seen));
+
+    let mut ordered = Vec::with_capacity(
+        ungrouped_items.len()
+            + group_order
+                .iter()
+                .map(|(_, _, items)| items.len())
+                .sum::<usize>(),
+    );
+    let mut ungrouped_items = ungrouped_items.into_iter().peekable();
+    let mut group_order = group_order.into_iter().peekable();
+
+    for bucket in [
+        ItemBucket::Use,
+        ItemBucket::ExternCrate,
+        ItemBucket::ForeignMod,
+        ItemBucket::Mod,
+        ItemBucket::Other,
+        ItemBucket::Global,
+        ItemBucket::Type,
+        ItemBucket::Trait,
+        ItemBucket::Impl,
+        ItemBucket::Fn,
+    ] {
+        while matches!(ungrouped_items.peek(), Some(item) if item.bucket == bucket) {
+            ordered.push(ungrouped_items.next().unwrap());
+        }
+        while matches!(group_order.peek(), Some((group_bucket, _, _)) if *group_bucket == bucket) {
+            ordered.extend(group_order.next().unwrap().2);
+        }
+    }
+
+    ordered
+}
+
+fn should_group_bucket(bucket: ItemBucket) -> bool {
+    matches!(
+        bucket,
+        ItemBucket::Global | ItemBucket::Type | ItemBucket::Trait | ItemBucket::Fn
+    )
+}
+
 fn parse_rust_file(path: &Path) -> Result<ParsedRustFile, String> {
     let source = fs::read_to_string(path).map_err(|e| format!("failed to read {path:?}: {e}"))?;
-    let krate = std::panic::catch_unwind(|| utils::ast::parse_crate(source))
-        .map_err(|_| format!("failed to parse {path:?}"))?;
+    parse_rust_source(&source).map_err(|_| format!("failed to parse {path:?}"))
+}
+
+fn parse_rust_source(source: &str) -> Result<ParsedRustFile, ()> {
+    let krate =
+        std::panic::catch_unwind(|| utils::ast::parse_crate(source.to_string())).map_err(|_| ())?;
 
     let inner_attrs = krate
         .attrs
@@ -646,9 +758,39 @@ fn parse_rust_file(path: &Path) -> Result<ParsedRustFile, String> {
     let items = krate
         .items
         .iter()
-        .map(|item| pprust::item_to_string(item))
+        .map(|item| ParsedItem {
+            text: pprust::item_to_string(item),
+            bucket: classify_item_kind(&item.kind),
+            group_name: grouped_item_name(item),
+        })
         .collect();
     Ok(ParsedRustFile { inner_attrs, items })
+}
+
+fn classify_item_kind(kind: &ItemKind) -> ItemBucket {
+    match kind {
+        ItemKind::Use(..) => ItemBucket::Use,
+        ItemKind::ExternCrate(..) => ItemBucket::ExternCrate,
+        ItemKind::ForeignMod(..) => ItemBucket::ForeignMod,
+        ItemKind::Mod(..) => ItemBucket::Mod,
+        ItemKind::Static(..) | ItemKind::Const(..) => ItemBucket::Global,
+        ItemKind::TyAlias(..) | ItemKind::Enum(..) | ItemKind::Union(..) | ItemKind::Struct(..) => {
+            ItemBucket::Type
+        }
+        ItemKind::Trait(..) | ItemKind::TraitAlias(..) => ItemBucket::Trait,
+        ItemKind::Impl(..) => ItemBucket::Impl,
+        ItemKind::Fn(..) => ItemBucket::Fn,
+        _ => ItemBucket::Other,
+    }
+}
+
+fn grouped_item_name(item: &rustc_ast::Item) -> Option<String> {
+    match classify_item_kind(&item.kind) {
+        ItemBucket::Global | ItemBucket::Type | ItemBucket::Trait | ItemBucket::Fn => {
+            item.kind.ident().map(|ident| ident.name.to_string())
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -658,7 +800,7 @@ mod tests {
         path::PathBuf,
     };
 
-    use super::{Translation, merged_cfg_attribute};
+    use super::{ItemBucket, OrderedItem, Translation, merged_cfg_attribute, reorder_items};
 
     fn translation(config: &[(&str, &str)]) -> Translation {
         let config = config
@@ -677,6 +819,27 @@ mod tests {
             config,
             features,
         }
+    }
+
+    fn ordered_item(
+        text: &str,
+        bucket: ItemBucket,
+        group_name: Option<&str>,
+        first_seen: usize,
+    ) -> OrderedItem {
+        OrderedItem {
+            text: text.to_string(),
+            bucket,
+            group_name: group_name.map(str::to_string),
+            first_seen,
+        }
+    }
+
+    fn reordered_item_texts(items: Vec<OrderedItem>) -> Vec<String> {
+        reorder_items(items)
+            .into_iter()
+            .map(|item| item.text)
+            .collect()
     }
 
     #[test]
@@ -701,5 +864,155 @@ mod tests {
 
         let cfg = merged_cfg_attribute("fn shared() {}", &item_variants, &translations, &variants);
         assert_eq!(cfg, Some("#[cfg(feature = \"os_linux\")]".to_string()));
+    }
+
+    #[test]
+    fn reorder_items_uses_bucket_order() {
+        let items = reordered_item_texts(vec![
+            ordered_item("fn zeta() {}", ItemBucket::Fn, Some("zeta"), 0),
+            ordered_item("impl Foo {}", ItemBucket::Impl, None, 1),
+            ordered_item("trait Worker {}", ItemBucket::Trait, Some("Worker"), 2),
+            ordered_item("type Alias = i32;", ItemBucket::Type, Some("Alias"), 3),
+            ordered_item("struct Foo;", ItemBucket::Type, Some("Foo"), 4),
+            ordered_item(
+                "const VALUE: i32 = 1;",
+                ItemBucket::Global,
+                Some("VALUE"),
+                5,
+            ),
+            ordered_item("mod inner {}", ItemBucket::Mod, None, 6),
+            ordered_item(
+                "unsafe extern \"C\" {\n    fn foreign();\n}",
+                ItemBucket::ForeignMod,
+                None,
+                7,
+            ),
+            ordered_item("extern crate core;", ItemBucket::ExternCrate, None, 8),
+            ordered_item("use std::fmt;", ItemBucket::Use, None, 9),
+        ]);
+
+        assert_eq!(
+            items,
+            vec![
+                "use std::fmt;",
+                "extern crate core;",
+                "unsafe extern \"C\" {\n    fn foreign();\n}",
+                "mod inner {}",
+                "const VALUE: i32 = 1;",
+                "type Alias = i32;",
+                "struct Foo;",
+                "trait Worker {}",
+                "impl Foo {}",
+                "fn zeta() {}",
+            ]
+        );
+    }
+
+    #[test]
+    fn reorder_items_groups_types_traits_and_functions_by_name() {
+        let items = reordered_item_texts(vec![
+            ordered_item(
+                "fn zebra() {\n    let _ = 0;\n}",
+                ItemBucket::Fn,
+                Some("zebra"),
+                0,
+            ),
+            ordered_item(
+                "fn apple() {\n    let _ = 1;\n}",
+                ItemBucket::Fn,
+                Some("apple"),
+                1,
+            ),
+            ordered_item("trait Beta {}", ItemBucket::Trait, Some("Beta"), 2),
+            ordered_item("type Shared = i32;", ItemBucket::Type, Some("Shared"), 3),
+            ordered_item("struct Pair;", ItemBucket::Type, Some("Pair"), 4),
+            ordered_item(
+                "trait AliasName = Clone;",
+                ItemBucket::Trait,
+                Some("AliasName"),
+                5,
+            ),
+            ordered_item(
+                "fn apple() {\n    let _ = 2;\n}",
+                ItemBucket::Fn,
+                Some("apple"),
+                6,
+            ),
+            ordered_item("enum Shared {}", ItemBucket::Type, Some("Shared"), 7),
+            ordered_item(
+                "trait AliasName = Copy;",
+                ItemBucket::Trait,
+                Some("AliasName"),
+                8,
+            ),
+            ordered_item(
+                "union Pair {\n    field: i32,\n}",
+                ItemBucket::Type,
+                Some("Pair"),
+                9,
+            ),
+            ordered_item(
+                "fn zebra() {\n    let _ = 3;\n}",
+                ItemBucket::Fn,
+                Some("zebra"),
+                10,
+            ),
+        ]);
+
+        assert_eq!(
+            items,
+            vec![
+                "type Shared = i32;",
+                "enum Shared {}",
+                "struct Pair;",
+                "union Pair {\n    field: i32,\n}",
+                "trait Beta {}",
+                "trait AliasName = Clone;",
+                "trait AliasName = Copy;",
+                "fn zebra() {\n    let _ = 0;\n}",
+                "fn zebra() {\n    let _ = 3;\n}",
+                "fn apple() {\n    let _ = 1;\n}",
+                "fn apple() {\n    let _ = 2;\n}",
+            ]
+        );
+    }
+
+    #[test]
+    fn reorder_items_groups_globals_by_name() {
+        let items = reordered_item_texts(vec![
+            ordered_item("const BETA: i32 = 1;", ItemBucket::Global, Some("BETA"), 0),
+            ordered_item(
+                "static ALPHA: i32 = 2;",
+                ItemBucket::Global,
+                Some("ALPHA"),
+                1,
+            ),
+            ordered_item(
+                "const ALPHA: i32 = 3;",
+                ItemBucket::Global,
+                Some("ALPHA"),
+                2,
+            ),
+            ordered_item("const BETA: i32 = 4;", ItemBucket::Global, Some("BETA"), 3),
+            ordered_item("fn run() {}", ItemBucket::Fn, Some("run"), 4),
+            ordered_item(
+                "macro_rules! demo { () => {}; }",
+                ItemBucket::Other,
+                None,
+                5,
+            ),
+        ]);
+
+        assert_eq!(
+            items,
+            vec![
+                "macro_rules! demo { () => {}; }",
+                "const BETA: i32 = 1;",
+                "const BETA: i32 = 4;",
+                "static ALPHA: i32 = 2;",
+                "const ALPHA: i32 = 3;",
+                "fn run() {}",
+            ]
+        );
     }
 }

--- a/crates/merger/src/lib.rs
+++ b/crates/merger/src/lib.rs
@@ -409,9 +409,11 @@ fn write_merged_rust_file(
     variants: &[(usize, PathBuf)],
 ) -> Result<(), String> {
     let mut shared_inner_attrs: Option<Vec<String>> = None;
+    let mut ordered_items = Vec::new();
+    let mut item_variants = BTreeMap::<String, BTreeSet<usize>>::new();
     let mut merged = String::new();
 
-    for (index, path) in variants {
+    for (variant_index, (_, path)) in variants.iter().enumerate() {
         let parsed = parse_rust_file(path)?;
         if let Some(existing) = shared_inner_attrs.as_ref() {
             if existing != &parsed.inner_attrs {
@@ -423,9 +425,25 @@ fn write_merged_rust_file(
             shared_inner_attrs = Some(parsed.inner_attrs.clone());
         }
 
-        let cfg = cfg_attribute(&translations[*index].features);
+        let mut seen_in_variant = BTreeSet::new();
         for item in parsed.items {
+            if !seen_in_variant.insert(item.clone()) {
+                continue;
+            }
+
+            let variants_for_item = item_variants.entry(item.clone()).or_default();
+            if variants_for_item.is_empty() {
+                ordered_items.push(item.clone());
+            }
+            variants_for_item.insert(variant_index);
+        }
+    }
+
+    for item in ordered_items {
+        if let Some(cfg) = merged_cfg_attribute(&item, &item_variants, translations, variants) {
             writeln!(merged, "{cfg}").unwrap();
+            writeln!(merged, "{item}").unwrap();
+        } else {
             writeln!(merged, "{item}").unwrap();
         }
     }
@@ -447,6 +465,28 @@ fn write_merged_rust_file(
     fs::write(output_path, code).map_err(|e| format!("failed to write {output_path:?}: {e}"))
 }
 
+fn merged_cfg_attribute(
+    item: &str,
+    item_variants: &BTreeMap<String, BTreeSet<usize>>,
+    translations: &[Translation],
+    variants: &[(usize, PathBuf)],
+) -> Option<String> {
+    let variant_indexes = item_variants.get(item).unwrap();
+    if variant_indexes.len() == variants.len() {
+        return None;
+    }
+
+    let conditions = variant_indexes
+        .iter()
+        .map(|variant_index| {
+            let translation_index = variants[*variant_index].0;
+            cfg_condition(&translations[translation_index].features)
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!("#[cfg(any({conditions}))]"))
+}
+
 fn parse_rust_file(path: &Path) -> Result<ParsedRustFile, String> {
     let source = fs::read_to_string(path).map_err(|e| format!("failed to read {path:?}: {e}"))?;
     let krate = std::panic::catch_unwind(|| utils::ast::parse_crate(source))
@@ -466,11 +506,11 @@ fn parse_rust_file(path: &Path) -> Result<ParsedRustFile, String> {
     Ok(ParsedRustFile { inner_attrs, items })
 }
 
-fn cfg_attribute(features: &[String]) -> String {
+fn cfg_condition(features: &[String]) -> String {
     let clauses = features
         .iter()
         .map(|feature| format!("feature = {feature:?}"))
         .collect::<Vec<_>>()
         .join(", ");
-    format!("#[cfg(all({clauses}))]")
+    format!("all({clauses})")
 }

--- a/crates/merger/src/lib.rs
+++ b/crates/merger/src/lib.rs
@@ -123,8 +123,9 @@ fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, Strin
 
     let base_dir = translations_json.parent().unwrap_or_else(|| Path::new("."));
     let expected_keys: BTreeSet<String> = raw[0].config.keys().cloned().collect();
+    let varying_params = varying_params(&raw, &expected_keys)?;
     let mut feature_map = BTreeMap::<String, (String, String)>::new();
-    let mut seen_feature_sets = BTreeSet::<Vec<String>>::new();
+    let mut seen_configs = BTreeSet::<BTreeMap<String, String>>::new();
     let mut translations = Vec::with_capacity(raw.len());
 
     for (index, entry) in raw.into_iter().enumerate() {
@@ -142,23 +143,25 @@ fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, Strin
         }
 
         let mut config = BTreeMap::new();
-        let mut features = Vec::with_capacity(entry.config.len());
+        let mut features = Vec::with_capacity(varying_params.len());
         for (param, value) in entry.config {
             let raw_value = config_value_to_string(&param, &value)?;
-            let feature = make_feature_name(&param, &raw_value)?;
-            if let Some((existing_param, existing_value)) = feature_map.get(&feature) {
-                if existing_param != &param || existing_value != &raw_value {
-                    return Err(format!(
-                        "feature name collision: {feature:?} maps to both {existing_param}={existing_value} and {param}={raw_value}"
-                    ));
+            if varying_params.contains(&param) {
+                let feature = make_feature_name(&param, &raw_value)?;
+                if let Some((existing_param, existing_value)) = feature_map.get(&feature) {
+                    if existing_param != &param || existing_value != &raw_value {
+                        return Err(format!(
+                            "feature name collision: {feature:?} maps to both {existing_param}={existing_value} and {param}={raw_value}"
+                        ));
+                    }
+                } else {
+                    feature_map.insert(feature.clone(), (param.clone(), raw_value.clone()));
                 }
-            } else {
-                feature_map.insert(feature.clone(), (param.clone(), raw_value.clone()));
+                features.push(feature);
             }
             config.insert(param.clone(), raw_value);
-            features.push(feature);
         }
-        if !seen_feature_sets.insert(features.clone()) {
+        if !seen_configs.insert(config.clone()) {
             return Err(format!(
                 "duplicate configuration detected for translation directory {dir:?}"
             ));
@@ -171,6 +174,36 @@ fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, Strin
     }
 
     Ok(translations)
+}
+
+fn varying_params(
+    raw: &[RawTranslation],
+    expected_keys: &BTreeSet<String>,
+) -> Result<BTreeSet<String>, String> {
+    let mut value_sets = expected_keys
+        .iter()
+        .cloned()
+        .map(|param| (param, BTreeSet::new()))
+        .collect::<BTreeMap<_, _>>();
+
+    for entry in raw {
+        for param in expected_keys {
+            let value = entry
+                .config
+                .get(param)
+                .ok_or_else(|| format!("missing configuration parameter {param:?}"))?;
+            let value = config_value_to_string(param, value)?;
+            value_sets
+                .get_mut(param)
+                .expect("expected key was pre-populated")
+                .insert(value);
+        }
+    }
+
+    Ok(value_sets
+        .into_iter()
+        .filter_map(|(param, values)| (values.len() > 1).then_some(param))
+        .collect())
 }
 
 fn resolve_dir(base_dir: &Path, dir: &Path) -> PathBuf {
@@ -533,11 +566,7 @@ fn simplified_cfg_condition(
     translations: &[Translation],
     variants: &[(usize, PathBuf)],
 ) -> String {
-    let params = translations[variants[0].0]
-        .config
-        .keys()
-        .cloned()
-        .collect::<Vec<_>>();
+    let params = varying_config_params(translations, variants);
     let value_lists = params
         .iter()
         .map(|param| {
@@ -667,6 +696,25 @@ fn lower_cfg_primitive_or(clauses: &[String]) -> String {
 
 fn feature_clause(feature: &str) -> String {
     format!("feature = {feature:?}")
+}
+
+fn varying_config_params(
+    translations: &[Translation],
+    variants: &[(usize, PathBuf)],
+) -> Vec<String> {
+    translations[variants[0].0]
+        .config
+        .keys()
+        .filter(|param| {
+            variants
+                .iter()
+                .map(|(translation_index, _)| &translations[*translation_index].config[*param])
+                .collect::<BTreeSet<_>>()
+                .len()
+                > 1
+        })
+        .cloned()
+        .collect()
 }
 
 fn reorder_items(items: Vec<OrderedItem>) -> Vec<OrderedItem> {
@@ -800,18 +848,19 @@ mod tests {
         path::PathBuf,
     };
 
-    use super::{ItemBucket, OrderedItem, Translation, merged_cfg_attribute, reorder_items};
+    use super::{
+        ItemBucket, OrderedItem, Translation, make_feature_name, merged_cfg_attribute,
+        reorder_items,
+    };
 
-    fn translation(config: &[(&str, &str)]) -> Translation {
-        let config = config
-            .iter()
-            .map(|(param, value)| (param.to_string(), value.to_string()))
-            .collect::<BTreeMap<_, _>>();
+    fn translation_with_features(
+        config: BTreeMap<String, String>,
+        varying_params: &BTreeSet<String>,
+    ) -> Translation {
         let features = config
             .iter()
-            .map(|(param, value)| {
-                super::make_feature_name(param, value).expect("test config is valid")
-            })
+            .filter(|(param, _)| varying_params.contains(*param))
+            .map(|(param, value)| make_feature_name(param, value).expect("test config is valid"))
             .collect::<Vec<_>>();
 
         Translation {
@@ -845,10 +894,34 @@ mod tests {
     #[test]
     fn merged_cfg_attribute_uses_cofactor_simplification() {
         let translations = vec![
-            translation(&[("os", "linux"), ("arch", "x86")]),
-            translation(&[("os", "linux"), ("arch", "arm")]),
-            translation(&[("os", "mac"), ("arch", "x86")]),
-            translation(&[("os", "mac"), ("arch", "arm")]),
+            translation_with_features(
+                [("os", "linux"), ("arch", "x86")]
+                    .into_iter()
+                    .map(|(param, value)| (param.to_string(), value.to_string()))
+                    .collect(),
+                &["os".to_string(), "arch".to_string()].into_iter().collect(),
+            ),
+            translation_with_features(
+                [("os", "linux"), ("arch", "arm")]
+                    .into_iter()
+                    .map(|(param, value)| (param.to_string(), value.to_string()))
+                    .collect(),
+                &["os".to_string(), "arch".to_string()].into_iter().collect(),
+            ),
+            translation_with_features(
+                [("os", "mac"), ("arch", "x86")]
+                    .into_iter()
+                    .map(|(param, value)| (param.to_string(), value.to_string()))
+                    .collect(),
+                &["os".to_string(), "arch".to_string()].into_iter().collect(),
+            ),
+            translation_with_features(
+                [("os", "mac"), ("arch", "arm")]
+                    .into_iter()
+                    .map(|(param, value)| (param.to_string(), value.to_string()))
+                    .collect(),
+                &["os".to_string(), "arch".to_string()].into_iter().collect(),
+            ),
         ];
         let variants = vec![
             (0, PathBuf::from("linux-x86.rs")),
@@ -864,6 +937,42 @@ mod tests {
 
         let cfg = merged_cfg_attribute("fn shared() {}", &item_variants, &translations, &variants);
         assert_eq!(cfg, Some("#[cfg(feature = \"os_linux\")]".to_string()));
+    }
+
+    #[test]
+    fn merged_cfg_attribute_omits_globally_constant_parameters() {
+        let varying_params = ["arch".to_string()].into_iter().collect();
+        let translations = vec![
+            translation_with_features(
+                [("os", "linux"), ("arch", "x86")]
+                    .into_iter()
+                    .map(|(param, value)| (param.to_string(), value.to_string()))
+                    .collect(),
+                &varying_params,
+            ),
+            translation_with_features(
+                [("os", "linux"), ("arch", "arm")]
+                    .into_iter()
+                    .map(|(param, value)| (param.to_string(), value.to_string()))
+                    .collect(),
+                &varying_params,
+            ),
+        ];
+        let variants = vec![
+            (0, PathBuf::from("linux-x86.rs")),
+            (1, PathBuf::from("linux-arm.rs")),
+        ];
+        let mut item_variants = BTreeMap::<String, BTreeSet<usize>>::new();
+        item_variants.insert(
+            "fn x86_only() {}".to_string(),
+            [0usize].into_iter().collect(),
+        );
+
+        let cfg =
+            merged_cfg_attribute("fn x86_only() {}", &item_variants, &translations, &variants);
+        assert_eq!(cfg, Some("#[cfg(feature = \"arch_x86\")]".to_string()));
+        assert_eq!(translations[0].features, vec!["arch_x86".to_string()]);
+        assert_eq!(translations[1].features, vec!["arch_arm".to_string()]);
     }
 
     #[test]

--- a/crates/merger/src/lib.rs
+++ b/crates/merger/src/lib.rs
@@ -3,6 +3,8 @@
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
 
+mod cofactor;
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     ffi::{OsStr, OsString},
@@ -17,6 +19,8 @@ use serde::Deserialize;
 use serde_json::Value;
 use toml_edit::{Array, DocumentMut, Item, Table, value};
 
+use crate::cofactor::{Expr, Solver, Universe};
+
 #[derive(Deserialize)]
 struct RawTranslation {
     dir: PathBuf,
@@ -27,7 +31,6 @@ struct RawTranslation {
 struct Translation {
     dir: PathBuf,
     config: BTreeMap<String, String>,
-    feature_by_param: BTreeMap<String, String>,
     features: Vec<String>,
 }
 
@@ -110,7 +113,6 @@ fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, Strin
         }
 
         let mut config = BTreeMap::new();
-        let mut feature_by_param = BTreeMap::new();
         let mut features = Vec::with_capacity(entry.config.len());
         for (param, value) in entry.config {
             let raw_value = config_value_to_string(&param, &value)?;
@@ -125,7 +127,6 @@ fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, Strin
                 feature_map.insert(feature.clone(), (param.clone(), raw_value.clone()));
             }
             config.insert(param.clone(), raw_value);
-            feature_by_param.insert(param, feature.clone());
             features.push(feature);
         }
         if !seen_feature_sets.insert(features.clone()) {
@@ -136,7 +137,6 @@ fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, Strin
         translations.push(Translation {
             dir,
             config,
-            feature_by_param,
             features,
         });
     }
@@ -487,76 +487,149 @@ fn merged_cfg_attribute(
         return None;
     }
 
-    if let Some(common_condition) =
-        simplified_cfg_condition(variant_indexes, translations, variants)
-    {
-        return Some(format!("#[cfg({common_condition})]"));
-    }
-
-    let conditions = variant_indexes
-        .iter()
-        .map(|variant_index| {
-            let translation_index = variants[*variant_index].0;
-            cfg_condition(&translations[translation_index].features)
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
-    Some(format!("#[cfg(any({conditions}))]"))
+    let condition = simplified_cfg_condition(variant_indexes, translations, variants);
+    Some(format!("#[cfg({condition})]"))
 }
 
 fn simplified_cfg_condition(
     variant_indexes: &BTreeSet<usize>,
     translations: &[Translation],
     variants: &[(usize, PathBuf)],
-) -> Option<String> {
-    let mut variant_iter = variant_indexes.iter();
-    let first_variant = *variant_iter.next()?;
-    let first_translation = &translations[variants[first_variant].0];
-    let mut common_params = first_translation.config.clone();
-
-    for variant_index in variant_iter {
-        let translation = &translations[variants[*variant_index].0];
-        common_params.retain(|param, value| translation.config.get(param) == Some(value));
-    }
-
-    let filtered_count = filtered_combination_count(&common_params, translations, variants);
-    if filtered_count != variant_indexes.len() {
-        return None;
-    }
-
-    let features = common_params
+) -> String {
+    let params = translations[variants[0].0]
+        .config
         .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    let value_lists = params
+        .iter()
         .map(|param| {
-            first_translation
-                .feature_by_param
-                .get(param)
-                .cloned()
-                .unwrap()
+            variants
+                .iter()
+                .map(|(translation_index, _)| {
+                    translations[*translation_index].config[param].clone()
+                })
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
-    Some(cfg_condition(&features))
-}
+    let value_indexes = value_lists
+        .iter()
+        .map(|values| {
+            values
+                .iter()
+                .enumerate()
+                .map(|(index, value)| (value.clone(), index))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .collect::<Vec<_>>();
+    let feature_lists = params
+        .iter()
+        .zip(&value_lists)
+        .map(|(param, values)| {
+            values
+                .iter()
+                .map(|value| {
+                    make_feature_name(param, value).expect("existing config value is valid")
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
 
-fn filtered_combination_count(
-    common_params: &BTreeMap<String, String>,
-    translations: &[Translation],
-    variants: &[(usize, PathBuf)],
-) -> usize {
-    let mut values_by_param = BTreeMap::<String, BTreeSet<&str>>::new();
-    for (translation_index, _) in variants {
-        for (param, value) in &translations[*translation_index].config {
-            values_by_param
-                .entry(param.clone())
-                .or_default()
-                .insert(value.as_str());
-        }
+    let universe = Universe::new(value_lists.iter().map(Vec::len).collect());
+    let coords = universe.all_coordinates();
+    let mut target = universe.empty_bits(&coords);
+    for &variant_index in variant_indexes {
+        let translation = &translations[variants[variant_index].0];
+        let tuple = params
+            .iter()
+            .enumerate()
+            .map(|(coord, param)| value_indexes[coord][&translation.config[param]])
+            .collect::<Vec<_>>();
+        universe.set_tuple_bit(&coords, &mut target, &tuple);
     }
 
-    values_by_param
-        .into_iter()
-        .filter(|(param, _)| !common_params.contains_key(param))
-        .map(|(_, values)| values.len())
-        .product()
+    let expr = Solver::new(&universe).solve(target);
+    lower_cfg_expr(&expr, &feature_lists)
+}
+
+fn lower_cfg_expr(expr: &Expr, feature_lists: &[Vec<String>]) -> String {
+    match expr {
+        Expr::True => "all()".to_string(),
+        Expr::False => "any()".to_string(),
+        Expr::Lit { coord, values } => lower_cfg_literal(*coord, values, feature_lists),
+        Expr::Not(expr) => format!("not({})", lower_cfg_expr(expr, feature_lists)),
+        Expr::And(args) => lower_cfg_operator("all", args, feature_lists),
+        Expr::Or(args) => lower_cfg_operator("any", args, feature_lists),
+    }
+}
+
+fn lower_cfg_operator(name: &str, args: &[Expr], feature_lists: &[Vec<String>]) -> String {
+    let args = args
+        .iter()
+        .map(|arg| lower_cfg_expr(arg, feature_lists))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{name}({args})")
+}
+
+fn lower_cfg_literal(
+    coord: usize,
+    values: &BTreeSet<usize>,
+    feature_lists: &[Vec<String>],
+) -> String {
+    let domain_size = feature_lists[coord].len();
+    if values.is_empty() {
+        return "any()".to_string();
+    }
+    if values.len() == domain_size {
+        return "all()".to_string();
+    }
+    if values.len() == 1 {
+        return feature_clause(&feature_lists[coord][*values.iter().next().unwrap()]);
+    }
+
+    let positive_cost = values.len() + 1;
+    let excluded = (0..domain_size)
+        .filter(|value| !values.contains(value))
+        .collect::<Vec<_>>();
+    let negative_cost = match excluded.len() {
+        0 => 1,
+        1 => 2,
+        count => count + 2,
+    };
+
+    if positive_cost <= negative_cost {
+        let clauses = values
+            .iter()
+            .map(|value| feature_clause(&feature_lists[coord][*value]))
+            .collect::<Vec<_>>();
+        lower_cfg_primitive_or(&clauses)
+    } else if excluded.len() == 1 {
+        format!(
+            "not({})",
+            feature_clause(&feature_lists[coord][excluded[0]])
+        )
+    } else {
+        let clauses = excluded
+            .into_iter()
+            .map(|value| feature_clause(&feature_lists[coord][value]))
+            .collect::<Vec<_>>();
+        format!("not({})", lower_cfg_primitive_or(&clauses))
+    }
+}
+
+fn lower_cfg_primitive_or(clauses: &[String]) -> String {
+    match clauses {
+        [] => "any()".to_string(),
+        [clause] => clause.clone(),
+        _ => format!("any({})", clauses.join(", ")),
+    }
+}
+
+fn feature_clause(feature: &str) -> String {
+    format!("feature = {feature:?}")
 }
 
 fn parse_rust_file(path: &Path) -> Result<ParsedRustFile, String> {
@@ -578,11 +651,55 @@ fn parse_rust_file(path: &Path) -> Result<ParsedRustFile, String> {
     Ok(ParsedRustFile { inner_attrs, items })
 }
 
-fn cfg_condition(features: &[String]) -> String {
-    let clauses = features
-        .iter()
-        .map(|feature| format!("feature = {feature:?}"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!("all({clauses})")
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        path::PathBuf,
+    };
+
+    use super::{Translation, merged_cfg_attribute};
+
+    fn translation(config: &[(&str, &str)]) -> Translation {
+        let config = config
+            .iter()
+            .map(|(param, value)| (param.to_string(), value.to_string()))
+            .collect::<BTreeMap<_, _>>();
+        let features = config
+            .iter()
+            .map(|(param, value)| {
+                super::make_feature_name(param, value).expect("test config is valid")
+            })
+            .collect::<Vec<_>>();
+
+        Translation {
+            dir: PathBuf::new(),
+            config,
+            features,
+        }
+    }
+
+    #[test]
+    fn merged_cfg_attribute_uses_cofactor_simplification() {
+        let translations = vec![
+            translation(&[("os", "linux"), ("arch", "x86")]),
+            translation(&[("os", "linux"), ("arch", "arm")]),
+            translation(&[("os", "mac"), ("arch", "x86")]),
+            translation(&[("os", "mac"), ("arch", "arm")]),
+        ];
+        let variants = vec![
+            (0, PathBuf::from("linux-x86.rs")),
+            (1, PathBuf::from("linux-arm.rs")),
+            (2, PathBuf::from("mac-x86.rs")),
+            (3, PathBuf::from("mac-arm.rs")),
+        ];
+        let mut item_variants = BTreeMap::<String, BTreeSet<usize>>::new();
+        item_variants.insert(
+            "fn shared() {}".to_string(),
+            [0usize, 1usize].into_iter().collect(),
+        );
+
+        let cfg = merged_cfg_attribute("fn shared() {}", &item_variants, &translations, &variants);
+        assert_eq!(cfg, Some("#[cfg(feature = \"os_linux\")]".to_string()));
+    }
 }

--- a/crates/merger/src/lib.rs
+++ b/crates/merger/src/lib.rs
@@ -1,0 +1,476 @@
+#![feature(rustc_private)]
+
+extern crate rustc_ast;
+extern crate rustc_ast_pretty;
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ffi::{OsStr, OsString},
+    fmt::Write as _,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use rustc_ast::AttrStyle;
+use rustc_ast_pretty::pprust;
+use serde::Deserialize;
+use serde_json::Value;
+use toml_edit::{Array, DocumentMut, Item, Table, value};
+
+#[derive(Deserialize)]
+struct RawTranslation {
+    dir: PathBuf,
+    #[serde(flatten)]
+    config: BTreeMap<String, Value>,
+}
+
+struct Translation {
+    dir: PathBuf,
+    features: Vec<String>,
+}
+
+struct SharedFile {
+    name: &'static str,
+    contents: Vec<u8>,
+}
+
+struct ParsedRustFile {
+    inner_attrs: Vec<String>,
+    items: Vec<String>,
+}
+
+pub fn merge(translations_json: &Path, output_root: &Path) -> Result<(), String> {
+    let translations = load_translations(translations_json)?;
+    let common_dir_name = common_dir_name(&translations)?;
+
+    if output_root.exists() && !output_root.is_dir() {
+        return Err(format!("{output_root:?} is not a directory"));
+    }
+    fs::create_dir_all(output_root)
+        .map_err(|e| format!("failed to create {output_root:?}: {e}"))?;
+
+    let output_dir = output_root.join(&common_dir_name);
+    if output_dir.exists() && !output_dir.is_dir() {
+        return Err(format!("{output_dir:?} is not a directory"));
+    }
+    fs::create_dir_all(&output_dir).map_err(|e| format!("failed to create {output_dir:?}: {e}"))?;
+    clean_output_dir(&output_dir)?;
+
+    let cargo_toml = shared_required_file(&translations, "Cargo.toml")?;
+    let build_rs = shared_optional_file(&translations, "build.rs")?;
+    let toolchain = shared_toolchain_file(&translations)?;
+
+    write_shared_file(&output_dir, &cargo_toml)?;
+    add_features_to_cargo_toml(&output_dir.join("Cargo.toml"), feature_union(&translations))?;
+    if let Some(file) = build_rs.as_ref() {
+        write_shared_file(&output_dir, file)?;
+    }
+    if let Some(file) = toolchain.as_ref() {
+        write_shared_file(&output_dir, file)?;
+    }
+
+    for (relative_path, variants) in collect_source_files(&translations)? {
+        write_merged_rust_file(&output_dir.join(relative_path), &translations, &variants)?;
+    }
+
+    Ok(())
+}
+
+fn load_translations(translations_json: &Path) -> Result<Vec<Translation>, String> {
+    let content = fs::read_to_string(translations_json)
+        .map_err(|e| format!("failed to read {translations_json:?}: {e}"))?;
+    let raw: Vec<RawTranslation> = serde_json::from_str(&content)
+        .map_err(|e| format!("failed to parse {translations_json:?}: {e}"))?;
+    if raw.is_empty() {
+        return Err(format!(
+            "{translations_json:?} does not contain any translations"
+        ));
+    }
+
+    let base_dir = translations_json.parent().unwrap_or_else(|| Path::new("."));
+    let expected_keys: BTreeSet<String> = raw[0].config.keys().cloned().collect();
+    let mut feature_map = BTreeMap::<String, (String, String)>::new();
+    let mut seen_feature_sets = BTreeSet::<Vec<String>>::new();
+    let mut translations = Vec::with_capacity(raw.len());
+
+    for (index, entry) in raw.into_iter().enumerate() {
+        let keys: BTreeSet<String> = entry.config.keys().cloned().collect();
+        if keys != expected_keys {
+            return Err(format!(
+                "translation {} has different configuration parameters",
+                index + 1
+            ));
+        }
+
+        let dir = resolve_dir(base_dir, &entry.dir);
+        if !dir.is_dir() {
+            return Err(format!("{dir:?} is not a directory"));
+        }
+
+        let mut features = Vec::with_capacity(entry.config.len());
+        for (param, value) in entry.config {
+            let raw_value = config_value_to_string(&param, &value)?;
+            let feature = make_feature_name(&param, &raw_value)?;
+            if let Some((existing_param, existing_value)) = feature_map.get(&feature) {
+                if existing_param != &param || existing_value != &raw_value {
+                    return Err(format!(
+                        "feature name collision: {feature:?} maps to both {existing_param}={existing_value} and {param}={raw_value}"
+                    ));
+                }
+            } else {
+                feature_map.insert(feature.clone(), (param, raw_value));
+            }
+            features.push(feature);
+        }
+        if !seen_feature_sets.insert(features.clone()) {
+            return Err(format!(
+                "duplicate configuration detected for translation directory {dir:?}"
+            ));
+        }
+        translations.push(Translation { dir, features });
+    }
+
+    Ok(translations)
+}
+
+fn resolve_dir(base_dir: &Path, dir: &Path) -> PathBuf {
+    if dir.is_absolute() {
+        dir.to_path_buf()
+    } else {
+        base_dir.join(dir)
+    }
+}
+
+fn config_value_to_string(param: &str, value: &Value) -> Result<String, String> {
+    match value {
+        Value::String(s) => Ok(s.clone()),
+        Value::Bool(b) => Ok(b.to_string()),
+        Value::Number(n) => Ok(n.to_string()),
+        _ => Err(format!(
+            "configuration value for {param:?} must be a string, number, or boolean"
+        )),
+    }
+}
+
+fn make_feature_name(param: &str, value: &str) -> Result<String, String> {
+    let param = normalize_feature_component(param)?;
+    let value = normalize_feature_component(value)?;
+    Ok(format!("{param}_{value}"))
+}
+
+fn normalize_feature_component(component: &str) -> Result<String, String> {
+    let mut normalized = String::new();
+    let mut previous_underscore = false;
+    for ch in component.chars() {
+        let ch = ch.to_ascii_lowercase();
+        if ch.is_ascii_alphanumeric() {
+            normalized.push(ch);
+            previous_underscore = false;
+        } else if ch == '_' && !previous_underscore {
+            normalized.push(ch);
+            previous_underscore = true;
+        } else if !previous_underscore && !normalized.is_empty() {
+            normalized.push('_');
+            previous_underscore = true;
+        }
+    }
+    while normalized.ends_with('_') {
+        normalized.pop();
+    }
+    if normalized.is_empty() {
+        return Err(format!(
+            "cannot derive a cargo feature component from {component:?}"
+        ));
+    }
+    Ok(normalized)
+}
+
+fn common_dir_name(translations: &[Translation]) -> Result<OsString, String> {
+    let first_name = translations[0]
+        .dir
+        .file_name()
+        .ok_or_else(|| format!("{:?} does not have a directory name", translations[0].dir))?
+        .to_os_string();
+    for translation in &translations[1..] {
+        let name = translation
+            .dir
+            .file_name()
+            .ok_or_else(|| format!("{:?} does not have a directory name", translation.dir))?;
+        if name != first_name {
+            return Err("translation directories must share the same final component".to_string());
+        }
+    }
+    Ok(first_name)
+}
+
+fn shared_required_file(
+    translations: &[Translation],
+    name: &'static str,
+) -> Result<SharedFile, String> {
+    let first_path = translations[0].dir.join(name);
+    let first_contents =
+        fs::read(&first_path).map_err(|e| format!("failed to read {first_path:?}: {e}"))?;
+    for translation in &translations[1..] {
+        let path = translation.dir.join(name);
+        let contents = fs::read(&path).map_err(|e| format!("failed to read {path:?}: {e}"))?;
+        if contents != first_contents {
+            return Err(format!("{name} differs across translation directories"));
+        }
+    }
+    Ok(SharedFile {
+        name,
+        contents: first_contents,
+    })
+}
+
+fn shared_optional_file(
+    translations: &[Translation],
+    name: &'static str,
+) -> Result<Option<SharedFile>, String> {
+    let first_path = translations[0].dir.join(name);
+    let first_contents = if first_path.exists() {
+        Some(fs::read(&first_path).map_err(|e| format!("failed to read {first_path:?}: {e}"))?)
+    } else {
+        None
+    };
+
+    for translation in &translations[1..] {
+        let path = translation.dir.join(name);
+        let contents = if path.exists() {
+            Some(fs::read(&path).map_err(|e| format!("failed to read {path:?}: {e}"))?)
+        } else {
+            None
+        };
+        if contents != first_contents {
+            return Err(format!("{name} differs across translation directories"));
+        }
+    }
+
+    Ok(first_contents.map(|contents| SharedFile { name, contents }))
+}
+
+fn shared_toolchain_file(translations: &[Translation]) -> Result<Option<SharedFile>, String> {
+    let first = detect_toolchain_file(&translations[0].dir)?;
+    for translation in &translations[1..] {
+        let candidate = detect_toolchain_file(&translation.dir)?;
+        match (&first, &candidate) {
+            (None, None) => {}
+            (Some(lhs), Some(rhs)) if lhs.name == rhs.name && lhs.contents == rhs.contents => {}
+            _ => return Err("toolchain file differs across translation directories".to_string()),
+        }
+    }
+    Ok(first)
+}
+
+fn detect_toolchain_file(dir: &Path) -> Result<Option<SharedFile>, String> {
+    let mut matches = Vec::new();
+    for name in ["rust-toolchain", "rust-toolchain.toml"] {
+        let path = dir.join(name);
+        if path.exists() {
+            let contents = fs::read(&path).map_err(|e| format!("failed to read {path:?}: {e}"))?;
+            matches.push(SharedFile { name, contents });
+        }
+    }
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        _ => Err(format!(
+            "{dir:?} contains both rust-toolchain and rust-toolchain.toml"
+        )),
+    }
+}
+
+fn write_shared_file(output_dir: &Path, file: &SharedFile) -> Result<(), String> {
+    let path = output_dir.join(file.name);
+    fs::write(&path, &file.contents).map_err(|e| format!("failed to write {path:?}: {e}"))
+}
+
+fn feature_union(translations: &[Translation]) -> Vec<String> {
+    let mut features = BTreeSet::new();
+    for translation in translations {
+        features.extend(translation.features.iter().cloned());
+    }
+    features.into_iter().collect()
+}
+
+fn add_features_to_cargo_toml(cargo_toml: &Path, features: Vec<String>) -> Result<(), String> {
+    let content = fs::read_to_string(cargo_toml)
+        .map_err(|e| format!("failed to read {cargo_toml:?}: {e}"))?;
+    let mut doc = content
+        .parse::<DocumentMut>()
+        .map_err(|e| format!("failed to parse {cargo_toml:?}: {e}"))?;
+
+    if !doc.contains_key("features") {
+        doc.insert("features", Item::Table(Table::new()));
+    }
+    let feature_table = doc
+        .get_mut("features")
+        .and_then(Item::as_table_mut)
+        .ok_or_else(|| format!("{cargo_toml:?} has a non-table [features] entry"))?;
+
+    for feature in features {
+        if !feature_table.contains_key(&feature) {
+            feature_table[&feature] = value(Array::default());
+        }
+    }
+
+    fs::write(cargo_toml, doc.to_string())
+        .map_err(|e| format!("failed to write {cargo_toml:?}: {e}"))
+}
+
+fn clean_output_dir(dir: &Path) -> Result<(), String> {
+    remove_named_file(dir.join("Cargo.toml"))?;
+    remove_named_file(dir.join("Cargo.lock"))?;
+    remove_named_file(dir.join("rust-toolchain"))?;
+    remove_named_file(dir.join("rust-toolchain.toml"))?;
+    remove_rs_files(dir)?;
+    Ok(())
+}
+
+fn remove_named_file(path: PathBuf) -> Result<(), String> {
+    if path.exists() {
+        fs::remove_file(&path).map_err(|e| format!("failed to remove {path:?}: {e}"))?;
+    }
+    Ok(())
+}
+
+fn remove_rs_files(dir: &Path) -> Result<(), String> {
+    let mut entries = read_dir_sorted(dir)?;
+    for entry in entries.drain(..) {
+        let path = entry.path();
+        let name = entry.file_name();
+        if path.is_dir() {
+            if name == OsStr::new("target") {
+                continue;
+            }
+            remove_rs_files(&path)?;
+            if fs::read_dir(&path)
+                .map_err(|e| format!("failed to read {path:?}: {e}"))?
+                .next()
+                .is_none()
+            {
+                fs::remove_dir(&path).map_err(|e| format!("failed to remove {path:?}: {e}"))?;
+            }
+        } else if path.extension() == Some(OsStr::new("rs")) {
+            fs::remove_file(&path).map_err(|e| format!("failed to remove {path:?}: {e}"))?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_source_files(
+    translations: &[Translation],
+) -> Result<BTreeMap<PathBuf, Vec<(usize, PathBuf)>>, String> {
+    let mut grouped = BTreeMap::<PathBuf, Vec<(usize, PathBuf)>>::new();
+    for (index, translation) in translations.iter().enumerate() {
+        let mut files = Vec::new();
+        collect_rs_files(&translation.dir, &translation.dir, &mut files)?;
+        for relative_path in files {
+            grouped
+                .entry(relative_path.clone())
+                .or_default()
+                .push((index, translation.dir.join(relative_path)));
+        }
+    }
+    Ok(grouped)
+}
+
+fn collect_rs_files(dir: &Path, root: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
+    for entry in read_dir_sorted(dir)? {
+        let path = entry.path();
+        let name = entry.file_name();
+        if path.is_dir() {
+            if name == OsStr::new("target") {
+                continue;
+            }
+            collect_rs_files(&path, root, files)?;
+        } else if path.extension() == Some(OsStr::new("rs")) && name != OsStr::new("build.rs") {
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|e| format!("failed to compute relative path for {path:?}: {e}"))?;
+            files.push(relative.to_path_buf());
+        }
+    }
+    Ok(())
+}
+
+fn read_dir_sorted(dir: &Path) -> Result<Vec<fs::DirEntry>, String> {
+    let mut entries = fs::read_dir(dir)
+        .map_err(|e| format!("failed to read {dir:?}: {e}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("failed to read {dir:?}: {e}"))?;
+    entries.sort_by_key(|entry| entry.path());
+    Ok(entries)
+}
+
+fn write_merged_rust_file(
+    output_path: &Path,
+    translations: &[Translation],
+    variants: &[(usize, PathBuf)],
+) -> Result<(), String> {
+    let mut shared_inner_attrs: Option<Vec<String>> = None;
+    let mut merged = String::new();
+
+    for (index, path) in variants {
+        let parsed = parse_rust_file(path)?;
+        if let Some(existing) = shared_inner_attrs.as_ref() {
+            if existing != &parsed.inner_attrs {
+                return Err(format!(
+                    "inner attributes differ for merged file {output_path:?}"
+                ));
+            }
+        } else {
+            shared_inner_attrs = Some(parsed.inner_attrs.clone());
+        }
+
+        let cfg = cfg_attribute(&translations[*index].features);
+        for item in parsed.items {
+            writeln!(merged, "{cfg}").unwrap();
+            writeln!(merged, "{item}").unwrap();
+        }
+    }
+
+    let mut code = String::new();
+    if let Some(inner_attrs) = shared_inner_attrs {
+        for attr in inner_attrs {
+            writeln!(code, "{attr}").unwrap();
+        }
+        if !code.is_empty() && !merged.is_empty() {
+            code.push('\n');
+        }
+    }
+    code.push_str(&merged);
+
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("failed to create {parent:?}: {e}"))?;
+    }
+    fs::write(output_path, code).map_err(|e| format!("failed to write {output_path:?}: {e}"))
+}
+
+fn parse_rust_file(path: &Path) -> Result<ParsedRustFile, String> {
+    let source = fs::read_to_string(path).map_err(|e| format!("failed to read {path:?}: {e}"))?;
+    let krate = std::panic::catch_unwind(|| utils::ast::parse_crate(source))
+        .map_err(|_| format!("failed to parse {path:?}"))?;
+
+    let inner_attrs = krate
+        .attrs
+        .iter()
+        .filter(|attr| attr.style == AttrStyle::Inner)
+        .map(pprust::attribute_to_string)
+        .collect();
+    let items = krate
+        .items
+        .iter()
+        .map(|item| pprust::item_to_string(item))
+        .collect();
+    Ok(ParsedRustFile { inner_attrs, items })
+}
+
+fn cfg_attribute(features: &[String]) -> String {
+    let clauses = features
+        .iter()
+        .map(|feature| format!("feature = {feature:?}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("#[cfg(all({clauses}))]")
+}

--- a/src/bin/crat-merge.rs
+++ b/src/bin/crat-merge.rs
@@ -21,5 +21,6 @@ fn main() {
             eprintln!("{e}");
             std::process::exit(1);
         }
-    }).unwrap();
+    })
+    .unwrap();
 }

--- a/src/bin/crat-merge.rs
+++ b/src/bin/crat-merge.rs
@@ -1,0 +1,25 @@
+#![feature(rustc_private)]
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(version)]
+struct Args {
+    #[arg(help = "Path to translations.json")]
+    translations: PathBuf,
+
+    #[arg(help = "Directory under which the merged crate will be created")]
+    output: PathBuf,
+}
+
+fn main() {
+    let args = Args::parse();
+    utils::compilation::run_compiler_on_str("fn main() {}", |_| {
+        if let Err(e) = merger::merge(&args.translations, &args.output) {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    }).unwrap();
+}


### PR DESCRIPTION
## Summary
- Introduces the `crat-merge` tool for merging items across build configurations
- Deduplicates merged items by cfg set and simplifies/omits constant cfg conditions
- Adds a globals bucket to merger item ordering

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)