### PR TITLE
Implement struct array field analysis

### DIFF
--- a/crates/pointer_replacer/src/analyses/mod.rs
+++ b/crates/pointer_replacer/src/analyses/mod.rs
@@ -7,4 +7,5 @@ pub mod mir_variable_grouping;
 pub mod offset_sign;
 pub(crate) mod output_params;
 pub mod ownership;
+pub mod struct_array_field;
 pub mod type_qualifier;

--- a/crates/pointer_replacer/src/analyses/struct_array_field.rs
+++ b/crates/pointer_replacer/src/analyses/struct_array_field.rs
@@ -1,0 +1,569 @@
+use points_to::andersen::{self, LocEdges, LocNode};
+use rustc_abi::Size;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_middle::{
+    mir::{BinOp, Body, Operand, Place, PlaceElem, Rvalue, StatementKind, TerminatorKind},
+    ty::{self, TyCtxt},
+};
+use rustc_span::{Symbol, def_id::LocalDefId};
+
+use crate::utils::rustc::RustProgram;
+
+/// a group of consecutive same-typed fields in a struct to merge into a single array field
+#[derive(Clone)]
+pub struct FieldGroup {
+    /// index of the first field in the group within the struct's field list
+    pub start_idx: usize,
+    /// number of consecutive same-typed fields (>= 2)
+    pub count: usize,
+    /// original names of the fields, in field definition order
+    pub field_names: Vec<Symbol>,
+}
+
+impl FieldGroup {
+    /// the name to use for the new array field (first field's name)
+    pub fn array_name(&self) -> Symbol {
+        self.field_names[0]
+    }
+
+    /// index within this group for a given original field name, if it belongs here
+    pub fn group_index(&self, name: Symbol) -> Option<usize> {
+        self.field_names.iter().position(|n| *n == name)
+    }
+}
+
+/// maps struct LocalDefId to the list of field groups to merge into arrays
+pub type StructRewriteCandidates = FxHashMap<LocalDefId, Vec<FieldGroup>>;
+
+pub fn find_candidates(
+    input: &RustProgram<'_>,
+    points_to: &andersen::AnalysisResult,
+) -> StructRewriteCandidates {
+    let tcx = input.tcx;
+    let candidates = select_candidates(input);
+    let mut field_to_group = FxHashMap::default();
+    let mut group_to_field_ty = FxHashMap::default();
+    for (&struct_did, groups) in &candidates {
+        let struct_ty = tcx.type_of(struct_did).skip_binder();
+        let ty::TyKind::Adt(adt_def, args) = struct_ty.kind() else {
+            continue;
+        };
+        for group in groups {
+            let field_ty = adt_def
+                .all_fields()
+                .nth(group.start_idx)
+                .expect("candidate field index must be valid")
+                .ty(tcx, args);
+            group_to_field_ty.insert((struct_did, group.start_idx), field_ty);
+            for field_idx in group.start_idx..group.start_idx + group.count {
+                field_to_group.insert((struct_did, field_idx), group.start_idx);
+            }
+        }
+    }
+
+    let mut field_ranges: FxHashMap<(LocalDefId, usize), Vec<LocRange>> = FxHashMap::default();
+    let mut offset_ranges = Vec::new();
+
+    for &fn_did in &input.functions {
+        let body = tcx.mir_drops_elaborated_and_const_checked(fn_did).borrow();
+        collect_field_ranges(
+            tcx,
+            fn_did,
+            &body,
+            points_to,
+            &field_to_group,
+            &mut field_ranges,
+        );
+        collect_offset_ranges(tcx, fn_did, &body, points_to, &mut offset_ranges);
+    }
+
+    let mut rewrite_groups = FxHashSet::default();
+    for (group_key, ranges) in &field_ranges {
+        let Some(&field_ty) = group_to_field_ty.get(group_key) else {
+            continue;
+        };
+        if ranges.iter().any(|field_range| {
+            offset_ranges.iter().any(|offset_range| {
+                ranges_overlap(*field_range, offset_range.range)
+                    && types_are_compatible(field_ty, offset_range.pointee_ty)
+            })
+        }) {
+            rewrite_groups.insert(*group_key);
+        }
+    }
+
+    let mut rewrite_targets = FxHashMap::default();
+    for (struct_did, groups) in candidates {
+        let groups: Vec<_> = groups
+            .into_iter()
+            .filter(|group| rewrite_groups.contains(&(struct_did, group.start_idx)))
+            .collect();
+        if !groups.is_empty() {
+            rewrite_targets.insert(struct_did, groups);
+        }
+    }
+
+    rewrite_targets
+}
+
+#[derive(Clone, Copy)]
+struct LocRange {
+    start: andersen::Loc,
+    end: andersen::Loc,
+}
+
+#[derive(Clone, Copy)]
+struct OffsetRange<'tcx> {
+    range: LocRange,
+    pointee_ty: ty::Ty<'tcx>,
+}
+
+fn select_candidates(input: &RustProgram<'_>) -> StructRewriteCandidates {
+    let tcx = input.tcx;
+    let mut candidates = FxHashMap::default();
+
+    for &struct_did in &input.structs {
+        let struct_ty = tcx.type_of(struct_did).skip_binder();
+        let ty::TyKind::Adt(adt_def, args) = struct_ty.kind() else {
+            continue;
+        };
+        let repr = adt_def.repr();
+        if !adt_def.is_struct()
+            || adt_def.is_union()
+            || !adt_def.did().is_local()
+            || !repr.c()
+            || repr.pack.is_some()
+        {
+            continue;
+        }
+
+        let fields: Vec<_> = adt_def.all_fields().collect();
+        let mut groups = Vec::new();
+        let mut start = 0;
+        while start < fields.len() {
+            let field_ty = fields[start].ty(tcx, args);
+            let mut end = start + 1;
+            while end < fields.len() && fields[end].ty(tcx, args) == field_ty {
+                end += 1;
+            }
+
+            if end - start >= 2
+                && candidate_element_ty_is_safe(tcx, struct_did, field_ty)
+                && layout_is_contiguous(tcx, struct_did, struct_ty, &fields, start, end)
+            {
+                groups.push(FieldGroup {
+                    start_idx: start,
+                    count: end - start,
+                    field_names: fields[start..end].iter().map(|f| f.name).collect(),
+                });
+            }
+            start = end;
+        }
+
+        if !groups.is_empty() {
+            candidates.insert(struct_did, groups);
+        }
+    }
+
+    candidates
+}
+
+fn types_are_compatible<'tcx>(field_ty: ty::Ty<'tcx>, pointee_ty: ty::Ty<'tcx>) -> bool {
+    field_ty == pointee_ty
+}
+
+fn candidate_element_ty_is_safe<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    owner: LocalDefId,
+    ty: ty::Ty<'tcx>,
+) -> bool {
+    let typing_env = ty::TypingEnv::post_analysis(tcx, owner);
+    let Ok(layout) = tcx.layout_of(typing_env.as_query_input(ty)) else {
+        return false;
+    };
+    if layout.size == Size::ZERO {
+        return false;
+    }
+
+    match ty.kind() {
+        ty::TyKind::Array(..)
+        | ty::TyKind::Slice(_)
+        | ty::TyKind::Str
+        | ty::TyKind::Dynamic(..)
+        | ty::TyKind::Tuple(_)
+        | ty::TyKind::Closure(..)
+        | ty::TyKind::CoroutineClosure(..)
+        | ty::TyKind::Coroutine(..)
+        | ty::TyKind::CoroutineWitness(..)
+        | ty::TyKind::Foreign(_) => false,
+        ty::TyKind::Adt(adt_def, _) => {
+            let repr = adt_def.repr();
+            adt_def.is_struct()
+                && !adt_def.is_union()
+                && adt_def.did().is_local()
+                && repr.c()
+                && repr.pack.is_none()
+                && tcx.type_is_copy_modulo_regions(typing_env, ty)
+        }
+        _ => true,
+    }
+}
+
+fn layout_is_contiguous<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    owner: LocalDefId,
+    struct_ty: ty::Ty<'tcx>,
+    fields: &[&rustc_middle::ty::FieldDef],
+    start: usize,
+    end: usize,
+) -> bool {
+    let typing_env = ty::TypingEnv::post_analysis(tcx, owner);
+    let Ok(struct_layout) = tcx.layout_of(typing_env.as_query_input(struct_ty)) else {
+        return false;
+    };
+    let ty::TyKind::Adt(_, args) = struct_ty.kind() else {
+        return false;
+    };
+    let elem_ty = fields[start].ty(tcx, args);
+    let Ok(elem_layout) = tcx.layout_of(typing_env.as_query_input(elem_ty)) else {
+        return false;
+    };
+    let elem_size = elem_layout.size;
+    if elem_size == Size::ZERO {
+        return false;
+    }
+
+    let first_offset = struct_layout.fields.offset(start);
+    for (pos, field_idx) in (start..end).enumerate() {
+        let field_ty = fields[field_idx].ty(tcx, args);
+        let Ok(field_layout) = tcx.layout_of(typing_env.as_query_input(field_ty)) else {
+            return false;
+        };
+        if field_layout.size != elem_size {
+            return false;
+        }
+        if struct_layout.fields.offset(field_idx) != first_offset + elem_size * pos as u64 {
+            return false;
+        }
+    }
+    true
+}
+
+fn collect_field_ranges<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    fn_did: LocalDefId,
+    body: &Body<'tcx>,
+    points_to: &andersen::AnalysisResult,
+    field_to_group: &FxHashMap<(LocalDefId, usize), usize>,
+    field_ranges: &mut FxHashMap<(LocalDefId, usize), Vec<LocRange>>,
+) {
+    for block in body.basic_blocks.iter() {
+        for statement in &block.statements {
+            let StatementKind::Assign(box (_, Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place))) =
+                &statement.kind
+            else {
+                continue;
+            };
+            let Some((struct_did, field_idx)) = candidate_field_from_place(body, place) else {
+                continue;
+            };
+            let Some(&group_start) = field_to_group.get(&(struct_did, field_idx)) else {
+                continue;
+            };
+
+            for loc in alias_target_locs_with_tys(points_to, body, tcx, fn_did, *place, 0) {
+                if let Some(end) = points_to.ends.get(loc).copied() {
+                    field_ranges
+                        .entry((struct_did, group_start))
+                        .or_default()
+                        .push(LocRange { start: loc, end });
+                }
+            }
+        }
+    }
+}
+
+fn collect_offset_ranges<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    fn_did: LocalDefId,
+    body: &Body<'tcx>,
+    points_to: &andersen::AnalysisResult,
+    offset_ranges: &mut Vec<OffsetRange<'tcx>>,
+) {
+    for block in body.basic_blocks.iter() {
+        for statement in &block.statements {
+            let StatementKind::Assign(box (_, Rvalue::BinaryOp(BinOp::Offset, box (ptr, _)))) =
+                &statement.kind
+            else {
+                continue;
+            };
+            collect_operand_pointees(tcx, fn_did, body, points_to, ptr, offset_ranges);
+        }
+
+        let TerminatorKind::Call { func, args, .. } = &block.terminator().kind else {
+            continue;
+        };
+        if !is_element_offset_call(tcx, func) {
+            continue;
+        }
+        if let Some(arg) = args.first() {
+            collect_operand_pointees(tcx, fn_did, body, points_to, &arg.node, offset_ranges);
+        }
+    }
+}
+
+fn collect_operand_pointees<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    fn_did: LocalDefId,
+    body: &Body<'tcx>,
+    points_to: &andersen::AnalysisResult,
+    operand: &Operand<'tcx>,
+    out: &mut Vec<OffsetRange<'tcx>>,
+) {
+    let Some(place) = operand.place() else {
+        return;
+    };
+    let Some(pointee_ty) = operand.ty(&body.local_decls, tcx).builtin_deref(true) else {
+        return;
+    };
+    for loc in alias_target_locs_with_tys(points_to, body, tcx, fn_did, place, 1) {
+        if let Some(end) = points_to.ends.get(loc).copied() {
+            out.push(OffsetRange {
+                range: LocRange { start: loc, end },
+                pointee_ty,
+            });
+        }
+    }
+}
+
+fn is_element_offset_call(tcx: TyCtxt<'_>, func: &Operand<'_>) -> bool {
+    let Some(func) = func.constant() else {
+        return false;
+    };
+    let ty::TyKind::FnDef(def_id, _) = func.ty().kind() else {
+        return false;
+    };
+    matches!(
+        tcx.item_name(*def_id).as_str(),
+        "offset" | "wrapping_offset"
+    ) && tcx.def_path_str(*def_id).contains("ptr::")
+}
+
+fn candidate_field_from_place<'tcx>(
+    body: &Body<'tcx>,
+    place: &Place<'tcx>,
+) -> Option<(LocalDefId, usize)> {
+    let mut base_ty = body.local_decls[place.local].ty;
+    let mut candidate = None;
+
+    for elem in place.projection {
+        match elem {
+            PlaceElem::Deref => {
+                base_ty = base_ty.builtin_deref(true)?;
+            }
+            PlaceElem::Field(field, field_ty) => {
+                if let ty::TyKind::Adt(adt_def, _) = base_ty.kind()
+                    && adt_def.is_struct()
+                    && !adt_def.is_union()
+                    && let Some(struct_did) = adt_def.did().as_local()
+                {
+                    candidate = Some((struct_did, field.index()));
+                }
+                base_ty = field_ty;
+            }
+            PlaceElem::Index(_) | PlaceElem::ConstantIndex { .. } | PlaceElem::Subslice { .. } => {
+                base_ty = base_ty.builtin_index()?;
+            }
+            PlaceElem::Downcast(_, _)
+            | PlaceElem::OpaqueCast(_)
+            | PlaceElem::UnwrapUnsafeBinder(_)
+            | PlaceElem::Subtype(_) => {}
+        }
+    }
+
+    candidate
+}
+
+fn project_nodes(
+    points_to: &andersen::AnalysisResult,
+    nodes: Vec<LocNode>,
+    elem: PlaceElem<'_>,
+) -> Vec<LocNode> {
+    let mut next = Vec::new();
+    match elem {
+        PlaceElem::Deref => {
+            for node in nodes {
+                if let Some(LocEdges::Deref(succs)) = points_to.graph.get(&node) {
+                    next.extend(succs.iter().copied());
+                    continue;
+                }
+                let p0 = LocNode {
+                    prefix: 0,
+                    index: node.index,
+                };
+                if let Some(LocEdges::Deref(succs)) = points_to.graph.get(&p0) {
+                    next.extend(succs.iter().copied());
+                }
+            }
+        }
+        PlaceElem::Field(field, _) => {
+            for node in nodes {
+                if let Some(LocEdges::Fields(succs)) = points_to.graph.get(&node)
+                    && field.index() < succs.len()
+                {
+                    next.push(succs[field]);
+                }
+            }
+        }
+        PlaceElem::Index(_) => {
+            for node in nodes {
+                if let Some(LocEdges::Index(succ)) = points_to.graph.get(&node) {
+                    next.push(*succ);
+                }
+            }
+        }
+        _ => {
+            next = nodes;
+        }
+    }
+
+    let mut seen = FxHashSet::default();
+    next.retain(|node| seen.insert(*node));
+    next
+}
+
+fn project_nodes_with_tys<'tcx>(
+    points_to: &andersen::AnalysisResult,
+    nodes: Vec<LocNode>,
+    elem: PlaceElem<'tcx>,
+    base_ty: ty::Ty<'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> Vec<LocNode> {
+    let mut next = project_nodes(points_to, nodes.clone(), elem);
+    if matches!(elem, PlaceElem::Field(_, _)) && next.is_empty() {
+        let PlaceElem::Field(field, _) = elem else { unreachable!() };
+        if let Some(offset) = field_offset_for_ty(tcx, base_ty, field.index()) {
+            next = nodes
+                .into_iter()
+                .filter_map(|node| {
+                    let index = node.index + offset;
+                    if index > points_to.ends[node.index] {
+                        return None;
+                    }
+                    Some(LocNode {
+                        prefix: node.prefix,
+                        index,
+                    })
+                })
+                .collect();
+        }
+    }
+    let mut seen = FxHashSet::default();
+    next.retain(|node| seen.insert(*node));
+    next
+}
+
+fn projected_ty<'tcx>(ty: ty::Ty<'tcx>, elem: PlaceElem<'tcx>) -> Option<ty::Ty<'tcx>> {
+    match elem {
+        PlaceElem::Deref => match ty.kind() {
+            ty::TyKind::Ref(_, inner, _) => Some(*inner),
+            ty::TyKind::RawPtr(inner, _) => Some(*inner),
+            _ => None,
+        },
+        PlaceElem::Field(_, field_ty) => Some(field_ty),
+        PlaceElem::Index(_) => match ty.kind() {
+            ty::TyKind::Array(inner, _) | ty::TyKind::Slice(inner) => Some(*inner),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn alias_target_locs_with_tys<'tcx>(
+    points_to: &andersen::AnalysisResult,
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+    place: Place<'tcx>,
+    implicit_deref_count: usize,
+) -> Vec<andersen::Loc> {
+    let Some(start) = points_to.var_nodes.get(&(def_id, place.local)) else {
+        return vec![];
+    };
+    let mut frontier = vec![*start];
+    let mut current_ty = body.local_decls[place.local].ty;
+
+    for elem in place.projection.iter() {
+        frontier = project_nodes_with_tys(points_to, frontier, elem, current_ty, tcx);
+        if frontier.is_empty() {
+            return vec![];
+        }
+        let Some(next_ty) = projected_ty(current_ty, elem) else {
+            return vec![];
+        };
+        current_ty = next_ty;
+    }
+
+    for _ in 0..implicit_deref_count {
+        let elem = PlaceElem::Deref;
+        frontier = project_nodes(points_to, frontier, elem);
+        if frontier.is_empty() {
+            return vec![];
+        }
+        let Some(next_ty) = projected_ty(current_ty, elem) else {
+            return vec![];
+        };
+        current_ty = next_ty;
+    }
+
+    let mut out = Vec::new();
+    let mut seen = FxHashSet::default();
+    for loc in frontier.into_iter().map(|node| node.index) {
+        if seen.insert(loc) {
+            out.push(loc);
+        }
+    }
+    out
+}
+
+fn field_offset_for_ty<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: ty::Ty<'tcx>,
+    field_index: usize,
+) -> Option<usize> {
+    let ty::TyKind::Adt(adt, args) = ty.kind() else {
+        return None;
+    };
+    if !adt.is_struct() && !adt.is_union() {
+        return None;
+    }
+    let mut offset = 0;
+    for (i, field) in adt.all_fields().enumerate() {
+        if i == field_index {
+            return Some(offset);
+        }
+        offset += ty_len(field.ty(tcx, args), tcx);
+    }
+    None
+}
+
+fn ty_len<'tcx>(ty: ty::Ty<'tcx>, tcx: TyCtxt<'tcx>) -> usize {
+    match ty.kind() {
+        ty::TyKind::Ref(_, _, _) | ty::TyKind::RawPtr(_, _) => 1,
+        ty::TyKind::Array(inner, len) => {
+            ty_len(*inner, tcx) * len.try_to_target_usize(tcx).unwrap_or(0) as usize
+        }
+        ty::TyKind::Adt(adt, args) => {
+            let mut len = 0;
+            for field in adt.all_fields() {
+                len += ty_len(field.ty(tcx, args), tcx);
+            }
+            len.max(1)
+        }
+        _ => 1,
+    }
+}
+
+fn ranges_overlap(a: LocRange, b: LocRange) -> bool {
+    a.start <= b.end && b.start <= a.end
+}

