### PR TITLE
Fix Crat pass edge cases

### DIFF
--- a/crates/io_replacer/src/tests.rs
+++ b/crates/io_replacer/src/tests.rs
@@ -340,7 +340,12 @@ unsafe fn f(mut stream: *mut FILE) {
         stream,
     );
 }",
-        &["crate::c_lib::rs_fgets", "TT", "Read"],
+        &[
+            "crate::c_lib::rs_fgets",
+            "TT",
+            "Read",
+            "if available.is_empty() {\n                if let Some(eof) = eof { *eof = 1; }\n                break;",
+        ],
         &["FILE"],
     );
 }

--- a/crates/io_replacer/src/tests.rs
+++ b/crates/io_replacer/src/tests.rs
@@ -431,6 +431,28 @@ unsafe fn f(mut stream: *mut FILE) {
 }
 
 #[test]
+fn test_printf_struct_string_key() {
+    run_test(
+        r#"
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Entry {
+    key: *mut libc::c_char,
+    value: libc::c_int,
+}
+unsafe fn f(mut entry: Entry) {
+    printf(
+        b"%s %d\0" as *const u8 as *const libc::c_char,
+        entry,
+        entry.value,
+    );
+}"#,
+        &["std::ffi::CStr::from_ptr((entry).key as _)", "write!"],
+        &["printf"],
+    );
+}
+
+#[test]
 fn test_vfprintf() {
     run_test(
         r#"

--- a/crates/io_replacer/src/transformation/fgets.rs
+++ b/crates/io_replacer/src/transformation/fgets.rs
@@ -79,6 +79,9 @@ pub(crate) fn rs_fgets<R: std::io::BufRead>(
             }
         };
         if available.is_empty() {
+            if let Some(eof) = eof {
+                *eof = 1;
+            }
             break;
         }
         s[pos] = available[0] as i8;

--- a/crates/io_replacer/src/transformation/fprintf.rs
+++ b/crates/io_replacer/src/transformation/fprintf.rs
@@ -186,9 +186,11 @@ impl TransformVisitor<'_, '_, '_> {
                                 format!("std::ffi::CStr::from_ptr(({arg_str}) as _)")
                             }
                         }
-                        _ => {
-                            format!("std::ffi::CStr::from_ptr(({arg_str}) as _)")
-                        }
+                        _ => self
+                            .cstr_from_struct_first_field(arg, &arg_str)
+                            .unwrap_or_else(|| {
+                                format!("std::ffi::CStr::from_ptr(({arg_str}) as _)")
+                            }),
                     };
                     if self.config.assume_to_str_ok {
                         write!(args, "{cstr}.to_str().unwrap(), ").unwrap();
@@ -297,6 +299,30 @@ impl TransformVisitor<'_, '_, '_> {
             format!("crate::c_lib::rs_vfprintf({stream_str}, {fmt}, {args})"),
             stream,
         )
+    }
+
+    fn cstr_from_struct_first_field(&self, arg: &Expr, arg_str: &str) -> Option<String> {
+        let hir_arg = self.ast_to_hir.get_expr(arg.id, self.tcx)?;
+        let typeck = self.tcx.typeck(hir_arg.hir_id.owner);
+        let ty = typeck.expr_ty(hir_arg).peel_refs();
+        let ty::TyKind::Adt(adt_def, generic_args) = ty.kind() else {
+            return None;
+        };
+        if !adt_def.is_struct() {
+            return None;
+        }
+        let field = adt_def.all_fields().next()?;
+        let field_ty = field.ty(self.tcx, generic_args);
+        let ty::TyKind::RawPtr(pointee, _) = field_ty.kind() else {
+            return None;
+        };
+        if *pointee != self.tcx.types.i8 && *pointee != self.tcx.types.u8 {
+            return None;
+        }
+        let field_name = field.ident(self.tcx).name;
+        Some(format!(
+            "std::ffi::CStr::from_ptr(({arg_str}).{field_name} as _)"
+        ))
     }
 }
 

--- a/crates/io_replacer/src/transformation/fscanf.rs
+++ b/crates/io_replacer/src/transformation/fscanf.rs
@@ -201,10 +201,7 @@ fn make_parsing_function(specs: &[ConversionSpec]) -> ParsingFunction {
     )
     .unwrap();
     let mut body = String::new();
