### PR TITLE
Add translation and tests on negative offset boxes

### DIFF
--- a/crates/pointer_replacer/src/rewriter/decision.rs
+++ b/crates/pointer_replacer/src/rewriter/decision.rs
@@ -166,7 +166,7 @@ impl<'tcx> DecisionMaker<'tcx> {
         }) {
             Some(PtrKind::Raw(self.mutable_pointers[local]))
         } else if self._owning_pointers[local] && self.array_pointers[local] {
-            if self.needs_cursor.contains(local) || is_local_struct {
+            if is_local_struct {
                 Some(PtrKind::Raw(self.mutable_pointers[local]))
             } else if self._output_params.contains(local) {
                 Some(PtrKind::Slice(true))
@@ -541,18 +541,18 @@ pub unsafe fn foo(p: {pointer_ty}) {{
     }
 
     #[test]
-    fn owning_array_output_with_cursor_need_stays_raw() {
+    fn owning_array_output_with_cursor_need_stays_mut_slice() {
         assert_eq!(
             decide_for_param(true, true, true, true, false, false, true),
-            PtrKind::Raw(true)
+            PtrKind::Slice(true)
         );
     }
 
     #[test]
-    fn owning_array_non_output_with_cursor_need_stays_raw() {
+    fn owning_array_non_output_with_cursor_need_becomes_opt_boxed_slice() {
         assert_eq!(
             decide_for_param(true, false, true, true, false, false, true),
-            PtrKind::Raw(true)
+            PtrKind::OptBoxedSlice
         );
     }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -3330,7 +3330,7 @@ pub unsafe fn consume(mut end: *mut i32, mut count: i32) -> i32 {
     sum
 }
 
-pub unsafe fn demo() -> i32 {
+pub unsafe fn foo() -> i32 {
     let mut array_size: i32 = 5;
     let mut data_array: *mut i32 =
         malloc(array_size as usize * std::mem::size_of::<i32>()) as *mut i32;
@@ -3349,8 +3349,96 @@ pub unsafe fn demo() -> i32 {
     sum
 }
 "#,
-        &["SliceCursor::with_pos(", ".as_deref().unwrap_or(&[])"],
+        &[
+            "let mut data_array: Option<Box<[i32]>>",
+            "SliceCursor::with_pos(",
+            ".as_deref().unwrap_or(&[])",
+        ],
         &["SliceCursor::with_pos(&data_array"],
+    );
+}
+
+#[test]
+fn test_owned_malloc_array_negative_offset_borrows_boxed_slice_as_cursor() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+}
+
+pub unsafe fn foo() -> i32 {
+    let mut data_array: *mut i32 = malloc(5 * std::mem::size_of::<i32>()) as *mut i32;
+    if data_array.is_null() {
+        return -1;
+    }
+    let mut i: i32 = 0;
+    while i < 5 {
+        *data_array.offset(i as isize) = i + 1;
+        i += 1;
+    }
+    let mut tail: *mut i32 = data_array.offset(4 as isize);
+    *tail.offset(-2 as isize)
+}
+"#,
+        &[
+            "let mut data_array: Option<Box<[i32]>>",
+            "SliceCursor::with_pos(",
+            ".as_deref().unwrap_or(&[])",
+        ],
+        &[
+            "let mut data_array: *mut i32",
+            "let mut tail: *mut i32",
+            "SliceCursor::with_pos(&data_array",
+        ],
+    );
+}
+
+#[test]
+fn test_inline_offset_call_arg_borrows_boxed_slice_as_cursor() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe fn consume(mut end: *mut i32, mut count: i32) -> i32 {
+    let mut sum: i32 = 0;
+    while count > 0 {
+        sum += *end;
+        end = end.offset(-1);
+        count -= 1;
+    }
+    sum
+}
+
+pub unsafe fn foo() -> i32 {
+    let mut array_size: i32 = 5;
+    let mut data_array: *mut i32 =
+        malloc(array_size as usize * std::mem::size_of::<i32>()) as *mut i32;
+    if data_array.is_null() {
+        return -1;
+    }
+    let mut i: i32 = 0;
+    while i < array_size {
+        *data_array.offset(i as isize) = i + 1;
+        i += 1;
+    }
+    let sum = consume(data_array.offset((array_size as isize) + -(1 as isize)), array_size);
+    free(data_array as *mut core::ffi::c_void);
+    sum
+}
+"#,
+        &[
+            "let mut data_array: Option<Box<[i32]>>",
+            "consume(crate::slice_cursor::SliceCursor::with_pos(",
+            ".as_deref().unwrap_or(&[])",
+        ],
+        &[
+            "let mut last_element:",
+            "SliceCursor::with_pos(&data_array",
+            "consume(data_array.offset(",
+        ],
     );
 }
 


### PR DESCRIPTION
## Summary

- Convert owning array pointers with negative offset accesses (`needs_cursor`) into `OptBoxedSlice`
  - This should be okay, since `.offsets` calls are treated as a borrow, there should be SliceCursor conversion between box and offset calls (`OptBoxedSlice` -> `SliceCursor` -> offset call)
- Added new tests in `tests.rs` to verify that owned malloc'd arrays with negative offsets are correctly transformed to use boxed slices and slice cursors.

## Test
Same number of test case failure compared to master

- Test Cases Discovered:      338
- Test Cases Skipped:         2
- Test Cases Tested:          331
- Test Cases Failed:          37