--- a/crates/pointer_replacer/src/lib.rs
+++ b/crates/pointer_replacer/src/lib.rs
@@ -22,12 +22,13 @@ extern crate rustc_mir_dataflow;
 extern crate rustc_span;
 extern crate rustc_type_ir;
 extern crate smallvec;
+extern crate thin_vec;
 
 mod analyses;
 mod rewriter;
 mod utils;
 
-pub use rewriter::{Config, replace_local_borrows};
+pub use rewriter::{Config, replace_local_borrows, rewrite_struct_arrays};
 
 #[cfg(test)]
 mod tests;

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -26,6 +26,7 @@ use crate::{
 
 mod collector;
 mod decision;
+mod struct_array_field_pre;
 mod transform;
 
 pub struct Analysis {
@@ -53,6 +54,7 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     let ast_to_hir = utils::ast::make_ast_to_hir(&mut krate, tcx);
     utils::ast::remove_unnecessary_items_from_ast(&mut krate);
 
+    let input = collect_input(tcx);
     let arena = typed_arena::Arena::new();
     let tss = utils::ty_shape::get_ty_shapes(&arena, tcx, false);
     let andersen_config = andersen::Config {
@@ -62,27 +64,6 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     let pre_points_to = andersen::pre_analyze(&andersen_config, &tss, tcx);
     let points_to = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
     let aliases = find_param_aliases(&pre_points_to, &points_to, tcx);
-
-    let mut functions = vec![];
-    let mut structs = vec![];
-    for maybe_owner in tcx.hir_crate(()).owners.iter() {
-        let Some(owner) = maybe_owner.as_owner() else {
-            continue;
-        };
-        let OwnerNode::Item(item) = owner.node() else {
-            continue;
-        };
-        match item.kind {
-            ItemKind::Fn { .. } => functions.push(item.owner_id.def_id),
-            ItemKind::Struct(..) => structs.push(item.owner_id.def_id),
-            _ => {}
-        };
-    }
-    let input = RustProgram {
-        tcx,
-        functions,
-        structs,
-    };
 
     let mutability_result =
         analyses::type_qualifier::foster::mutability::mutability_analysis(&input);
@@ -124,6 +105,57 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     }
 
     (code, visitor.bytemuck.get())
+}
+
+pub fn rewrite_struct_arrays(config: &Config, tcx: TyCtxt<'_>) -> (String, bool) {
+    let mut krate = utils::ast::expanded_ast(tcx);
+    let ast_to_hir = utils::ast::make_ast_to_hir(&mut krate, tcx);
+    utils::ast::remove_unnecessary_items_from_ast(&mut krate);
+
+    let input = collect_input(tcx);
+    let arena = typed_arena::Arena::new();
+    let tss = utils::ty_shape::get_ty_shapes(&arena, tcx, false);
+    let andersen_config = andersen::Config {
+        use_optimized_mir: false,
+        c_exposed_fns: config.c_exposed_fns.clone(),
+    };
+    let pre_points_to = andersen::pre_analyze(&andersen_config, &tss, tcx);
+    let points_to = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
+    let points_to = andersen::post_analyze(&andersen_config, pre_points_to, points_to, &tss, tcx);
+
+    let candidates = analyses::struct_array_field::find_candidates(&input, &points_to);
+    let changed = struct_array_field_pre::apply_struct_array_transform(
+        &mut krate,
+        &candidates,
+        tcx,
+        &ast_to_hir,
+    );
+
+    (pprust::crate_to_string_for_macros(&krate), changed)
+}
+
+fn collect_input(tcx: TyCtxt<'_>) -> RustProgram<'_> {
+    let mut functions = vec![];
+    let mut structs = vec![];
+    for maybe_owner in tcx.hir_crate(()).owners.iter() {
+        let Some(owner) = maybe_owner.as_owner() else {
+            continue;
+        };
+        let OwnerNode::Item(item) = owner.node() else {
+            continue;
+        };
+        match item.kind {
+            ItemKind::Fn { .. } => functions.push(item.owner_id.def_id),
+            ItemKind::Struct(..) => structs.push(item.owner_id.def_id),
+            _ => {}
+        };
+    }
+
+    RustProgram {
+        tcx,
+        functions,
+        structs,
+    }
 }
 
 fn maybe_solidified_ownership<'tcx>(

--- a/crates/pointer_replacer/src/rewriter/struct_array_field_pre.rs
+++ b/crates/pointer_replacer/src/rewriter/struct_array_field_pre.rs
@@ -1,0 +1,398 @@
+use rustc_ast::{
+    mut_visit::{self, MutVisitor},
+    ptr::P,
+    *,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{self as hir, def::Res};
+use rustc_middle::ty::{self, TyCtxt};
+use rustc_span::{DUMMY_SP, Ident, Symbol, def_id::LocalDefId};
+use thin_vec::{ThinVec, thin_vec};
+use utils::ir::AstToHir;
+
+use crate::analyses::struct_array_field::{FieldGroup, StructRewriteCandidates};
+
+#[derive(Clone, Copy)]
+struct StructArrayCtx<'a, 'tcx> {
+    candidates: &'a StructRewriteCandidates,
+    ast_to_hir: &'a AstToHir,
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'a, 'tcx> StructArrayCtx<'a, 'tcx> {
+    fn new(
+        candidates: &'a StructRewriteCandidates,
+        ast_to_hir: &'a AstToHir,
+        tcx: TyCtxt<'tcx>,
+    ) -> Self {
+        Self {
+            candidates,
+            ast_to_hir,
+            tcx,
+        }
+    }
+
+    fn candidate_groups(&self, struct_did: LocalDefId) -> Option<&'a [FieldGroup]> {
+        self.candidates.get(&struct_did).map(Vec::as_slice)
+    }
+
+    /// resolve the type of an expression from its AST NodeId via HIR
+    fn expr_struct_did(&self, node_id: NodeId) -> Option<LocalDefId> {
+        let hir_expr = self.ast_to_hir.get_expr(node_id, self.tcx)?;
+        let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
+        let ty = typeck.expr_ty(hir_expr);
+        let ty::TyKind::Adt(adt_def, _) = ty.kind() else {
+            return None;
+        };
+        adt_def.did().as_local()
+    }
+
+    fn struct_field_order(&self, node_id: NodeId) -> Option<Vec<Symbol>> {
+        let hir_expr = self.ast_to_hir.get_expr(node_id, self.tcx)?;
+        let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
+        let struct_ty = typeck.expr_ty(hir_expr);
+        let ty::TyKind::Adt(adt_def, _) = struct_ty.kind() else {
+            return None;
+        };
+        Some(adt_def.all_fields().map(|f| f.name).collect())
+    }
+
+    fn offset_of_struct_did(&self, expr: &Expr, ast_ty: &Ty) -> Option<LocalDefId> {
+        if let Some(hir_expr) = self.ast_to_hir.get_expr(expr.id, self.tcx)
+            && let hir::ExprKind::OffsetOf(hir_ty, _) = hir_expr.kind
+            && let Some(struct_did) = self.hir_ty_struct_did(hir_ty)
+        {
+            return Some(struct_did);
+        }
+
+        let hir_ty = self.ast_to_hir.get_ty(ast_ty.id, self.tcx)?;
+        self.hir_ty_struct_did(hir_ty)
+    }
+
+    fn hir_ty_struct_did(&self, hir_ty: &hir::Ty<'_>) -> Option<LocalDefId> {
+        let hir::TyKind::Path(hir::QPath::Resolved(_, path)) = hir_ty.kind else {
+            return None;
+        };
+        let Res::Def(_, def_id) = path.res else {
+            return None;
+        };
+        let ty = self.tcx.type_of(def_id).skip_binder();
+        let ty::TyKind::Adt(adt_def, _) = ty.kind() else {
+            return None;
+        };
+        if adt_def.is_struct() && !adt_def.is_union() {
+            adt_def.did().as_local()
+        } else {
+            None
+        }
+    }
+}
+
+fn group_for_field(groups: &[FieldGroup], field_name: Symbol) -> Option<(&FieldGroup, usize)> {
+    groups
+        .iter()
+        .find_map(|group| group.group_index(field_name).map(|idx| (group, idx)))
+}
+
+struct StructArrayTransformVisitor<'a, 'tcx> {
+    ctx: StructArrayCtx<'a, 'tcx>,
+}
+
+impl<'a, 'tcx> StructArrayTransformVisitor<'a, 'tcx> {
+    fn new(
+        candidates: &'a StructRewriteCandidates,
+        ast_to_hir: &'a AstToHir,
+        tcx: TyCtxt<'tcx>,
+    ) -> Self {
+        Self {
+            ctx: StructArrayCtx::new(candidates, ast_to_hir, tcx),
+        }
+    }
+}
+
+impl MutVisitor for StructArrayTransformVisitor<'_, '_> {
+    fn visit_item(&mut self, item: &mut Item) {
+        if let ItemKind::Struct(_, _, VariantData::Struct { ref mut fields, .. }) = item.kind {
+            let struct_did = self.ctx.ast_to_hir.global_map.get(&item.id).copied();
+            if let Some(groups) = struct_did.and_then(|did| self.ctx.candidate_groups(did)) {
+                rewrite_struct_definition_fields(fields, groups);
+            }
+        }
+        mut_visit::walk_item(self, item);
+    }
+
+    fn visit_expr(&mut self, expr: &mut Expr) {
+        // recurse into sub-expressions first
+        mut_visit::walk_expr(self, expr);
+
+        match expr.kind {
+            ExprKind::Field(_, _) => {
+                self.rewrite_field_expr(expr);
+            }
+            ExprKind::Struct(_) => {
+                self.rewrite_struct_expr(expr);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl StructArrayTransformVisitor<'_, '_> {
+    fn rewrite_field_expr(&self, expr: &mut Expr) {
+        let ExprKind::Field(ref base_expr, field_ident) = expr.kind else {
+            return;
+        };
+        let field_name = field_ident.name;
+
+        let Some(struct_did) = self.ctx.expr_struct_did(base_expr.id) else {
+            return;
+        };
+        let Some(groups) = self.ctx.candidate_groups(struct_did) else {
+            return;
+        };
+        let Some((group, field_idx)) = group_for_field(groups, field_name) else {
+            return;
+        };
+        let array_name = group.array_name();
+
+        // rewrite: expr.field_name to (expr.array_name)[group_idx]
+        let span = expr.span;
+        let old_expr = utils::ast::take_expr(expr);
+        let ExprKind::Field(base, _) = old_expr.kind else { unreachable!() };
+
+        let field_expr = Expr {
+            id: DUMMY_NODE_ID,
+            kind: ExprKind::Field(base, Ident::new(array_name, span)),
+            span,
+            attrs: thin_vec![],
+            tokens: None,
+        };
+        let idx_expr = utils::expr!("{}", field_idx);
+        expr.kind = ExprKind::Index(P(field_expr), P(idx_expr), span);
+    }
+
+    fn rewrite_struct_expr(&self, expr: &mut Expr) {
+        let expr_id = expr.id;
+        let Some(struct_did) = self.ctx.expr_struct_did(expr_id) else {
+            return;
+        };
+        let Some(groups) = self.ctx.candidate_groups(struct_did) else {
+            return;
+        };
+
+        let ExprKind::Struct(ref se) = expr.kind else { unreachable!() };
+        if !struct_literal_has_group_field(se, groups) {
+            return;
+        }
+
+        let Some(def_order) = self.ctx.struct_field_order(expr_id) else {
+            return;
+        };
+        let ExprKind::Struct(ref mut se) = expr.kind else {
+            return;
+        };
+        let old_fields = std::mem::take(&mut se.fields);
+        se.fields = build_rewritten_struct_fields(old_fields, groups, &def_order);
+    }
+}
+
+fn rewrite_struct_definition_fields(fields: &mut ThinVec<FieldDef>, groups: &[FieldGroup]) {
+    let mut sorted_groups: Vec<&FieldGroup> = groups.iter().collect();
+    sorted_groups.sort_by(|a, b| b.start_idx.cmp(&a.start_idx));
+
+    for group in sorted_groups {
+        let elem_ty = fields[group.start_idx].ty.clone();
+        let span = fields[group.start_idx].span;
+        fields[group.start_idx].ty = P(Ty {
+            id: DUMMY_NODE_ID,
+            kind: TyKind::Array(
+                elem_ty,
+                AnonConst {
+                    id: DUMMY_NODE_ID,
+                    value: P(utils::expr!("{}", group.count)),
+                },
+            ),
+            span,
+            tokens: None,
+        });
+        fields.drain(group.start_idx + 1..group.start_idx + group.count);
+    }
+}
+
+fn struct_literal_has_group_field(se: &StructExpr, groups: &[FieldGroup]) -> bool {
+    se.fields
+        .iter()
+        .any(|ef| group_for_field(groups, ef.ident.name).is_some())
+}
+
+fn build_rewritten_struct_fields(
+    old_fields: ThinVec<ExprField>,
+    groups: &[FieldGroup],
+    def_order: &[Symbol],
+) -> ThinVec<ExprField> {
+    let mut field_map: FxHashMap<Symbol, ExprField> = old_fields
+        .into_iter()
+        .map(|ef| (ef.ident.name, ef))
+        .collect();
+    let skipped: FxHashSet<Symbol> = groups
+        .iter()
+        .flat_map(|g| g.field_names[1..].iter().copied())
+        .collect();
+
+    let mut new_fields = ThinVec::new();
+    for field_name in def_order {
+        if let Some(group) = groups
+            .iter()
+            .find(|group| group.field_names.first() == Some(field_name))
+        {
+            new_fields.push(build_group_expr_field(group, &mut field_map));
+        } else if !skipped.contains(field_name)
+            && let Some(ef) = field_map.remove(field_name)
+        {
+            new_fields.push(ef);
+        }
+    }
+
+    new_fields
+}
+
+fn build_group_expr_field(
+    group: &FieldGroup,
+    field_map: &mut FxHashMap<Symbol, ExprField>,
+) -> ExprField {
+    let array_exprs: ThinVec<P<Expr>> = group
+        .field_names
+        .iter()
+        .map(|name| {
+            field_map
+                .remove(name)
+                .map(|field| field.expr)
+                .expect("partial struct-array literal should be filtered before transform")
+        })
+        .collect();
+    let array_expr = Expr {
+        id: DUMMY_NODE_ID,
+        kind: ExprKind::Array(array_exprs),
+        span: DUMMY_SP,
+        attrs: thin_vec![],
+        tokens: None,
+    };
+    ExprField {
+        attrs: thin_vec![],
+        id: DUMMY_NODE_ID,
+        span: DUMMY_SP,
+        ident: Ident::new(group.array_name(), DUMMY_SP),
+        expr: P(array_expr),
+        is_shorthand: false,
+        is_placeholder: false,
+    }
+}
+
+struct StructArraySafetyVisitor<'a, 'tcx> {
+    ctx: StructArrayCtx<'a, 'tcx>,
+    rejected: FxHashSet<(LocalDefId, usize)>,
+}
+
+impl<'a, 'tcx> StructArraySafetyVisitor<'a, 'tcx> {
+    fn new(
+        candidates: &'a StructRewriteCandidates,
+        ast_to_hir: &'a AstToHir,
+        tcx: TyCtxt<'tcx>,
+    ) -> Self {
+        Self {
+            ctx: StructArrayCtx::new(candidates, ast_to_hir, tcx),
+            rejected: FxHashSet::default(),
+        }
+    }
+
+    fn reject_offset_of_escape(&mut self, expr: &Expr) {
+        let ExprKind::OffsetOf(ref ast_ty, ref fields) = expr.kind else {
+            return;
+        };
+        let Some(struct_did) = self.ctx.offset_of_struct_did(expr, ast_ty) else {
+            return;
+        };
+        let Some(groups) = self.ctx.candidate_groups(struct_did) else {
+            return;
+        };
+
+        for group in groups {
+            if fields
+                .iter()
+                .any(|field| group.group_index(field.name).is_some())
+            {
+                self.rejected.insert((struct_did, group.start_idx));
+            }
+        }
+    }
+
+    fn reject_partial_struct_literal(&mut self, expr: &Expr) {
+        let ExprKind::Struct(ref se) = expr.kind else {
+            return;
+        };
+        let Some(struct_did) = self.ctx.expr_struct_did(expr.id) else {
+            return;
+        };
+        let Some(groups) = self.ctx.candidate_groups(struct_did) else {
+            return;
+        };
+
+        let present: FxHashSet<Symbol> = se.fields.iter().map(|field| field.ident.name).collect();
+        for group in groups {
+            let present_count = group
+                .field_names
+                .iter()
+                .filter(|name| present.contains(name))
+                .count();
+            if present_count > 0 && present_count < group.count {
+                self.rejected.insert((struct_did, group.start_idx));
+            }
+        }
+    }
+}
+
+impl MutVisitor for StructArraySafetyVisitor<'_, '_> {
+    fn visit_expr(&mut self, expr: &mut Expr) {
+        self.reject_offset_of_escape(expr);
+        self.reject_partial_struct_literal(expr);
+        mut_visit::walk_expr(self, expr);
+    }
+}
+
+fn filter_safe_candidates(
+    krate: &mut rustc_ast::ast::Crate,
+    candidates: &StructRewriteCandidates,
+    tcx: TyCtxt<'_>,
+    ast_to_hir: &AstToHir,
+) -> StructRewriteCandidates {
+    let mut visitor = StructArraySafetyVisitor::new(candidates, ast_to_hir, tcx);
+    visitor.visit_crate(krate);
+
+    let mut filtered = FxHashMap::default();
+    for (&struct_did, groups) in candidates {
+        let groups: Vec<_> = groups
+            .iter()
+            .filter(|group| !visitor.rejected.contains(&(struct_did, group.start_idx)))
+            .cloned()
+            .collect();
+        if !groups.is_empty() {
+            filtered.insert(struct_did, groups);
+        }
+    }
+    filtered
+}
+
+pub fn apply_struct_array_transform<'tcx>(
+    krate: &mut rustc_ast::ast::Crate,
+    candidates: &StructRewriteCandidates,
+    tcx: TyCtxt<'tcx>,
+    ast_to_hir: &AstToHir,
+) -> bool {
+    let candidates = filter_safe_candidates(krate, candidates, tcx, ast_to_hir);
+    if candidates.is_empty() {
+        return false;
+    }
+    let mut visitor = StructArrayTransformVisitor::new(&candidates, ast_to_hir, tcx);
+    visitor.visit_crate(krate);
+    true
+}

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -5,6 +5,17 @@ fn rewrite_with_config(code: &str, config: &Config) -> (String, bool) {
         .unwrap()
 }
 
+fn rewrite_struct_arrays_with_config(code: &str, config: &Config) -> (String, bool) {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| rewrite_struct_arrays(config, tcx))
+        .unwrap()
+}
+
+fn rewrite_struct_arrays_then_pointer(code: &str, config: &Config) -> (String, bool) {
+    let (pre, changed) = rewrite_struct_arrays_with_config(code, config);
+    let input = if changed { pre.as_str() } else { code };
+    rewrite_with_config(input, config)
+}
+
 fn run_test(code: &str, includes: &[&str], excludes: &[&str]) {
     let config = Config::default();
     let (s, _) = rewrite_with_config(code, &config);
@@ -3472,6 +3483,263 @@ pub unsafe fn copy_tail(
         &["(&((*(src).as_deref().unwrap()).data))[("],
         &["&mut ((*(src).as_deref().unwrap()).data)"],
     );
+}
+
+#[test]
+fn test_replace_local_borrows_does_not_run_struct_array_field_pre_stage() {
+    let code = r#"
+#[repr(C)]
+pub struct Elem {
+    pub x: i32,
+}
+impl Copy for Elem {}
+impl Clone for Elem {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+pub struct Group {
+    pub a: Elem,
+    pub b: Elem,
+    pub c: Elem,
+    pub tag: i32,
+}
+
+pub unsafe fn foo() -> i32 {
+    let mut s: Group = Group {
+        a: Elem { x: 1 },
+        b: Elem { x: 2 },
+        c: Elem { x: 3 },
+        tag: 4,
+    };
+    let mut p: *mut Elem = &raw mut s.a;
+    let mut q: *mut Elem = p as *mut Elem;
+    (*q.offset(1)).x = 7;
+    s.b.x
+}
+"#;
+    let (s, _) = rewrite_with_config(code, &Config::default());
+    assert!(!s.contains("pub a: [Elem; 3]"), "{s}");
+    assert!(s.contains("pub b: Elem"), "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+}
+
+#[test]
+fn test_struct_array_field_run_from_field_rooted_offset() {
+    let code = r#"
+#[repr(C)]
+pub struct Elem {
+    pub x: i32,
+}
+impl Copy for Elem {}
+impl Clone for Elem {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+pub struct Group {
+    pub a: Elem,
+    pub b: Elem,
+    pub c: Elem,
+    pub tag: i32,
+}
+
+pub unsafe fn foo() -> i32 {
+    let mut s: Group = Group {
+        a: Elem { x: 1 },
+        b: Elem { x: 2 },
+        c: Elem { x: 3 },
+        tag: 4,
+    };
+    let mut p: *mut Elem = &raw mut s.a;
+    let mut q: *mut Elem = p as *mut Elem;
+    (*q.offset(1)).x = 7;
+    s.b.x
+}
+"#;
+    let (s, bytemuck) = rewrite_struct_arrays_then_pointer(code, &Config::default());
+    assert!(!bytemuck);
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    for include in [
+        "pub a: [Elem; 3]",
+        "a: [Elem { x: 1 }, Elem { x: 2 }, Elem { x: 3 }]",
+        "s.a[1].x",
+    ] {
+        assert!(s.contains(include), "Expected to find `{include}` in:\n{s}");
+    }
+    for exclude in ["pub b: Elem", "s.b.x"] {
+        assert!(
+            !s.contains(exclude),
+            "Expected not to find `{exclude}` in:\n{s}",
+        );
+    }
+}
+
+#[test]
+fn test_struct_array_rejects_offset_with_different_pointee_type() {
+    let code = r#"
+#[repr(C)]
+pub struct Group {
+    pub a: i32,
+    pub b: i32,
+    pub c: i32,
+}
+
+pub unsafe fn foo(s: *mut Group) {
+    let p: *mut i32 = &raw mut (*s).a;
+    let q: *mut i64 = p as *mut i64;
+    let _r = q.offset(1);
+}
+"#;
+    let (s, changed) = rewrite_struct_arrays_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    assert!(s.contains("pub a: i32"), "{s}");
+    assert!(s.contains("pub b: i32"), "{s}");
+    assert!(s.contains("pub c: i32"), "{s}");
+    assert!(!s.contains("pub a: [i32; 3]"), "{s}");
+}
+
+#[test]
+fn test_struct_array_rejects_offset_with_same_size_different_pointee_type() {
+    let code = r#"
+#[repr(C)]
+pub struct Pair {
+    pub key: i32,
+    pub value: i32,
+}
+
+#[repr(C)]
+pub struct Header {
+    pub length: usize,
+    pub capacity: usize,
+    pub payload: *mut core::ffi::c_void,
+}
+
+pub unsafe fn foo(items: *mut Pair) -> usize {
+    let header = items.offset(-1) as *mut Header;
+    (*header).length + (*header).capacity
+}
+"#;
+    let (s, changed) = rewrite_struct_arrays_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    assert!(s.contains("pub length: usize"), "{s}");
+    assert!(s.contains("pub capacity: usize"), "{s}");
+    assert!(!s.contains("pub length: [usize; 2]"), "{s}");
+}
+
+#[test]
+fn test_struct_array_rejects_nested_array_element_type() {
+    let code = r#"
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct c2v {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct c2Poly {
+    pub count: i32,
+    pub verts: [c2v; 8],
+    pub norms: [c2v; 8],
+}
+
+pub unsafe fn foo(poly: *mut c2Poly) {
+    let p: *mut [c2v; 8] = &raw mut (*poly).verts;
+    let _q = p.offset(1);
+}
+"#;
+    let (s, changed) = rewrite_struct_arrays_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    assert!(s.contains("pub verts: [c2v; 8]"), "{s}");
+    assert!(s.contains("pub norms: [c2v; 8]"), "{s}");
+    assert!(!s.contains("pub verts: [[c2v; 8]; 2]"), "{s}");
+}
+
+#[test]
+fn test_struct_array_rejects_whole_struct_byte_inspection() {
+    let code = r#"
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct house_t {
+    pub floors: i32,
+    pub bedrooms: i32,
+    pub bathrooms: f64,
+}
+
+extern "C" {
+    fn print_hex(p: *mut core::ffi::c_uchar, n: core::ffi::c_int);
+}
+
+pub unsafe fn foo() {
+    let mut house = house_t {
+        floors: 2,
+        bedrooms: 3,
+        bathrooms: 1.5,
+    };
+    print_hex(
+        &mut house as *mut house_t as *mut core::ffi::c_uchar,
+        ::core::mem::size_of::<house_t>() as core::ffi::c_int,
+    );
+}
+"#;
+    let (s, changed) = rewrite_struct_arrays_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    assert!(s.contains("pub floors: i32"), "{s}");
+    assert!(s.contains("pub bedrooms: i32"), "{s}");
+    assert!(!s.contains("pub floors: [i32; 2]"), "{s}");
+}
+
+#[test]
+fn test_struct_array_rejects_partial_literal_group() {
+    let code = r#"
+#[repr(C)]
+pub struct Group {
+    pub a: i32,
+    pub b: i32,
+    pub c: i32,
+}
+
+pub unsafe fn foo(s: *mut Group) {
+    let _partial = Group { a: 1, ..*s };
+    let p: *mut i32 = &raw mut (*s).a;
+    let _q = p.offset(1);
+}
+"#;
+    let (s, changed) = rewrite_struct_arrays_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    assert!(s.contains("pub a: i32"), "{s}");
+    assert!(s.contains("pub b: i32"), "{s}");
+    assert!(s.contains("pub c: i32"), "{s}");
+}
+
+#[test]
+fn test_struct_array_rejects_offset_of_escape() {
+    let code = r#"
+#[repr(C)]
+pub struct Group {
+    pub a: i32,
+    pub b: i32,
+    pub c: i32,
+}
+
+pub unsafe fn foo(s: *mut Group) -> usize {
+    let p: *mut i32 = &raw mut (*s).a;
+    let _q = p.offset(1);
+    ::core::mem::offset_of!(Group, b)
+}
+"#;
+    let (s, changed) = rewrite_struct_arrays_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    assert!(s.contains("pub a: i32"), "{s}");
+    assert!(s.contains("pub b: i32"), "{s}");
+    assert!(s.contains("pub c: i32"), "{s}");
+    assert!(!s.contains("pub a: [i32; 3]"), "{s}");
 }
 
 #[test]

--- a/crates/points_to/src/andersen.rs
+++ b/crates/points_to/src/andersen.rs
@@ -1075,9 +1075,10 @@ fn compute_bitfield_writes<'tcx>(
     let local_def_id = some_or!(def_id.as_local(), return);
     let (local_def_id, method) = some_or!(receiver_and_method(local_def_id, tcx), return);
     let field = some_or!(method.strip_prefix("set_"), return);
+    let bitfield = some_or!(tss.bitfields.get(&local_def_id), return);
+    let idx = some_or!(bitfield.name_to_idx.get(field).copied(), return);
     let TyKind::Ref(_, ty, _) = args[0].node.ty(ctx.locals, tcx).kind() else { unreachable!() };
     let TyShape::Struct(_, fs, _) = tss.tys[ty] else { unreachable!() };
-    let idx = tss.bitfields[&local_def_id].name_to_idx[field];
     let offset = fs[idx.as_usize()].0;
     let lhs = args[0].node.place().unwrap();
     assert!(lhs.projection.is_empty());

--- a/src/bin/crat.rs
+++ b/src/bin/crat.rs
@@ -543,6 +543,14 @@ fn main() {
                 }
             }
             Pass::Pointer => {
+                let (s, changed) = run_compiler_on_path(&file, |tcx| {
+                    pointer_replacer::rewrite_struct_arrays(&config.pointer, tcx)
+                })
+                .unwrap();
+                if changed {
+                    std::fs::write(&file, s).unwrap();
+                }
+
                 let (s, bytemuck) = run_compiler_on_path(&file, |tcx| {
                     pointer_replacer::replace_local_borrows(&config.pointer, tcx)
                 })


### PR DESCRIPTION

## Summary 
- Added struct_array_field analysis to analyze the consecutive fields which are used as an array in the source code
  - Select target structs by seeing its type   
  - By using andersen analysis, find `.offset` accesses to target struct fields 
  - Rewrite only if the pointee type of the accessed pointer and target field type are the same. 
- Perform struct_array_field rewriting before pointer rewriting

## Test
Rewrite the following struct in 7 test cases
```
#[derive(Copy, Clone)]
#[repr(C)]
pub struct c2Simplex {
    pub a: c2sv,
    pub b: c2sv,
    pub c: c2sv,
    pub d: c2sv,
    pub div: core::ffi::c_float,
    pub count: core::ffi::c_int,
}
```

```
#[repr(C)]
#[derive(Copy, Clone)]
pub struct c2Simplex {
    pub a: [c2sv; 4],
    pub div: f32,
    pub count: i32,
}
```

Run on test-corpus:
Summary:
- Test Cases Discovered:      338
- Test Cases Skipped:         2
- Test Cases Tested:          331
- Test Cases Failed:          37