-    let consume_whitespace = !matches!(
-        specs[0].conversion,
-        Conversion::Seq | Conversion::ScanSet(_)
-    );
+    let consume_whitespace = specs[0].leading_space || skips_leading_whitespace(&specs[0]);
     writeln!(
         body,
         "    if is_eof(&mut stream, err.as_deref_mut(), eof.as_deref_mut(), {consume_whitespace}) {{
@@ -231,6 +228,9 @@ fn make_parsing_function(specs: &[ConversionSpec]) -> ParsingFunction {
         }
         match &spec.conversion {
             Conversion::ScanSet(scan_set) => {
+                if spec.leading_space {
+                    write!(name, "_lead_ws").unwrap();
+                }
                 write!(name, "_{}", !scan_set.negative).unwrap();
                 for c in &scan_set.chars {
                     if c.is_ascii_digit() || c.is_ascii_lowercase() {
@@ -244,6 +244,9 @@ fn make_parsing_function(specs: &[ConversionSpec]) -> ParsingFunction {
             Conversion::S => write!(name, "_big_s").unwrap(),
             Conversion::Percent => write!(name, "_percent").unwrap(),
             conv => write!(name, "_{conv}").unwrap(),
+        }
+        if spec.trailing_space {
+            write!(name, "_trail_ws").unwrap();
         }
 
         let assign = if !spec.assign {
@@ -338,6 +341,13 @@ fn make_parsing_function(specs: &[ConversionSpec]) -> ParsingFunction {
             Conversion::Percent => todo!(),
         };
         let width = spec.width;
+        if spec.leading_space && !skips_leading_whitespace(spec) {
+            writeln!(
+                body,
+                "    let _ = is_eof(&mut stream, err.as_deref_mut(), eof.as_deref_mut(), true);",
+            )
+            .unwrap();
+        }
         writeln!(
             body,
             "    let _v = {f}(&mut stream, {width:?}, err.as_deref_mut(), eof.as_deref_mut(){call_args});",
@@ -352,6 +362,13 @@ fn make_parsing_function(specs: &[ConversionSpec]) -> ParsingFunction {
     }}"
         )
         .unwrap();
+        if spec.trailing_space {
+            writeln!(
+                body,
+                "    let _ = is_eof(&mut stream, err.as_deref_mut(), eof.as_deref_mut(), true);",
+            )
+            .unwrap();
+        }
     }
     writeln!(body, "    count").unwrap();
     let code = format!(
@@ -365,6 +382,10 @@ fn make_parsing_function(specs: &[ConversionSpec]) -> ParsingFunction {
         lib_items,
         num_traits,
     }
+}
+
+fn skips_leading_whitespace(spec: &ConversionSpec) -> bool {
+    !matches!(spec.conversion, Conversion::Seq | Conversion::ScanSet(_))
 }
 
 pub(super) static IS_EOF: &str = r#"
@@ -399,10 +420,28 @@ fn parse_scan_set<R: std::io::BufRead>(
     pos: bool,
     set: &[u8],
 ) -> Option<Vec<i8>> {
+    fn scan_set_contains(set: &[u8], c: u8) -> bool {
+        let mut i = 0;
+        while i < set.len() {
+            if i + 2 < set.len() && set[i + 1] == b'-' && set[i] <= set[i + 2] {
+                if (set[i]..=set[i + 2]).contains(&c) {
+                    return true;
+                }
+                i += 3;
+            } else {
+                if set[i] == c {
+                    return true;
+                }
+                i += 1;
+            }
+        }
+        false
+    }
+
     let mut v: Vec<i8> = Vec::new();
     while width.is_none_or(|lim| v.len() < lim) {
         let c = peek(&mut stream, err.as_deref_mut(), eof.as_deref_mut());
-        if c == 0xff || set.contains(&c) != pos {
+        if c == 0xff || scan_set_contains(set, c) != pos {
             break;
         }
         v.push(c as i8);

--- a/crates/passes/src/interface_fixer.rs
+++ b/crates/passes/src/interface_fixer.rs
@@ -10,7 +10,7 @@ use rustc_hir::{
     intravisit,
 };
 use rustc_middle::{hir::nested_filter, ty, ty::TyCtxt};
-use rustc_span::Symbol;
+use rustc_span::{Symbol, sym};
 use serde::Deserialize;
 use utils::ir::AstToHir;
 
@@ -108,6 +108,9 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
 
             let ItemKind::Fn(f) = &mut items[0].kind else { panic!() };
             f.ident.name = *name;
+            items[0]
+                .attrs
+                .retain(|attr| !attr.has_name(sym::export_name));
         }
 
         items
@@ -174,7 +177,14 @@ impl<'tcx> intravisit::Visitor<'tcx> for HirVisitor<'_, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
         if let hir::ItemKind::Fn { ident, body, .. } = item.kind
             && let name = ident.name.as_str()
-            && self.config.c_exposed_fns.contains(name)
+            && (self.config.c_exposed_fns.contains(name)
+                || self
+                    .tcx
+                    .get_attrs(item.owner_id.def_id.to_def_id(), sym::export_name)
+                    .any(|attr| {
+                        attr.value_str()
+                            .is_some_and(|s| self.config.c_exposed_fns.contains(s.as_str()))
+                    }))
         {
             let body = self.tcx.hir_body(body);
             let typeck = self.tcx.typeck(item.owner_id.def_id);
@@ -231,5 +241,33 @@ impl<'tcx> intravisit::Visitor<'tcx> for HirVisitor<'_, 'tcx> {
         }
 
         intravisit::walk_item(self, item);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustc_hash::FxHashSet;
+
+    #[test]
+    fn wraps_exposed_export_name_function() {
+        let code = r#"
+#[export_name = "match"]
+pub unsafe extern "C" fn match_0(test: &[f64], reference: &[f64], bins: i32) -> i32 {
+    (test[0] == reference[0]) as i32 + bins
+}
+"#;
+        let config = super::Config {
+            c_exposed_fns: FxHashSet::from_iter(["match".to_string()]),
+        };
+        let transformed = utils::compilation::run_compiler_on_str(code, |tcx| {
+            super::fix_interfaces(&config, tcx)
+        })
+        .unwrap();
+        utils::compilation::run_compiler_on_str(&transformed, utils::type_check)
+            .expect(&transformed);
+
+        assert!(transformed.contains("fn match_0_internal"));
+        assert!(transformed.contains("fn match_0(test: *const f64"));
+        assert_eq!(transformed.matches("#[export_name = \"match\"]").count(), 1);
     }
 }

--- a/crates/passes/src/interface_fixer.rs
+++ b/crates/passes/src/interface_fixer.rs
@@ -73,7 +73,7 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
                         ParamFixKind::Slice => {
                             write!(
                                 call,
-                                "if {x}.is_null() {{ &{}[] }} else {{ std::slice::from_raw_parts{}({x}, 1024) }}, ",
+                                "if {x}.is_null() {{ &{}[] }} else {{ std::slice::from_raw_parts{}({x}, 1_000_000) }}, ",
                                 if fix.mutability.is_mut() { "mut " } else { "" },
                                 if fix.mutability.is_mut() { "_mut" } else { "" },
                             )
@@ -83,13 +83,13 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
                             if fix.mutability.is_mut() {
                                 write!(
                                     call,
-                                    "if {x}.is_null() {{ crate::slice_cursor::SliceCursorMut::empty() }} else {{ crate::slice_cursor::SliceCursorMut::new(std::slice::from_raw_parts_mut({x}, 1024)) }}, ",
+                                    "if {x}.is_null() {{ crate::slice_cursor::SliceCursorMut::empty() }} else {{ crate::slice_cursor::SliceCursorMut::new(std::slice::from_raw_parts_mut({x}, 1_000_000)) }}, ",
                                 )
                                 .unwrap();
                             } else {
                                 write!(
                                     call,
-                                    "if {x}.is_null() {{ crate::slice_cursor::SliceCursor::empty() }} else {{ crate::slice_cursor::SliceCursor::new(std::slice::from_raw_parts({x}, 1024)) }}, ",
+                                    "if {x}.is_null() {{ crate::slice_cursor::SliceCursor::empty() }} else {{ crate::slice_cursor::SliceCursor::new(std::slice::from_raw_parts({x}, 1_000_000)) }}, ",
                                 )
                                 .unwrap();
                             }

--- a/crates/passes/src/libc_replacer/mod.rs
+++ b/crates/passes/src/libc_replacer/mod.rs
@@ -359,16 +359,16 @@ impl MutVisitor for TransformVisitor<'_> {
             let arg = expr_to_parenthesized_string(unwrap_cast(arg));
             match flag.ident.as_str() {
                 "_ISalnum" => {
-                    *expr = expr!("(({arg} as u8 as char).is_alphanumeric() as i32)");
+                    *expr = expr!("(({arg} as u8 as char).is_ascii_alphanumeric() as i32)");
                 }
                 "_ISalpha" => {
-                    *expr = expr!("(({arg} as u8 as char).is_alphabetic() as i32)");
+                    *expr = expr!("(({arg} as u8 as char).is_ascii_alphabetic() as i32)");
                 }
                 "_ISlower" => {
-                    *expr = expr!("(({arg} as u8 as char).is_lowercase() as i32)");
+                    *expr = expr!("(({arg} as u8 as char).is_ascii_lowercase() as i32)");
                 }
                 "_ISupper" => {
-                    *expr = expr!("(({arg} as u8 as char).is_uppercase() as i32)");
+                    *expr = expr!("(({arg} as u8 as char).is_ascii_uppercase() as i32)");
                 }
                 "_ISdigit" => {
                     *expr = expr!("(({arg} as u8 as char).is_ascii_digit() as i32)");
@@ -383,7 +383,9 @@ impl MutVisitor for TransformVisitor<'_> {
                     *expr = expr!("(({arg} as u8 as char).is_ascii_graphic() as i32)");
                 }
                 "_ISspace" => {
-                    *expr = expr!("(({arg} as u8 as char).is_whitespace() as i32)");
+                    *expr = expr!(
+                        "(matches!({arg} as u8, b' ' | b'\\t' | b'\\n' | b'\\r' | 0x0b | 0x0c) as i32)"
+                    );
                 }
                 "_ISblank" => {
                     *expr = expr!("matches!({arg} as u8 as char, ' ' | '\\t') as i32");

--- a/crates/passes/src/libc_replacer/str_utils.rs
+++ b/crates/passes/src/libc_replacer/str_utils.rs
@@ -33,14 +33,14 @@ impl super::TransformVisitor<'_> {
                 let array1 = pprust::expr_to_string(array1);
                 let array2 = pprust::expr_to_string(array2);
                 return Some(utils::expr!(
-                    "(&mut ({array1}))[..({n_str})].copy_from_slice(&({array2})[..({n_str})])"
+                    "{{ let ___n = ({n_str}) as usize; let ___dst = (&mut ({array1}))[..___n].as_mut_ptr(); let ___src = &(&({array2}))[..]; let ___len = ___src.iter().position(|&___c| ___c == 0).map_or(___src.len(), |___i| ___i + 1).min(___n); unsafe {{ std::ptr::write_bytes(___dst, 0, ___n); std::ptr::copy_nonoverlapping(___src.as_ptr(), ___dst, ___len); }} }}"
                 ));
             } else if ty1 == self.tcx.types.u8 || ty1 == self.tcx.types.i8 {
                 self.bytemuck = true;
                 let array1 = pprust::expr_to_string(array1);
                 let array2 = pprust::expr_to_string(array2);
                 return Some(utils::expr!(
-                    "(&mut ({array1}))[..({n_str})].copy_from_slice(bytemuck::cast_slice(&({array2})[..({n_str})]))"
+                    "{{ let ___n = ({n_str}) as usize; let ___dst = (&mut ({array1}))[..___n].as_mut_ptr(); let ___src = bytemuck::cast_slice(&(&({array2}))[..]); let ___len = ___src.iter().position(|&___c| ___c == 0).map_or(___src.len(), |___i| ___i + 1).min(___n); unsafe {{ std::ptr::write_bytes(___dst, 0, ___n); std::ptr::copy_nonoverlapping(___src.as_ptr(), ___dst, ___len); }} }}"
                 ));
             }
         }

--- a/crates/passes/src/libc_replacer/strto.rs
+++ b/crates/passes/src/libc_replacer/strto.rs
@@ -42,7 +42,7 @@ impl super::TransformVisitor<'_> {
 
         utils::expr!(
             "crate::c_lib::strtod(
-                std::slice::from_raw_parts(({nptr_str}) as _, 100000),
+                std::slice::from_raw_parts(({nptr_str}) as _, 1_000_000),
                 ({endptr_str} as *mut *const u8).as_mut(),
                 {error},
             )"
@@ -95,7 +95,7 @@ impl super::TransformVisitor<'_> {
 
         utils::expr!(
             "crate::c_lib::strtol(
-                std::slice::from_raw_parts(({nptr_str}) as _, 100000),
+                std::slice::from_raw_parts(({nptr_str}) as _, 1_000_000),
                 ({endptr_str} as *mut *const u8).as_mut(),
                 {base_str},
                 {error},
@@ -149,7 +149,7 @@ impl super::TransformVisitor<'_> {
 
         utils::expr!(
             "crate::c_lib::strtoul(
-                std::slice::from_raw_parts(({nptr_str}) as _, 100000),
+                std::slice::from_raw_parts(({nptr_str}) as _, 1_000_000),
                 ({endptr_str} as *mut *const u8).as_mut(),
                 {base_str},
                 {error},
@@ -175,7 +175,7 @@ impl super::TransformVisitor<'_> {
             }
         }
 
-        utils::expr!("crate::c_lib::atof(std::slice::from_raw_parts(({s_str}) as _, 100000))")
+        utils::expr!("crate::c_lib::atof(std::slice::from_raw_parts(({s_str}) as _, 1_000_000))")
     }
 
     pub fn transform_atoi(&mut self, s: &Expr) -> Expr {
@@ -195,7 +195,7 @@ impl super::TransformVisitor<'_> {
             }
         }
 
-        utils::expr!("crate::c_lib::atoi(std::slice::from_raw_parts(({s_str}) as _, 100000))")
+        utils::expr!("crate::c_lib::atoi(std::slice::from_raw_parts(({s_str}) as _, 1_000_000))")
     }
 }
 

--- a/crates/passes/src/libc_replacer/tests.rs
+++ b/crates/passes/src/libc_replacer/tests.rs
@@ -64,3 +64,53 @@ pub unsafe fn copy_name(mut src: &[i8]) {
         &["copy_from_slice(&src[..63])"],
     );
 }
+
+#[test]
+fn test_ctype_masks_use_ascii_classification() {
+    run_test(
+        r#"
+pub const _ISalnum: core::ffi::c_uint = 8;
+pub const _ISalpha: core::ffi::c_uint = 1024;
+pub const _ISspace: core::ffi::c_uint = 8192;
+
+extern "C" {
+    fn __ctype_b_loc() -> *mut *const core::ffi::c_ushort;
+}
+
+pub unsafe fn foo(mut c: core::ffi::c_char) -> core::ffi::c_int {
+    let mut n = 0;
+    if *(*__ctype_b_loc()).offset(c as core::ffi::c_int as isize) as core::ffi::c_int
+        & _ISalnum as core::ffi::c_int as core::ffi::c_ushort as core::ffi::c_int
+        != 0
+    {
+        n += 1;
+    }
+    if *(*__ctype_b_loc()).offset(c as core::ffi::c_int as isize) as core::ffi::c_int
+        & _ISalpha as core::ffi::c_int as core::ffi::c_ushort as core::ffi::c_int
+        != 0
+    {
+        n += 1;
+    }
+    if *(*__ctype_b_loc()).offset(c as core::ffi::c_int as isize) as core::ffi::c_int
+        & _ISspace as core::ffi::c_int as core::ffi::c_ushort as core::ffi::c_int
+        != 0
+    {
+        n += 1;
+    }
+    n
+}
+        "#,
+        &[
+            ".is_ascii_alphanumeric()",
+            ".is_ascii_alphabetic()",
+            "matches!",
+            "0x0b",
+        ],
+        &[
+            ".is_alphanumeric()",
+            ".is_alphabetic()",
+            ".is_whitespace()",
+            ".is_ascii_whitespace()",
+        ],
+    );
+}

--- a/crates/passes/src/libc_replacer/tests.rs
+++ b/crates/passes/src/libc_replacer/tests.rs
@@ -40,3 +40,27 @@ pub unsafe extern "C" fn foo(mut p: *mut s, mut q: *mut s) {
         &[],
     );
 }
+
+#[test]
+fn test_strncpy_from_short_slice_caps_copy_len() {
+    run_test(
+        r#"
+extern "C" {
+    fn strncpy(__dest: *mut i8, __src: *const i8, __n: usize) -> *mut i8;
+}
+
+pub unsafe fn copy_name(mut src: &[i8]) {
+    let mut dst = [1i8; 64];
+    strncpy(dst.as_mut_ptr(), src.as_ptr(), 63);
+}
+        "#,
+        &[
+            "std::ptr::write_bytes(___dst, 0, ___n)",
+            "std::ptr::copy_nonoverlapping(___src.as_ptr(), ___dst, ___len)",
+            "position(|&___c|",
+            "___c == 0",
+            ".min(___n)",
+        ],
+        &["copy_from_slice(&src[..63])"],
+    );
+}

--- a/crates/pointer_replacer/src/rewriter/collector.rs
+++ b/crates/pointer_replacer/src/rewriter/collector.rs
@@ -15,6 +15,7 @@ pub fn collect_diffs<'tcx>(
     analysis: &Analysis,
 ) -> FxHashMap<HirId, PtrKind> {
     let mut ptr_kinds = FxHashMap::default();
+    let non_outermost_owning_locals = collect_non_outermost_owning_hir_locals(rust_program);
 
     let fn_ptrs = collect_fn_ptrs(rust_program);
 
@@ -53,15 +54,59 @@ pub fn collect_diffs<'tcx>(
         // skip inputs if used as fn ptr
         {
             let aliases = aliases.and_then(|aliases| aliases.get(&local));
-            if let Some(ptr_kind) = decision_maker.decide(local, decl, aliases)
+            if let Some(mut ptr_kind) = decision_maker.decide(local, decl, aliases)
                 && let Some(hir_id) = local_to_binding.get(&local)
             {
+                if non_outermost_owning_locals.contains(hir_id)
+                    && matches!(ptr_kind, PtrKind::OptBox | PtrKind::OptBoxedSlice)
+                {
+                    ptr_kind = PtrKind::Raw(ptr_kind.is_mut());
+                }
                 ptr_kinds.insert(*hir_id, ptr_kind);
             }
         }
     }
 
     ptr_kinds
+}
+
+fn collect_non_outermost_owning_hir_locals(rust_program: &RustProgram) -> FxHashSet<HirId> {
+    fn local_path_id(expr: &rustc_hir::Expr<'_>) -> Option<HirId> {
+        if let ExprKind::Path(QPath::Resolved(_, path)) = expr.kind
+            && let Res::Local(hir_id) = path.res
+        {
+            Some(hir_id)
+        } else if let ExprKind::Cast(inner, _) = expr.kind {
+            local_path_id(inner)
+        } else {
+            None
+        }
+    }
+
+    struct NonOutermostCollector {
+        locals: FxHashSet<HirId>,
+    }
+
+    impl<'tcx> Visitor<'tcx> for NonOutermostCollector {
+        fn visit_expr(&mut self, ex: &'tcx rustc_hir::Expr<'tcx>) -> Self::Result {
+            if let ExprKind::Assign(lhs, rhs, _) = ex.kind
+                && !matches!(lhs.kind, ExprKind::Path(QPath::Resolved(_, path)) if matches!(path.res, Res::Local(_)))
+                && let Some(hir_id) = local_path_id(rhs)
+            {
+                self.locals.insert(hir_id);
+            }
+            walk_expr(self, ex);
+        }
+    }
+
+    let mut collector = NonOutermostCollector {
+        locals: FxHashSet::default(),
+    };
+    for def_id in rust_program.functions.iter() {
+        let body = rust_program.tcx.hir_body_owned_by(*def_id);
+        collector.visit_body(body);
+    }
+    collector.locals
 }
 
 pub fn collect_fn_ptrs(rust_program: &RustProgram) -> FxHashSet<LocalDefId> {

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -1533,7 +1533,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                         );
                     } else {
                         *ptr = utils::expr!(
-                            "std::slice::from_raw_parts{0}(&raw {1} ({2}) as *{1} _, 100000)",
+                            "std::slice::from_raw_parts{0}(&raw {1} ({2}) as *{1} _, 1_000_000)",
                             if m { "_mut" } else { "" },
                             if m { "mut" } else { "const" },
                             pprust::expr_to_string(e),
@@ -2696,14 +2696,14 @@ impl<'tcx> TransformVisitor<'tcx> {
             // we assume that the pointer is not null when such methods are called
             if !need_cast {
                 utils::expr!(
-                    "std::slice::from_raw_parts{}(({}){}, 100000)",
+                    "std::slice::from_raw_parts{}(({}){}, 1_000_000)",
                     if m { "_mut" } else { "" },
                     pprust::expr_to_string(e),
                     cast_mut,
                 )
             } else {
                 utils::expr!(
-                    "std::slice::from_raw_parts{}(({}){} as *{} _, 100000)",
+                    "std::slice::from_raw_parts{}(({}){} as *{} _, 1_000_000)",
                     if m { "_mut" } else { "" },
                     pprust::expr_to_string(e),
                     cast_mut,
@@ -2716,7 +2716,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                     "if ({0}).is_null() {{
                         &{1}[]
                     }} else {{
-                        std::slice::from_raw_parts{2}(({0}){3}, 100000)
+                        std::slice::from_raw_parts{2}(({0}){3}, 1_000_000)
                     }}",
                     pprust::expr_to_string(e),
                     if m { "mut " } else { "" },
@@ -2728,7 +2728,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                     "if ({0}).is_null() {{
                         &{1}[]
                     }} else {{
-                        std::slice::from_raw_parts{2}(({0}){3} as *{4} _, 100000)
+                        std::slice::from_raw_parts{2}(({0}){3} as *{4} _, 1_000_000)
                     }}",
                     pprust::expr_to_string(e),
                     if m { "mut " } else { "" },
@@ -2744,7 +2744,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                     if _x.is_null() {{
                         &{}[]
                     }} else {{
-                        std::slice::from_raw_parts{}(_x{}, 100000)
+                        std::slice::from_raw_parts{}(_x{}, 1_000_000)
                     }}
                 }}",
                 pprust::expr_to_string(e),
@@ -2759,7 +2759,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                     if _x.is_null() {{
                         &{}[]
                     }} else {{
-                        std::slice::from_raw_parts{}(_x{} as *{} _, 100000)
+                        std::slice::from_raw_parts{}(_x{} as *{} _, 1_000_000)
                     }}
                 }}",
                 pprust::expr_to_string(e),
@@ -2794,7 +2794,7 @@ impl<'tcx> TransformVisitor<'tcx> {
             // we assume that the pointer is not null when such methods are called
             if !need_cast {
                 utils::expr!(
-                    "{}::from_raw_parts{}(({}){}, 100000)",
+                    "{}::from_raw_parts{}(({}){}, 1_000_000)",
                     cursor_ty,
                     if m { "_mut" } else { "" },
                     pprust::expr_to_string(e),
@@ -2802,7 +2802,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                 )
             } else {
                 utils::expr!(
-                    "{}::from_raw_parts{}(({}){} as *{} _, 100000)",
+                    "{}::from_raw_parts{}(({}){} as *{} _, 1_000_000)",
                     cursor_ty,
                     if m { "_mut" } else { "" },
                     pprust::expr_to_string(e),
@@ -2816,7 +2816,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                     "if ({0}).is_null() {{
                         {1}::empty()
                     }} else {{
-                        {1}::from_raw_parts{2}(({0}){3}, 100000)
+                        {1}::from_raw_parts{2}(({0}){3}, 1_000_000)
                     }}",
                     pprust::expr_to_string(e),
                     cursor_ty,
@@ -2828,7 +2828,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                     "if ({0}).is_null() {{
                         {1}::empty()
                     }} else {{
-                        {1}::from_raw_parts{2}(({0}){3} as *{4} _, 100000)
+                        {1}::from_raw_parts{2}(({0}){3} as *{4} _, 1_000_000)
                     }}",
                     pprust::expr_to_string(e),
                     cursor_ty,
@@ -2844,7 +2844,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                     if _x.is_null() {{
                         {}::empty()
                     }} else {{
-                        {}::from_raw_parts{}(_x{}, 100000)
+                        {}::from_raw_parts{}(_x{}, 1_000_000)
                     }}
                 }}",
                 pprust::expr_to_string(e),
@@ -2860,7 +2860,7 @@ impl<'tcx> TransformVisitor<'tcx> {
                     if _x.is_null() {{
                         {}::empty()
                     }} else {{
-                        {}::from_raw_parts{}(_x{} as *{} _, 100000)
+                        {}::from_raw_parts{}(_x{} as *{} _, 1_000_000)
                     }}
                 }}",
                 pprust::expr_to_string(e),
@@ -2920,7 +2920,7 @@ impl<'tcx> TransformVisitor<'tcx> {
         } else {
             // can be used for deref, so type must be specified
             utils::expr!(
-                "std::slice::from_raw_parts{0}(({1}).as{0}_ptr() as *{2} {3}, 100000)",
+                "std::slice::from_raw_parts{0}(({1}).as{0}_ptr() as *{2} {3}, 1_000_000)",
                 if m { "_mut" } else { "" },
                 pprust::expr_to_string(e),
                 if m { "mut" } else { "const" },
@@ -3017,7 +3017,7 @@ impl<'tcx> TransformVisitor<'tcx> {
             )
         } else {
             utils::expr!(
-                "{}::from_raw_parts{}(({}).as_{}ptr() as *{} {}, 100000)",
+                "{}::from_raw_parts{}(({}).as_{}ptr() as *{} {}, 1_000_000)",
                 cursor_ty,
                 if m { "_mut" } else { "" },
                 pprust::expr_to_string(e),
@@ -3055,7 +3055,7 @@ impl<'tcx> TransformVisitor<'tcx> {
             )
         } else {
             utils::expr!(
-                "{}::from_raw_parts{}(({}).as_ptr() as *{} {}, 100000)",
+                "{}::from_raw_parts{}(({}).as_ptr() as *{} {}, 1_000_000)",
                 cursor_ty,
                 if m { "_mut" } else { "" },
                 pprust::expr_to_string(e),

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -1553,12 +1553,16 @@ impl<'tcx> TransformVisitor<'tcx> {
         }
 
         if pe.as_ptr && self.is_base_not_a_raw_ptr(&pe) {
-            let base = self.projected_expr(&pe, pe.as_mut_ptr, false);
-            let raw_expr = utils::expr!(
-                "({}).as_{}ptr()",
-                pprust::expr_to_string(&base),
-                if pe.as_mut_ptr { "mut_" } else { "" },
-            );
+            let raw_expr = if is_array_field_ptr_arithmetic(&pe) {
+                e.clone()
+            } else {
+                let base = self.projected_expr(&pe, pe.as_mut_ptr, false);
+                utils::expr!(
+                    "({}).as_{}ptr()",
+                    pprust::expr_to_string(&base),
+                    if pe.as_mut_ptr { "mut_" } else { "" },
+                )
+            };
             match ctx {
                 PtrCtx::Rhs(PtrKind::Raw(m)) => {
                     if !need_cast {
@@ -3981,6 +3985,19 @@ fn ty_is_byte_sized_raw_inner(ty: ty::Ty<'_>) -> bool {
         ty.kind(),
         ty::TyKind::Int(ty::IntTy::I8) | ty::TyKind::Uint(ty::UintTy::U8)
     )
+}
+
+fn is_array_field_ptr_arithmetic(pe: &PtrExpr<'_, '_>) -> bool {
+    pe.as_ptr
+        && pe.as_mut_ptr
+        && pe.base_ty.is_array()
+        && matches!(unwrap_paren(pe.base).kind, ExprKind::Field(..))
+        && pe.projs.iter().any(|proj| {
+            matches!(
+                proj,
+                PtrExprProj::Offset(_) | PtrExprProj::IntegerOp(..) | PtrExprProj::IntegerBinOp(..)
+            )
+        })
 }
 
 fn hir_is_casted_local(rhs: &hir::Expr<'_>, target: HirId) -> bool {

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -237,7 +237,14 @@ impl MutVisitor for TransformVisitor<'_> {
             let hir_body = self.tcx.hir_body(body_id);
             let hir::ExprKind::Block(hir_block, _) = hir_body.value.kind else { return };
             let Some(hir_tail) = hir_block.expr else { return };
-            self.transform_rhs(expr, hir_tail, output_kind);
+            let return_decl = self
+                .tcx
+                .mir_drops_elaborated_and_const_checked(def_id)
+                .borrow()
+                .local_decls[rustc_middle::mir::Local::from_u32(0)]
+            .ty;
+            let Some((lhs_inner_ty, _)) = unwrap_ptr_from_mir_ty(return_decl) else { return };
+            self.transform_return_rhs(expr, hir_tail, output_kind, lhs_inner_ty);
         }
     }
 
@@ -591,13 +598,14 @@ impl MutVisitor for TransformVisitor<'_> {
                     .skip_binder()
                     .skip_binder();
                 if let ty::TyKind::RawPtr(_, m) = sig.output().kind() {
+                    let (lhs_inner_ty, _) = unwrap_ptr_from_mir_ty(sig.output()).unwrap();
                     let kind = self
                         .sig_decs
                         .data
                         .get(&hir_ret.hir_id.owner.def_id)
                         .and_then(|sd| sd.output_dec)
                         .unwrap_or(PtrKind::Raw(m.is_mut()));
-                    self.transform_rhs(ret, hir_ret, kind);
+                    self.transform_return_rhs(ret, hir_ret, kind, lhs_inner_ty);
                 } else if let ty::TyKind::Tuple(tys) = sig.output().kind() {
                     let ExprKind::Tup(elems) = &mut ret.kind else {
                         panic!("expected tuple expr for tuple return type")
@@ -607,10 +615,12 @@ impl MutVisitor for TransformVisitor<'_> {
                     };
                     for (i, elem_ty) in tys.iter().enumerate() {
                         if let ty::TyKind::RawPtr(_, m) = elem_ty.kind() {
-                            self.transform_rhs(
+                            let (lhs_inner_ty, _) = unwrap_ptr_from_mir_ty(elem_ty).unwrap();
+                            self.transform_return_rhs(
                                 &mut elems[i],
                                 &hir_elems[i],
                                 PtrKind::Raw(m.is_mut()),
+                                lhs_inner_ty,
                             );
                         }
                     }
@@ -840,6 +850,50 @@ impl<'tcx> TransformVisitor<'tcx> {
                 utils::expr!("{ptr_expr}")
             }
         }
+    }
+
+    fn transform_return_rhs(
+        &mut self,
+        rhs: &mut Expr,
+        hir_rhs: &'tcx hir::Expr<'tcx>,
+        output_kind: PtrKind,
+        lhs_inner_ty: ty::Ty<'tcx>,
+    ) {
+        let PtrKind::Raw(m) = output_kind else {
+            self.transform_rhs(rhs, hir_rhs, output_kind);
+            return;
+        };
+        let Some((rhs_inner_ty, _)) = unwrap_ptr_from_mir_ty(
+            self.tcx
+                .typeck(hir_rhs.hir_id.owner)
+                .expr_ty_adjusted(hir_rhs),
+        ) else {
+            self.transform_rhs(rhs, hir_rhs, output_kind);
+            return;
+        };
+        let rhs_expr = unwrap_addr_of_deref(unwrap_cast_and_paren(rhs));
+        let hir_rhs_expr = hir_unwrap_addr_of_deref(hir_unwrap_cast(hir_rhs));
+        if let Some(pe) = self.ptr_expr(rhs_expr, hir_rhs_expr)
+            && pe.projs.is_empty()
+        {
+            match self.ptr_source_kind(&pe) {
+                Some(PtrKind::OptBox) => {
+                    *rhs = self.raw_from_opt_box_return(pe.base, m, lhs_inner_ty, rhs_inner_ty);
+                    return;
+                }
+                Some(PtrKind::OptBoxedSlice) => {
+                    *rhs = self.raw_from_opt_boxed_slice_return(
+                        pe.base,
+                        m,
+                        lhs_inner_ty,
+                        rhs_inner_ty,
+                    );
+                    return;
+                }
+                _ => {}
+            }
+        }
+        self.transform_rhs(rhs, hir_rhs, output_kind);
     }
 
     fn rewrite_direct_free_call(
@@ -2275,6 +2329,81 @@ impl<'tcx> TransformVisitor<'tcx> {
                 if m { "mut" } else { "const" },
                 rhs_ty,
                 if m { "mut" } else { "const" },
+                lhs_ty,
+            )
+        }
+    }
+
+    fn raw_from_opt_box_return(
+        &self,
+        e: &Expr,
+        m: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let lhs_ty = mir_ty_to_string(lhs_inner_ty, self.tcx);
+        let rhs_ty = mir_ty_to_string(rhs_inner_ty, self.tcx);
+        let null = if m { "null_mut" } else { "null" };
+        if lhs_inner_ty == rhs_inner_ty {
+            if m {
+                utils::expr!(
+                    "({}).map_or(std::ptr::null_mut::<{}>(), |_x| Box::into_raw(_x) as *mut {})",
+                    pprust::expr_to_string(e),
+                    lhs_ty,
+                    lhs_ty,
+                )
+            } else {
+                utils::expr!(
+                    "({}).map_or(std::ptr::null::<{}>(), |_x| Box::into_raw(_x) as *const {})",
+                    pprust::expr_to_string(e),
+                    lhs_ty,
+                    lhs_ty,
+                )
+            }
+        } else {
+            utils::expr!(
+                "({}).map_or(std::ptr::{}::<{}>(), |_x| Box::into_raw(_x) as *{} {} as *{} {})",
+                pprust::expr_to_string(e),
+                null,
+                lhs_ty,
+                if m { "mut" } else { "const" },
+                rhs_ty,
+                if m { "mut" } else { "const" },
+                lhs_ty,
+            )
+        }
+    }
+
+    fn raw_from_opt_boxed_slice_return(
+        &self,
+        e: &Expr,
+        m: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let lhs_ty = mir_ty_to_string(lhs_inner_ty, self.tcx);
+        let rhs_ty = mir_ty_to_string(rhs_inner_ty, self.tcx);
+        let ptr_method = if m { "as_mut_ptr" } else { "as_ptr" };
+        let ptr_mut = if m { "mut" } else { "const" };
+        let null = if m { "null_mut" } else { "null" };
+        if lhs_inner_ty == rhs_inner_ty {
+            utils::expr!(
+                "({}).map_or(std::ptr::{}::<{}>(), |_x| Box::leak(_x).{}())",
+                pprust::expr_to_string(e),
+                null,
+                lhs_ty,
+                ptr_method,
+            )
+        } else {
+            utils::expr!(
+                "({}).map_or(std::ptr::{}::<{}>(), |_x| Box::leak(_x).{}() as *{} {} as *{} {})",
+                pprust::expr_to_string(e),
+                null,
+                lhs_ty,
+                ptr_method,
+                ptr_mut,
+                rhs_ty,
+                ptr_mut,
                 lhs_ty,
             )
         }

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -6252,9 +6252,9 @@ fn collect_raw_local_assignment_bindings(
     ptr_kinds: &FxHashMap<HirId, PtrKind>,
 ) -> FxHashSet<HirId> {
     struct RawLocalBindingVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
         ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
         bindings: FxHashSet<HirId>,
-        _marker: std::marker::PhantomData<TyCtxt<'tcx>>,
     }
 
     impl<'tcx> Visitor<'tcx> for RawLocalBindingVisitor<'_, 'tcx> {
@@ -6265,6 +6265,12 @@ fn collect_raw_local_assignment_bindings(
                 && let hir::ExprKind::Path(hir::QPath::Resolved(_, rhs_path)) = rhs.kind
                 && let Res::Local(rhs_hir_id) = rhs_path.res
                 && matches!(self.ptr_kinds.get(&rhs_hir_id), Some(PtrKind::Raw(_)))
+            {
+                self.bindings.insert(lhs_hir_id);
+            }
+            if let hir::ExprKind::Assign(lhs, rhs, _) = expr.kind
+                && let Some(lhs_hir_id) = hir_deref_addr_of_local(lhs)
+                && self.tcx.typeck(rhs.hir_id.owner).expr_ty(rhs).is_raw_ptr()
             {
                 self.bindings.insert(lhs_hir_id);
             }
@@ -6286,14 +6292,26 @@ fn collect_raw_local_assignment_bindings(
         };
         let body = tcx.hir_body(body);
         let mut visitor = RawLocalBindingVisitor {
+            tcx,
             ptr_kinds,
             bindings: FxHashSet::default(),
-            _marker: std::marker::PhantomData,
         };
         visitor.visit_expr(body.value);
         bindings.extend(visitor.bindings);
     }
     bindings
+}
+
+fn hir_deref_addr_of_local(expr: &hir::Expr<'_>) -> Option<HirId> {
+    let hir::ExprKind::Unary(hir::UnOp::Deref, addr_of) = expr.kind else {
+        return None;
+    };
+    let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Mut, pointee) =
+        utils::hir::unwrap_drop_temps(addr_of).kind
+    else {
+        return None;
+    };
+    hir_unwrapped_local_id(pointee)
 }
 
 fn hir_rhs_supports_box_target<'tcx>(

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -4589,6 +4589,25 @@ fn hir_unwrapped_local_id(expr: &hir::Expr<'_>) -> Option<HirId> {
     Some(hir_id)
 }
 
+fn hir_local_ids_in_expr(expr: &hir::Expr<'_>) -> Vec<HirId> {
+    struct LocalUseVisitor {
+        locals: Vec<HirId>,
+    }
+
+    impl<'tcx> Visitor<'tcx> for LocalUseVisitor {
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            if let Some(hir_id) = hir_unwrapped_local_id(expr) {
+                self.locals.push(hir_id);
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut visitor = LocalUseVisitor { locals: Vec::new() };
+    visitor.visit_expr(expr);
+    visitor.locals
+}
+
 fn hir_expr_verbatim_snippet(tcx: TyCtxt<'_>, expr: &hir::Expr<'_>) -> Option<String> {
     tcx.sess.source_map().span_to_snippet(expr.span).ok()
 }
@@ -5130,6 +5149,18 @@ fn collect_local_allocator_wrappers(tcx: TyCtxt<'_>) -> FxHashMap<LocalDefId, Al
                 }
             }
 
+            fn mark_disqualified_for_lhs_use(&mut self, hir_id: HirId) {
+                if let Some(root) = self.root_of.get(&hir_id).copied()
+                    && self
+                        .candidates
+                        .get(&root)
+                        .is_some_and(|candidate| candidate.byte_view_aliases.contains(&hir_id))
+                {
+                    return;
+                }
+                self.mark_disqualified(hir_id);
+            }
+
             fn mark_returned(&mut self, hir_id: HirId) {
                 if let Some(root) = self.root_of.get(&hir_id).copied() {
                     if self
@@ -5247,8 +5278,18 @@ fn collect_local_allocator_wrappers(tcx: TyCtxt<'_>) -> FxHashMap<LocalDefId, Al
                                 }
                             }
                             self.record_scalar_local(lhs_hir_id, rhs);
-                        } else if let Some(rhs_hir_id) = hir_unwrapped_local_id(rhs) {
-                            self.mark_disqualified(rhs_hir_id);
+                        } else {
+                            for lhs_hir_id in hir_local_ids_in_expr(lhs) {
+                                self.mark_disqualified_for_lhs_use(lhs_hir_id);
+                            }
+                            if let Some(rhs_hir_id) = hir_unwrapped_local_id(rhs) {
+                                self.mark_disqualified(rhs_hir_id);
+                            }
+                        }
+                    }
+                    hir::ExprKind::AssignOp(_, lhs, _) => {
+                        for lhs_hir_id in hir_local_ids_in_expr(lhs) {
+                            self.mark_disqualified_for_lhs_use(lhs_hir_id);
                         }
                     }
                     hir::ExprKind::Ret(Some(ret)) => {
@@ -5885,6 +5926,13 @@ fn collect_raw_bridge_bindings(
             }
         }
 
+        fn disqualify_lhs_use(&mut self, hir_id: HirId) {
+            if self.byte_view_aliases.contains(&hir_id) {
+                return;
+            }
+            self.disqualify_local(hir_id);
+        }
+
         fn update_local_from_rhs(
             &mut self,
             lhs_hir_id: HirId,
@@ -5982,6 +6030,13 @@ fn collect_raw_bridge_bindings(
                 && hir_unwrapped_local_id(lhs).is_none()
             {
                 self.disqualify_local(rhs_hir_id);
+            }
+            if let hir::ExprKind::Assign(lhs, _, _) | hir::ExprKind::AssignOp(_, lhs, _) = expr.kind
+                && hir_unwrapped_local_id(lhs).is_none()
+            {
+                for lhs_hir_id in hir_local_ids_in_expr(lhs) {
+                    self.disqualify_lhs_use(lhs_hir_id);
+                }
             }
             if let hir::ExprKind::Call(_, args) = expr.kind {
                 let free_arg = hir_free_like_arg_local_id(self.tcx, expr, self.free_like_wrappers)

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -700,8 +700,13 @@ enum PtrCtx {
 
 #[derive(Clone, Copy, Debug)]
 enum AllocatorRoot<'a> {
-    Malloc { bytes: &'a Expr },
-    Calloc { count: &'a Expr },
+    Malloc {
+        bytes: &'a Expr,
+    },
+    Calloc {
+        count: &'a Expr,
+        elem_size: &'a Expr,
+    },
 }
 
 impl<'tcx> TransformVisitor<'tcx> {
@@ -2109,7 +2114,7 @@ impl<'tcx> TransformVisitor<'tcx> {
         let name = path.segments.last()?.ident.name.as_str();
         match (name, &args[..]) {
             ("malloc", [bytes]) => Some(AllocatorRoot::Malloc { bytes }),
-            ("calloc", [count, _elem_size]) => Some(AllocatorRoot::Calloc { count }),
+            ("calloc", [count, elem_size]) => Some(AllocatorRoot::Calloc { count, elem_size }),
             ("realloc", [ptr, bytes]) if is_null_like_ptr_arg(ptr) => {
                 Some(AllocatorRoot::Malloc { bytes })
             }
@@ -2207,11 +2212,12 @@ impl<'tcx> TransformVisitor<'tcx> {
                 *ptr = utils::expr!("Some(Box::new({default_expr_str}))");
                 Some(PtrKind::OptBox)
             }
-            (PtrKind::OptBoxedSlice, AllocatorRoot::Calloc { count }) => {
+            (PtrKind::OptBoxedSlice, AllocatorRoot::Calloc { count, elem_size }) => {
                 *ptr = utils::expr!(
-                    "Some(std::iter::repeat_with(|| {0}).take(({1}) as usize).collect::<Vec<{2}>>().into_boxed_slice())",
+                    "Some(std::iter::repeat_with(|| {0}).take((({1}) * ({2}) / std::mem::size_of::<{3}>()) as usize).collect::<Vec<{3}>>().into_boxed_slice())",
                     default_expr_str,
                     pprust::expr_to_string(count),
+                    pprust::expr_to_string(elem_size),
                     ty,
                 );
                 Some(PtrKind::OptBoxedSlice)

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -2522,7 +2522,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
 
 /// addr_of with Slice context, non-bytemuck cast: different-size numerics
 /// (c_int vs c_short) with .offset() usage.
-/// Output: `std::slice::from_raw_parts_mut(&raw mut (x) as *mut _, 100000)`.
+/// Output: `std::slice::from_raw_parts_mut(&raw mut (x) as *mut _, 1_000_000)`.
 #[test]
 fn test_addr_of_slice_cast() {
     run_test(

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -2811,8 +2811,12 @@ pub unsafe fn complexmode(
     result
 }
 "#,
-        &["let mut log_msg___v: *mut i8"],
-        &["let mut log_msg___v: *const i8"],
+        &[
+            "let mut log_msg___v: *mut i8",
+            "let mut log_message: *mut i8",
+            "log_message)).unwrap() = rv___t.1",
+        ],
+        &["let mut log_msg___v: *const i8", "let mut log_message: &"],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -359,7 +359,7 @@ pub unsafe fn foo() {
         &[
             "pub unsafe fn keep_raw() -> *mut i32",
             "Option<Box<i32>>",
-            "map_or(std::ptr::null_mut::<i32>(), |_x| _x)",
+            "Box::into_raw(_x) as *mut i32",
             "let fp: unsafe fn() -> *mut i32 = keep_raw;",
         ],
         &[],
@@ -391,7 +391,7 @@ pub unsafe fn foo() {
             "as_deref_mut().unwrap_or(&mut [])",
             "let fp: unsafe fn() -> *mut i32 = keep_raw_arr;",
         ],
-        &["-> Option<Box<[i32]>>", "Box::into_raw(", "Box::leak("],
+        &["-> Option<Box<[i32]>>", "Box::into_raw("],
     );
 }
 
@@ -1725,7 +1725,7 @@ pub unsafe fn caller() -> *mut i32 {
         &[
             "fn alloc_one() -> *mut i32",
             "let mut p: Option<Box<i32>>",
-            "as_deref_mut().map_or(std::ptr::null_mut::<i32>(), |_x| _x)",
+            "Box::into_raw(_x) as *mut i32",
         ],
         &[],
     );
@@ -1756,7 +1756,7 @@ pub unsafe fn caller() -> *mut i32 {
             "as_deref_mut().unwrap_or(&mut [])",
             "let f: unsafe fn() -> *mut i32 = alloc_arr;",
         ],
-        &["-> Option<Box<[i32]>>", "Box::into_raw(", "Box::leak("],
+        &["-> Option<Box<[i32]>>", "Box::into_raw("],
     );
 }
 
@@ -1780,7 +1780,7 @@ pub unsafe fn maybe_alloc(flag: bool) -> *mut i32 {
         &[
             "fn maybe_alloc(flag: bool) -> *const i32",
             "std::ptr::null()",
-            "as_deref().map_or(std::ptr::null::<i32>(), |_x| _x)",
+            "Box::into_raw(_x) as *const i32",
         ],
         &["-> Option<Box<i32>>"],
     );

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -797,6 +797,54 @@ pub unsafe fn caller() {
 }
 
 #[test]
+fn test_rewriter_keeps_initialized_allocator_wrapper_call_raw() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+#[repr(C)]
+pub struct BufferArray {
+    pub buffers: *mut i32,
+    pub count: i32,
+}
+
+pub unsafe fn alloc_array(count: i32) -> *mut BufferArray {
+    let arr: *mut BufferArray =
+        malloc(std::mem::size_of::<BufferArray>()) as *mut BufferArray;
+    if arr.is_null() {
+        return std::ptr::null_mut();
+    }
+    (*arr).buffers = malloc((count as usize) * std::mem::size_of::<i32>()) as *mut i32;
+    (*arr).count = count;
+    arr
+}
+
+pub unsafe fn free_array(arr: *mut BufferArray) {
+    free((*arr).buffers as *mut core::ffi::c_void);
+    free(arr as *mut core::ffi::c_void);
+}
+
+pub unsafe fn caller(count: i32) {
+    let arr: *mut BufferArray = alloc_array(count);
+    if arr.is_null() {
+        return;
+    }
+    *(*arr).buffers = 1;
+    free_array(arr);
+}
+"#,
+        &[
+            "alloc_array(count)",
+            "(*arr.as_deref_mut().unwrap()).buffers =\n        malloc((count as usize) * std::mem::size_of::<i32>())",
+        ],
+        &["let mut arr: *mut crate::BufferArray = Box::into_raw(Box::new"],
+    );
+}
+
+#[test]
 fn test_rewriter_generalizes_wrapper_with_internal_free_after_foreign_use() {
     run_test(
         r#"

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -99,6 +99,33 @@ pub unsafe fn foo() -> *mut i32 {
 }
 
 #[test]
+fn test_rewriter_keeps_field_stored_malloc_raw() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub data: *mut i32,
+}
+
+pub unsafe fn stash(owner: *mut Holder) {
+    let data: *mut i32 = malloc(std::mem::size_of::<i32>());
+    *data = 7;
+    (*owner).data = data;
+}
+"#,
+        &[
+            "malloc(std::mem::size_of::<i32>())",
+            "(*owner).data = data;",
+        ],
+        &["Option<Box<i32>>", "Some(Box::new("],
+    );
+}
+
+#[test]
 fn test_rewriter_rewrites_malloc_casted_sizeof_local_struct_to_opt_box() {
     run_test(
         r#"

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -219,6 +219,29 @@ pub unsafe fn foo() -> *mut i32 {
 }
 
 #[test]
+fn test_rewriter_rewrites_byte_calloc_size_to_opt_boxed_slice_len() {
+    run_test(
+        r#"
+extern "C" {
+    fn calloc(count: usize, size: usize) -> *mut core::ffi::c_void;
+}
+
+pub unsafe fn make_buf(len: usize) -> *mut core::ffi::c_char {
+    let p: *mut core::ffi::c_char = calloc(1, len) as *mut core::ffi::c_char;
+    *p.offset(len.wrapping_sub(1) as isize) = 0;
+    p
+}
+"#,
+        &[
+            "pub unsafe fn make_buf(len: usize) -> Option<Box<[i8]>>",
+            ".take(((1) * (len) /",
+            "std::mem::size_of::<i8>()) as",
+        ],
+        &["Box::leak(", "Box::into_raw(", "calloc(1, len)"],
+    );
+}
+
+#[test]
 fn test_rewriter_rewrites_malloc_array_to_opt_boxed_slice() {
     run_test(
         r#"

--- a/crates/static_replacer/src/transformation.rs
+++ b/crates/static_replacer/src/transformation.rs
@@ -8,7 +8,10 @@ use rustc_hir::{
     def_id::LocalDefId,
     intravisit,
 };
-use rustc_middle::{hir::nested_filter, ty::TyCtxt};
+use rustc_middle::{
+    hir::nested_filter,
+    ty::{self, Ty, TyCtxt},
+};
 use rustc_span::{Symbol, sym};
 use utils::{expr, item};
 
@@ -102,6 +105,17 @@ impl<'tcx> AstVisitor<'tcx> {
         }
     }
 
+    fn has_only_new_shared_borrows(&self, had_previous_borrows: bool) -> bool {
+        !had_previous_borrows
+            && !self.borrows.is_empty()
+            && self.borrows.values().all(|is_mut| !*is_mut)
+    }
+
+    fn hir_expr_type_contains_ref_or_raw_ptr(&self, expr: &hir::Expr<'_>) -> bool {
+        let typeck = self.tcx.typeck(expr.hir_id.owner);
+        ty_contains_ref_or_raw_ptr(typeck.expr_ty(expr))
+    }
+
     fn get_hir_parent(&self, hir_id: HirId) -> hir::Node<'tcx> {
         for (_, node) in self.tcx.hir_parent_iter(hir_id) {
             if let hir::Node::Expr(e) = node
@@ -149,6 +163,7 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
     }
 
     fn visit_expr(&mut self, expr: &mut Expr) {
+        let had_previous_borrows = !self.borrows.is_empty();
         mut_visit::walk_expr(self, expr);
 
         let hir_expr = some_or!(self.ast_to_hir.get_expr(expr.id, self.tcx), return);
@@ -340,6 +355,18 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
 
         match self.get_hir_parent(hir_expr.hir_id) {
             hir::Node::Expr(e) => {
+                if self.has_only_new_shared_borrows(had_previous_borrows)
+                    && match e.kind {
+                        hir::ExprKind::Call(_, args) => {
+                            args.iter().any(|arg| arg.hir_id == hir_expr.hir_id)
+                        }
+                        _ => false,
+                    }
+                    && !self.hir_expr_type_contains_ref_or_raw_ptr(hir_expr)
+                {
+                    self.introduce_borrow(expr);
+                }
+
                 if let hir::ExprKind::If(p, _, _) | hir::ExprKind::Ret(Some(p)) = e.kind
                     && std::iter::once(hir_expr.hir_id)
                         .chain(self.tcx.hir_parent_id_iter(hir_expr.hir_id))
@@ -390,6 +417,16 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
             }
             _ => {}
         }
+    }
+}
+
+fn ty_contains_ref_or_raw_ptr(ty: Ty<'_>) -> bool {
+    match ty.kind() {
+        ty::Ref(..) | ty::RawPtr(..) => true,
+        ty::Array(ty, _) | ty::Slice(ty) => ty_contains_ref_or_raw_ptr(*ty),
+        ty::Tuple(tys) => tys.iter().any(ty_contains_ref_or_raw_ptr),
+        ty::Adt(_, args) => args.types().any(ty_contains_ref_or_raw_ptr),
+        _ => false,
     }
 }
 
@@ -842,6 +879,117 @@ unsafe fn g(x: &mut [i32; 10]) -> i32 { x[0] }
             code,
             &["thread_local", "std::cell::RefCell", ".with_borrow("],
             &["static mut"],
+        );
+    }
+
+    #[test]
+    fn test_refcell_call_arg_read() {
+        let code = r#"
+struct Node { id: i32, active: i32 }
+impl Copy for Node {}
+impl Clone for Node { fn clone(&self) -> Self { *self } }
+static mut S: [Node; 10] = [Node { id: 0, active: 0 }; 10];
+unsafe fn f() -> *mut Node { S.as_mut_ptr() }
+unsafe fn g() -> i32 {
+    let mut sum = 0;
+    let mut i = 0;
+    while i < 10 {
+        if S[i].active != 0 {
+            sum += h(S[i].id);
+        }
+        i += 1;
+    }
+    sum
+}
+unsafe fn h(x: i32) -> i32 { x }
+"#;
+        run_test(
+            code,
+            &["thread_local", "std::cell::RefCell", "h(S.with_borrow("],
+            &["static mut", "S.with_borrow(|S_ref| sum += h"],
+        );
+    }
+
+    #[test]
+    fn test_refcell_option_ref_call_arg() {
+        let code = r#"
+struct Hooks { allocate: Option<unsafe fn(usize) -> *mut u8> }
+static mut global_hooks: Hooks = Hooks { allocate: None };
+unsafe fn f() -> usize {
+    global_hooks.allocate = None;
+    new_item(Some(&global_hooks))
+}
+unsafe fn new_item(hooks: Option<&Hooks>) -> usize {
+    if hooks.is_some() { 1 } else { 0 }
+}
+"#;
+        run_test(
+            code,
+            &[
+                "thread_local",
+                "std::cell::RefCell",
+                "global_hooks.with_borrow(|global_hooks_ref|",
+                "new_item(Some(global_hooks_ref))",
+            ],
+            &[
+                "static mut",
+                "new_item(global_hooks.with_borrow(|global_hooks_ref| Some(global_hooks_ref)))",
+            ],
+        );
+    }
+
+    #[test]
+    fn test_refcell_function_pointer_field_call() {
+        let code = r#"
+struct Hooks { deallocate: Option<unsafe fn(*mut u8)> }
+static mut global_hooks: Hooks = Hooks { deallocate: None };
+unsafe fn f(ptr: *mut u8) {
+    touch(&mut global_hooks);
+    global_hooks.deallocate = None;
+    if global_hooks.deallocate.is_some() {
+        (global_hooks.deallocate).unwrap()(ptr);
+    }
+}
+unsafe fn touch(hooks: &mut Hooks) {}
+"#;
+        run_test(
+            code,
+            &[
+                "thread_local",
+                "std::cell::RefCell",
+                "global_hooks.with_borrow(|global_hooks_ref|",
+                "(global_hooks_ref.deallocate).unwrap()(ptr)",
+            ],
+            &[
+                "static mut",
+                "(global_hooks_ref.deallocate).unwrap()(global_hooks.with_borrow(",
+            ],
+        );
+    }
+
+    #[test]
+    fn test_refcell_reference_arg_keeps_later_args_in_scope() {
+        let code = r#"
+static mut S: [i32; 2] = [0; 2];
+unsafe fn f() {
+    g(S.as_mut_ptr());
+    h(std::slice::from_ref(&S[0]), S[1]);
+}
+unsafe fn g(x: *mut i32) { *x = 1; }
+unsafe fn h(x: &[i32], y: i32) -> i32 { x[0] + y }
+"#;
+        run_test(
+            code,
+            &[
+                "thread_local",
+                "std::cell::RefCell",
+                "S.with_borrow(|S_ref| h(std::slice::from_ref(&S_ref[0]), S_ref[1]))",
+            ],
+            &[
+                "static mut",
+                "h(std::slice::from_ref(&S.with_borrow(",
+                "S.with_borrow(|S_ref| S_ref[1])",
+            ],
         );
     }
 }

--- a/crates/static_replacer/src/transformation.rs
+++ b/crates/static_replacer/src/transformation.rs
@@ -376,6 +376,18 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
             hir::Node::Stmt(_) | hir::Node::LetStmt(_) => {
                 self.introduce_borrow(expr);
             }
+            hir::Node::Block(block) => {
+                let mut parent = self.get_hir_parent(block.hir_id);
+                if let hir::Node::Expr(e) = parent
+                    && matches!(e.kind, hir::ExprKind::Block(..))
+                {
+                    parent = self.get_hir_parent(e.hir_id);
+                }
+                if !matches!(parent, hir::Node::Expr(e) if matches!(e.kind, hir::ExprKind::If(..)))
+                {
+                    self.introduce_borrow(expr);
+                }
+            }
             _ => {}
         }
     }
@@ -409,7 +421,7 @@ fn find_context<'a, 'tcx>(
                                 expr = parent;
                                 mutated = true;
                             }
-                            "as_ptr" => {
+                            "as_ptr" | "offset" => {
                                 expr = parent;
                             }
                             "is_null" | "is_none" | "is_some" | "unwrap" | "expect" => {}
@@ -791,6 +803,23 @@ unsafe fn f() {
         run_test(
             code,
             &["thread_local", "std::cell::RefCell", ".with_borrow_mut("],
+            &["static mut"],
+        );
+    }
+
+    #[test]
+    fn test_refcell_field_offset() {
+        let code = r#"
+struct S { p: *const u8, i: usize }
+static mut S: S = S { p: 0 as *const u8, i: 0 };
+unsafe fn f() -> *const u8 {
+    S.i = 1;
+    S.p.offset(S.i as isize)
+}
+"#;
+        run_test(
+            code,
+            &["thread_local", "std::cell::RefCell", ".with_borrow("],
             &["static mut"],
         );
     }

--- a/crates/utils/src/c_lib.rs
+++ b/crates/utils/src/c_lib.rs
@@ -93,7 +93,7 @@ fn parse_integer<R: std::io::BufRead>(
     match u64::from_str_radix(&num, base) {
         Ok(v) => {
             if !signed {
-                (Some(v), false)
+                (Some(if negative { v.wrapping_neg() } else { v }), false)
             } else if !negative {
                 if v > i64::MAX as u64 {
                     (Some(i64::MAX as u64), true)

--- a/crates/utils/src/file/fscanf.rs
+++ b/crates/utils/src/file/fscanf.rs
@@ -4,8 +4,15 @@ pub fn parse_specs(mut remaining: &[u8]) -> Vec<ConversionSpec> {
         let res = parse_format(remaining);
         if let Some(rem) = res.remaining {
             remaining = rem;
-            specs.push(res.conversion_spec.unwrap());
+            let mut conversion_spec = res.conversion_spec.unwrap();
+            conversion_spec.leading_space = res.prefix.iter().any(u8::is_ascii_whitespace);
+            specs.push(conversion_spec);
         } else {
+            if res.prefix.iter().any(u8::is_ascii_whitespace)
+                && let Some(last) = specs.last_mut()
+            {
+                last.trailing_space = true;
+            }
             break specs;
         }
     }
@@ -148,6 +155,8 @@ fn parse_format(s: &[u8]) -> ParseResult<'_> {
                     width,
                     length,
                     conversion,
+                    leading_space: false,
+                    trailing_space: false,
                 }),
                 remaining: Some(&s[last_idx + 1..]),
             }
@@ -343,6 +352,8 @@ pub struct ConversionSpec {
     pub width: Option<usize>,
     pub length: Option<LengthMod>,
     pub conversion: Conversion,
+    pub leading_space: bool,
+    pub trailing_space: bool,
 }
 
 impl std::fmt::Display for ConversionSpec {
@@ -385,7 +396,9 @@ fn test_scanf_parse() {
             assign: true,
             width: None,
             length: None,
-            conversion: Conversion::Int10
+            conversion: Conversion::Int10,
+            leading_space: false,
+            trailing_space: false,
         }
     );
     assert_eq!(
@@ -394,7 +407,9 @@ fn test_scanf_parse() {
             assign: true,
             width: None,
             length: Some(LengthMod::Long),
-            conversion: Conversion::Int10
+            conversion: Conversion::Int10,
+            leading_space: false,
+            trailing_space: false,
         }
     );
     assert_eq!(
@@ -403,7 +418,9 @@ fn test_scanf_parse() {
             assign: true,
             width: None,
             length: Some(LengthMod::Char),
-            conversion: Conversion::Int10
+            conversion: Conversion::Int10,
+            leading_space: false,
+            trailing_space: false,
         }
     );
     assert_eq!(
@@ -412,7 +429,9 @@ fn test_scanf_parse() {
             assign: true,
             width: Some(10),
             length: None,
-            conversion: Conversion::Str
+            conversion: Conversion::Str,
+            leading_space: false,
+            trailing_space: false,
         }
     );
     assert_eq!(
@@ -421,7 +440,9 @@ fn test_scanf_parse() {
             assign: false,
             width: None,
             length: None,
-            conversion: Conversion::Str
+            conversion: Conversion::Str,
+            leading_space: false,
+            trailing_space: false,
         }
     );
     assert_eq!(
@@ -433,7 +454,9 @@ fn test_scanf_parse() {
             conversion: Conversion::ScanSet(ScanSet {
                 negative: false,
                 chars: vec![b'a', b'b', b'c', b'd']
-            })
+            }),
+            leading_space: false,
+            trailing_space: false,
         }
     );
     assert_eq!(
@@ -445,7 +468,16 @@ fn test_scanf_parse() {
             conversion: Conversion::ScanSet(ScanSet {
                 negative: true,
                 chars: vec![b'\n']
-            })
+            }),
+            leading_space: false,
+            trailing_space: false,
         }
     );
+
+    let specs = parse_specs(b"%d %3[A-Z] ");
+    assert_eq!(specs.len(), 2);
+    assert!(!specs[0].leading_space);
+    assert!(!specs[0].trailing_space);
+    assert!(specs[1].leading_space);
+    assert!(specs[1].trailing_space);
 }

--- a/src/bin/crat.rs
+++ b/src/bin/crat.rs
@@ -486,7 +486,7 @@ fn main() {
             Pass::Libc => {
                 let res = run_compiler_on_path(&file, libc_replacer::replace_libc).unwrap();
                 std::fs::write(&file, res.code).unwrap();
-                if res.bytemuck {
+                if res.bytemuck && !utils::has_dependency(&dir, "bytemuck") {
                     utils::add_dependency(&dir, "bytemuck", "1.24.0");
                 }
                 if res.num_traits {
@@ -535,7 +535,7 @@ fn main() {
                 if res.dependencies.tempfile.get() {
                     utils::add_dependency(&dir, "tempfile", "3.19.1");
                 }
-                if res.dependencies.bytemuck.get() {
+                if res.dependencies.bytemuck.get() && !utils::has_dependency(&dir, "bytemuck") {
                     utils::add_dependency(&dir, "bytemuck", "1.24.0");
                 }
                 if res.dependencies.num_traits.get() {
@@ -556,7 +556,7 @@ fn main() {
                 })
                 .unwrap();
                 std::fs::write(&file, s).unwrap();
-                if bytemuck {
+                if bytemuck && !utils::has_dependency(&dir, "bytemuck") {
                     utils::add_dependency(&dir, "bytemuck", "1.24.0");
                 }
             }


### PR DESCRIPTION
## Summary
- Tightens IO transformations for scanf, fscanf, fgets, and fprintf so translated code preserves whitespace and scanset behavior, tracks EOF handling, parses unsigned negative inputs consistently, and formats struct-backed strings correctly.
- Fixes pointer and allocation rewrites around escaped malloc ownership, allocator wrapper initialization, raw returns from owned pointer replacements, calloc boxed slice lengths, array-field pointer arithmetic, and raw outparam receiver promotion.
- Improves static and interface transformations by constraining RefCell borrow scopes for call arguments and generating wrappers that preserve exported names.
- Fixes libc and dependency edge cases including ASCII ctype classification, consistent magic slice length handling, and preserving existing bytemuck dependency configuration.
- Adds regression coverage across the affected IO, libc, pointer, and static replacement paths.

## Validation
Summary:
- Test Cases Discovered:      338
- Test Cases Skipped:         2
- Test Cases Tested:          336
- Test Cases Failed:          2
- Test Vectors Passed:        2603
- Test Vectors Skipped:       155
- Test Vectors Failed:        11