### PR TITLE
Use nullity analysis for non-null pointer rewrites

### DIFF
--- a/crates/pointer_replacer/src/analyses/mod.rs
+++ b/crates/pointer_replacer/src/analyses/mod.rs
@@ -4,6 +4,7 @@ mod lattice;
 mod liveness;
 mod mir;
 pub mod mir_variable_grouping;
+pub mod nullity;
 pub mod offset_sign;
 pub(crate) mod output_params;
 pub mod ownership;

--- a/crates/pointer_replacer/src/analyses/nullity/mod.rs
+++ b/crates/pointer_replacer/src/analyses/nullity/mod.rs
@@ -1,0 +1,461 @@
+#![allow(dead_code)]
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_index::bit_set::DenseBitSet;
+use rustc_middle::{
+    mir::{
+        self, BasicBlock, Body, Local, Location, Operand, Place, Rvalue, Statement, StatementKind,
+        Terminator, TerminatorKind,
+    },
+    ty::{self, Ty, TyCtxt},
+};
+use rustc_span::{Symbol, def_id::LocalDefId};
+
+use crate::{
+    analyses::mir::{CallGraphPostOrder, CallKind, MirFunctionCall, TerminatorExt},
+    utils::rustc::RustProgram,
+};
+
+#[derive(Debug, Default)]
+pub struct NullityResult {
+    pub non_null_params: FxHashMap<LocalDefId, DenseBitSet<Local>>,
+}
+
+pub fn analyze(program: &RustProgram<'_>) -> NullityResult {
+    let tcx = program.tcx;
+    let function_set: FxHashSet<_> = program.functions.iter().copied().collect();
+    let mut summaries = FxHashMap::default();
+    summaries.reserve(program.functions.len());
+
+    for &did in &program.functions {
+        let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+        summaries.insert(did, DenseBitSet::new_empty(body.local_decls.len()));
+    }
+
+    let call_graph = CallGraphPostOrder::new(program);
+    loop {
+        let mut changed = false;
+
+        for scc in call_graph.sccs() {
+            loop {
+                let mut scc_changed = false;
+
+                for &did in scc {
+                    let did = did.expect_local();
+                    let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+                    let params_to_add = raw_pointer_params(&body)
+                        .into_iter()
+                        .filter(|param| !summaries[&did].contains(*param))
+                        .filter(|param| {
+                            SingleParamAnalyzer {
+                                tcx,
+                                body: &body,
+                                summaries: &summaries,
+                                function_set: &function_set,
+                                positive_memo: FxHashSet::default(),
+                            }
+                            .proves_non_null(*param)
+                        })
+                        .collect::<Vec<_>>();
+
+                    let summary = summaries.get_mut(&did).unwrap();
+                    for param in params_to_add {
+                        scc_changed |= summary.insert(param);
+                    }
+                }
+
+                changed |= scc_changed;
+                if !scc_changed {
+                    break;
+                }
+            }
+        }
+
+        if !changed {
+            break;
+        }
+    }
+
+    NullityResult {
+        non_null_params: summaries
+            .into_iter()
+            .filter(|(_, params)| !params.is_empty())
+            .collect(),
+    }
+}
+
+fn raw_pointer_params(body: &Body<'_>) -> Vec<Local> {
+    body.args_iter()
+        .filter(|&local| is_raw_pointer_ty(body.local_decls[local].ty))
+        .collect()
+}
+
+fn is_raw_pointer_ty(ty: Ty<'_>) -> bool {
+    matches!(ty.kind(), ty::TyKind::RawPtr(..))
+}
+
+struct SingleParamAnalyzer<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    body: &'a Body<'tcx>,
+    summaries: &'a FxHashMap<LocalDefId, DenseBitSet<Local>>,
+    function_set: &'a FxHashSet<LocalDefId>,
+    positive_memo: FxHashSet<TraversalKey>,
+}
+
+impl<'a, 'tcx> SingleParamAnalyzer<'a, 'tcx> {
+    fn proves_non_null(mut self, param: Local) -> bool {
+        self.prove_from(
+            Location::START,
+            Aliases::new(param),
+            &mut FxHashSet::default(),
+        )
+    }
+
+    fn prove_from(
+        &mut self,
+        location: Location,
+        aliases: Aliases,
+        path: &mut FxHashSet<TraversalKey>,
+    ) -> bool {
+        let key = TraversalKey::new(location, &aliases);
+        if self.positive_memo.contains(&key) {
+            return true;
+        }
+        if !path.insert(key.clone()) {
+            return false;
+        }
+
+        let proved = self.prove_from_uncached(location, aliases, path);
+
+        path.remove(&key);
+        if proved {
+            self.positive_memo.insert(key);
+        }
+        proved
+    }
+
+    fn prove_from_uncached(
+        &mut self,
+        location: Location,
+        aliases: Aliases,
+        path: &mut FxHashSet<TraversalKey>,
+    ) -> bool {
+        let block = &self.body.basic_blocks[location.block];
+        if location.statement_index < block.statements.len() {
+            return match self
+                .transfer_statement(&block.statements[location.statement_index], aliases)
+            {
+                Step::Proof => true,
+                Step::Barrier => false,
+                Step::Continue(aliases) => {
+                    self.prove_from(location.successor_within_block(), aliases, path)
+                }
+            };
+        }
+
+        self.transfer_terminator(block.terminator(), aliases, path)
+    }
+
+    fn transfer_statement(&self, statement: &Statement<'tcx>, mut aliases: Aliases) -> Step {
+        let StatementKind::Assign(box (lhs, rvalue)) = &statement.kind else {
+            return Step::Continue(aliases);
+        };
+
+        if place_derefs_alias(lhs, &aliases) || rvalue_derefs_alias(rvalue, &aliases) {
+            return Step::Proof;
+        }
+
+        if rvalue_takes_alias_address(rvalue, &aliases) {
+            return Step::Barrier;
+        }
+
+        let rhs_direct_alias = rvalue_direct_alias_source(rvalue, &aliases)
+            && is_raw_pointer_ty(self.body.local_decls[lhs.local].ty);
+        let rhs_contains_alias = rvalue_contains_alias_value(rvalue, &aliases);
+
+        if lhs.projection.is_empty() {
+            if rhs_direct_alias {
+                aliases.insert(lhs.local);
+                return Step::Continue(aliases);
+            }
+
+            if aliases.contains(lhs.local) || rhs_contains_alias {
+                return Step::Barrier;
+            }
+        } else if rhs_direct_alias || rhs_contains_alias {
+            return Step::Barrier;
+        }
+
+        Step::Continue(aliases)
+    }
+
+    fn transfer_terminator(
+        &mut self,
+        terminator: &Terminator<'tcx>,
+        aliases: Aliases,
+        path: &mut FxHashSet<TraversalKey>,
+    ) -> bool {
+        if let Some(call) = terminator.as_call(self.tcx) {
+            return self.transfer_call(terminator, call, aliases, path);
+        }
+
+        if terminator_derefs_alias(terminator, &aliases) {
+            return true;
+        }
+
+        self.prove_successors(terminator.successors(), aliases, path)
+    }
+
+    fn transfer_call(
+        &mut self,
+        terminator: &Terminator<'tcx>,
+        call: MirFunctionCall<'_, 'tcx>,
+        aliases: Aliases,
+        path: &mut FxHashSet<TraversalKey>,
+    ) -> bool {
+        let mut alias_arg_indices = vec![];
+
+        for (idx, arg) in call.args.iter().enumerate() {
+            if operand_derefs_alias(&arg.node, &aliases) {
+                return true;
+            }
+            if operand_contains_alias_value(&arg.node, &aliases) {
+                alias_arg_indices.push(idx);
+            }
+        }
+
+        if place_derefs_alias(&call.destination, &aliases) {
+            return true;
+        }
+
+        if !alias_arg_indices.is_empty() {
+            return self.call_requires_non_null(&call.func, &alias_arg_indices);
+        }
+
+        if call.destination.projection.is_empty() && aliases.contains(call.destination.local) {
+            return false;
+        }
+
+        self.prove_successors(terminator.successors(), aliases, path)
+    }
+
+    fn call_requires_non_null(&self, func: &CallKind, alias_arg_indices: &[usize]) -> bool {
+        match func {
+            CallKind::FreeStanding(callee) if self.function_set.contains(callee) => {
+                let Some(summary) = self.summaries.get(callee) else {
+                    return false;
+                };
+                alias_arg_indices
+                    .iter()
+                    .all(|idx| summary.contains(Local::from_usize(idx + 1)))
+            }
+            CallKind::LibC(name) => libc_requires_non_null(*name, alias_arg_indices),
+            CallKind::RustLib(def_id) if is_raw_pointer_is_null(self.tcx, *def_id) => false,
+            CallKind::FreeStanding(_)
+            | CallKind::RustLib(_)
+            | CallKind::Impl(_)
+            | CallKind::Closure
+            | CallKind::Dynamic => false,
+        }
+    }
+
+    fn prove_successors(
+        &mut self,
+        successors: impl Iterator<Item = BasicBlock>,
+        aliases: Aliases,
+        path: &mut FxHashSet<TraversalKey>,
+    ) -> bool {
+        let successors = successors.collect::<Vec<_>>();
+        if successors.is_empty() {
+            return false;
+        }
+
+        successors.into_iter().all(|block| {
+            self.prove_from(
+                Location {
+                    block,
+                    statement_index: 0,
+                },
+                aliases.clone(),
+                path,
+            )
+        })
+    }
+}
+
+enum Step {
+    Proof,
+    Barrier,
+    Continue(Aliases),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Aliases(Vec<Local>);
+
+impl Aliases {
+    fn new(local: Local) -> Self {
+        Self(vec![local])
+    }
+
+    fn contains(&self, local: Local) -> bool {
+        self.0
+            .binary_search_by_key(&local.index(), |local| local.index())
+            .is_ok()
+    }
+
+    fn insert(&mut self, local: Local) {
+        match self
+            .0
+            .binary_search_by_key(&local.index(), |local| local.index())
+        {
+            Ok(_) => {}
+            Err(idx) => self.0.insert(idx, local),
+        }
+    }
+
+    fn key(&self) -> Vec<usize> {
+        self.0.iter().map(|local| local.index()).collect()
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct TraversalKey {
+    block: usize,
+    statement_index: usize,
+    aliases: Vec<usize>,
+}
+
+impl TraversalKey {
+    fn new(location: Location, aliases: &Aliases) -> Self {
+        Self {
+            block: location.block.as_usize(),
+            statement_index: location.statement_index,
+            aliases: aliases.key(),
+        }
+    }
+}
+
+fn libc_requires_non_null(name: Symbol, alias_arg_indices: &[usize]) -> bool {
+    let non_null_args: &[usize] = match name.as_str() {
+        "strlen" | "strchr" | "strrchr" | "atoi" | "atol" | "atof" | "puts" => &[0],
+        "strcmp" | "strcasecmp" | "strcpy" | "strcat" | "strstr" => &[0, 1],
+        "fputs" => &[0],
+        _ => return false,
+    };
+
+    alias_arg_indices
+        .iter()
+        .all(|idx| non_null_args.contains(idx))
+}
+
+fn is_raw_pointer_is_null(tcx: TyCtxt<'_>, def_id: rustc_span::def_id::DefId) -> bool {
+    let name = tcx.def_path(def_id).to_string_no_crate_verbose();
+    let mut segs = name.rsplit("::");
+    matches!(segs.next(), Some("is_null"))
+        && segs.next().is_some()
+        && matches!(segs.next(), Some("mut_ptr" | "const_ptr"))
+        && matches!(segs.next(), Some("ptr"))
+}
+
+fn terminator_derefs_alias(terminator: &Terminator<'_>, aliases: &Aliases) -> bool {
+    match &terminator.kind {
+        TerminatorKind::SwitchInt { discr, .. } | TerminatorKind::Assert { cond: discr, .. } => {
+            operand_derefs_alias(discr, aliases)
+        }
+        TerminatorKind::Drop { place, .. } => place_derefs_alias(place, aliases),
+        TerminatorKind::Yield { value, .. } => operand_derefs_alias(value, aliases),
+        _ => false,
+    }
+}
+
+fn rvalue_direct_alias_source(rvalue: &Rvalue<'_>, aliases: &Aliases) -> bool {
+    match rvalue {
+        Rvalue::Use(operand) => operand_plain_alias(operand, aliases),
+        Rvalue::Cast(_, operand, ty) if is_raw_pointer_ty(*ty) => {
+            operand_plain_alias(operand, aliases)
+        }
+        _ => false,
+    }
+}
+
+fn rvalue_takes_alias_address(rvalue: &Rvalue<'_>, aliases: &Aliases) -> bool {
+    matches!(
+        rvalue,
+        Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place)
+            if aliases.contains(place.local) && !place_has_deref(place)
+    )
+}
+
+fn rvalue_derefs_alias(rvalue: &Rvalue<'_>, aliases: &Aliases) -> bool {
+    match rvalue {
+        Rvalue::Use(operand)
+        | Rvalue::Repeat(operand, _)
+        | Rvalue::UnaryOp(_, operand)
+        | Rvalue::Cast(_, operand, _) => operand_derefs_alias(operand, aliases),
+        Rvalue::BinaryOp(_, box (lhs, rhs)) => {
+            operand_derefs_alias(lhs, aliases) || operand_derefs_alias(rhs, aliases)
+        }
+        Rvalue::Ref(_, _, place)
+        | Rvalue::RawPtr(_, place)
+        | Rvalue::Len(place)
+        | Rvalue::Discriminant(place) => place_derefs_alias(place, aliases),
+        Rvalue::CopyForDeref(place) => aliases.contains(place.local),
+        Rvalue::Aggregate(_, operands) => operands
+            .iter()
+            .any(|operand| operand_derefs_alias(operand, aliases)),
+        _ => false,
+    }
+}
+
+fn rvalue_contains_alias_value(rvalue: &Rvalue<'_>, aliases: &Aliases) -> bool {
+    match rvalue {
+        Rvalue::Use(operand)
+        | Rvalue::Repeat(operand, _)
+        | Rvalue::UnaryOp(_, operand)
+        | Rvalue::Cast(_, operand, _) => operand_contains_alias_value(operand, aliases),
+        Rvalue::BinaryOp(_, box (lhs, rhs)) => {
+            operand_contains_alias_value(lhs, aliases) || operand_contains_alias_value(rhs, aliases)
+        }
+        Rvalue::Aggregate(_, operands) => operands
+            .iter()
+            .any(|operand| operand_contains_alias_value(operand, aliases)),
+        _ => false,
+    }
+}
+
+fn operand_plain_alias(operand: &Operand<'_>, aliases: &Aliases) -> bool {
+    matches!(
+        operand,
+        Operand::Copy(place) | Operand::Move(place)
+            if place.projection.is_empty() && aliases.contains(place.local)
+    )
+}
+
+fn operand_derefs_alias(operand: &Operand<'_>, aliases: &Aliases) -> bool {
+    matches!(
+        operand,
+        Operand::Copy(place) | Operand::Move(place) if place_derefs_alias(place, aliases)
+    )
+}
+
+fn operand_contains_alias_value(operand: &Operand<'_>, aliases: &Aliases) -> bool {
+    matches!(
+        operand,
+        Operand::Copy(place) | Operand::Move(place)
+            if aliases.contains(place.local) && !place_has_deref(place)
+    )
+}
+
+fn place_derefs_alias(place: &Place<'_>, aliases: &Aliases) -> bool {
+    aliases.contains(place.local) && place_has_deref(place)
+}
+
+fn place_has_deref(place: &Place<'_>) -> bool {
+    place
+        .projection
+        .iter()
+        .any(|elem| matches!(elem, mir::ProjectionElem::Deref))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pointer_replacer/src/analyses/nullity/tests.rs
+++ b/crates/pointer_replacer/src/analyses/nullity/tests.rs
@@ -1,0 +1,434 @@
+use rustc_hash::FxHashSet;
+use rustc_hir::{ItemKind, OwnerNode};
+use rustc_middle::{mir::VarDebugInfoContents, ty::TyCtxt};
+
+use super::analyze;
+use crate::utils::rustc::RustProgram;
+
+fn build_rust_program(tcx: TyCtxt<'_>) -> RustProgram<'_> {
+    let mut functions = vec![];
+    for maybe_owner in tcx.hir_crate(()).owners.iter() {
+        let Some(owner) = maybe_owner.as_owner() else {
+            continue;
+        };
+        let OwnerNode::Item(item) = owner.node() else {
+            continue;
+        };
+        if matches!(item.kind, ItemKind::Fn { .. }) {
+            functions.push(item.owner_id.def_id);
+        }
+    }
+    RustProgram {
+        tcx,
+        functions,
+        structs: vec![],
+    }
+}
+
+fn run_analysis(code: &str) -> FxHashSet<(String, String)> {
+    let code = format!(
+        "
+        #![allow(dead_code)]
+        #![allow(improper_ctypes)]
+        #![allow(unconditional_recursion)]
+        #![allow(unreachable_code)]
+        #![allow(unused_mut)]
+        #![allow(unused_variables)]
+        {code}
+        "
+    );
+
+    ::utils::compilation::run_compiler_on_str(&code, |tcx| {
+        let rust_program = build_rust_program(tcx);
+        let result = analyze(&rust_program);
+        let mut params = FxHashSet::default();
+
+        for (&did, non_null_params) in &result.non_null_params {
+            let fn_name = tcx.item_name(did.to_def_id()).to_string();
+            let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+            for var_debug_info in body.var_debug_info.iter() {
+                let VarDebugInfoContents::Place(place) = &var_debug_info.value else {
+                    continue;
+                };
+                let Some(local) = place.as_local() else {
+                    continue;
+                };
+                if var_debug_info.argument_index.is_some() && non_null_params.contains(local) {
+                    params.insert((fn_name.clone(), var_debug_info.name.as_str().to_string()));
+                }
+            }
+        }
+
+        params
+    })
+    .unwrap()
+}
+
+fn expect_non_null(code: &str, expected: &[(&str, &str)]) {
+    let expected = expected
+        .iter()
+        .map(|(function, param)| ((*function).to_string(), (*param).to_string()))
+        .collect::<FxHashSet<_>>();
+    assert_eq!(run_analysis(code), expected);
+}
+
+#[test]
+fn direct_deref_before_return_is_non_null() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32) -> i32 {
+            *p
+        }
+        ",
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn is_null_before_deref_is_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32) -> i32 {
+            if p.is_null() {
+                return 0;
+            }
+            *p
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn one_branch_returns_before_proof_is_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32, flag: bool) -> i32 {
+            if flag {
+                *p
+            } else {
+                0
+            }
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn both_branches_deref_is_non_null() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32, flag: bool) -> i32 {
+            if flag {
+                *p
+            } else {
+                *p
+            }
+        }
+        ",
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn alias_copy_deref_is_non_null() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32) -> i32 {
+            let q = p;
+            *q
+        }
+        ",
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn alias_cast_deref_is_non_null() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *mut i32) -> i32 {
+            let q = p as *const i32;
+            *q
+        }
+        ",
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn is_null_on_alias_is_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32) -> i32 {
+            let q = p;
+            if q.is_null() {
+                return 0;
+            }
+            *p
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn alias_reassignment_noop_is_non_null() {
+    expect_non_null(
+        "
+        pub unsafe fn f(mut p: *const i32) -> i32 {
+            let q = p;
+            p = q;
+            *p
+        }
+        ",
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn alias_reassigned_from_non_alias_loses_original_proof() {
+    expect_non_null(
+        "
+        pub unsafe fn f(mut p: *const i32, r: *const i32) -> i32 {
+            p = r;
+            *p
+        }
+        ",
+        &[("f", "r")],
+    );
+}
+
+#[test]
+fn storing_alias_through_pointer_is_nullable_for_stored_alias() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32, out: *mut *const i32) -> i32 {
+            *out = p;
+            *p
+        }
+        ",
+        &[("f", "out")],
+    );
+}
+
+#[test]
+fn pointer_arithmetic_assignment_is_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn f(mut p: *const i32) -> i32 {
+            p = p.offset(1);
+            *p
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn address_take_of_pointer_variable_is_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32) -> i32 {
+            let _addr = &p;
+            *p
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn local_callee_non_null_param_proves_caller_param() {
+    expect_non_null(
+        "
+        pub unsafe fn callee(x: *const i32) -> i32 {
+            *x
+        }
+
+        pub unsafe fn caller(p: *const i32) -> i32 {
+            callee(p)
+        }
+        ",
+        &[("callee", "x"), ("caller", "p")],
+    );
+}
+
+#[test]
+fn local_callee_nullable_param_keeps_caller_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn callee(x: *const i32) -> i32 {
+            if x.is_null() {
+                return 0;
+            }
+            *x
+        }
+
+        pub unsafe fn caller(p: *const i32) -> i32 {
+            callee(p)
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn same_alias_passed_to_nullable_formal_keeps_caller_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn callee(a: *const i32, b: *const i32) -> i32 {
+            let v = *a;
+            if b.is_null() {
+                return v;
+            }
+            v + *b
+        }
+
+        pub unsafe fn caller(p: *const i32) -> i32 {
+            callee(p, p)
+        }
+        ",
+        &[("callee", "a")],
+    );
+}
+
+#[test]
+fn recursive_deref_before_call_is_non_null() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32) -> i32 {
+            let v = *p;
+            f(p);
+            v
+        }
+        ",
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn recursive_call_before_deref_is_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32) -> i32 {
+            f(p);
+            *p
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn mutual_recursion_with_deref_before_calls_is_non_null() {
+    expect_non_null(
+        "
+        pub unsafe fn a(p: *const i32) -> i32 {
+            let v = *p;
+            b(p);
+            v
+        }
+
+        pub unsafe fn b(p: *const i32) -> i32 {
+            let v = *p;
+            a(p);
+            v
+        }
+        ",
+        &[("a", "p"), ("b", "p")],
+    );
+}
+
+#[test]
+fn loop_before_deref_is_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32, mut n: i32) -> i32 {
+            while n > 0 {
+                n -= 1;
+            }
+            *p
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn loop_body_deref_before_revisit_is_non_null() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32) -> i32 {
+            loop {
+                let v = *p;
+                if v == 0 {
+                    return v;
+                }
+            }
+        }
+        ",
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn function_pointer_call_with_alias_is_nullable() {
+    expect_non_null(
+        "
+        pub unsafe fn f(p: *const i32, fp: unsafe fn(*const i32) -> i32) -> i32 {
+            fp(p)
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn modeled_libc_strlen_proves_non_null() {
+    expect_non_null(
+        "
+        extern \"C\" {
+            fn strlen(s: *const i8) -> usize;
+        }
+
+        pub unsafe fn f(p: *const i8) {
+            let _ = strlen(p);
+        }
+        ",
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn free_accepts_null_and_is_nullable() {
+    expect_non_null(
+        "
+        extern \"C\" {
+            fn free(p: *mut core::ffi::c_void);
+        }
+
+        pub unsafe fn f(p: *mut core::ffi::c_void) {
+            free(p);
+        }
+        ",
+        &[],
+    );
+}
+
+#[test]
+fn unmodeled_libc_call_is_nullable() {
+    expect_non_null(
+        "
+        extern \"C\" {
+            fn maybe_accepts_null(p: *const i8);
+        }
+
+        pub unsafe fn f(p: *const i8) {
+            maybe_accepts_null(p);
+        }
+        ",
+        &[],
+    );
+}

--- a/crates/pointer_replacer/src/rewriter/collector.rs
+++ b/crates/pointer_replacer/src/rewriter/collector.rs
@@ -57,9 +57,7 @@ pub fn collect_diffs<'tcx>(
             if let Some(mut ptr_kind) = decision_maker.decide(local, decl, aliases)
                 && let Some(hir_id) = local_to_binding.get(&local)
             {
-                if non_outermost_owning_locals.contains(hir_id)
-                    && matches!(ptr_kind, PtrKind::OptBox | PtrKind::OptBoxedSlice)
-                {
+                if non_outermost_owning_locals.contains(hir_id) && ptr_kind.is_owning_box_like() {
                     ptr_kind = PtrKind::Raw(ptr_kind.is_mut());
                 }
                 ptr_kinds.insert(*hir_id, ptr_kind);

--- a/crates/pointer_replacer/src/rewriter/decision.rs
+++ b/crates/pointer_replacer/src/rewriter/decision.rs
@@ -12,11 +12,17 @@ use crate::{analyses::ownership::Ownership, utils::rustc::RustProgram};
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PtrKind {
     /// reference: &mut T for Ref(true), or &T for Ref(false)
+    Ref(bool),
+    /// optional reference: Option<&mut T> for OptRef(true), or Option<&T> for OptRef(false)
     OptRef(bool),
+    /// owning scalar pointer rewritten to Box<T>
+    Box,
     /// owning scalar pointer rewritten to Option<Box<T>>
     OptBox,
     /// raw pointer: *mut T for Raw(true), or *const T for Raw(false)
     Raw(bool),
+    /// owning array pointer rewritten to Box<[T]>
+    BoxedSlice,
     /// owning array pointer rewritten to Option<Box<[T]>>
     OptBoxedSlice,
     /// plain slice: &mut [T] for Slice(true), or &[T] for Slice(false)
@@ -29,10 +35,44 @@ pub enum PtrKind {
 impl PtrKind {
     pub fn is_mut(&self) -> bool {
         match self {
-            PtrKind::OptRef(m) | PtrKind::Raw(m) | PtrKind::Slice(m) | PtrKind::SliceCursor(m) => {
-                *m
-            }
-            PtrKind::OptBox | PtrKind::OptBoxedSlice => true,
+            PtrKind::Ref(m)
+            | PtrKind::OptRef(m)
+            | PtrKind::Raw(m)
+            | PtrKind::Slice(m)
+            | PtrKind::SliceCursor(m) => *m,
+            PtrKind::Box | PtrKind::OptBox | PtrKind::BoxedSlice | PtrKind::OptBoxedSlice => true,
+        }
+    }
+
+    pub fn is_owning_box_like(&self) -> bool {
+        matches!(
+            self,
+            PtrKind::Box | PtrKind::OptBox | PtrKind::BoxedSlice | PtrKind::OptBoxedSlice
+        )
+    }
+
+    pub fn is_optional(&self) -> bool {
+        matches!(
+            self,
+            PtrKind::OptRef(_) | PtrKind::OptBox | PtrKind::OptBoxedSlice
+        )
+    }
+
+    pub fn non_null_variant(self) -> Self {
+        match self {
+            PtrKind::OptRef(m) => PtrKind::Ref(m),
+            PtrKind::OptBox => PtrKind::Box,
+            PtrKind::OptBoxedSlice => PtrKind::BoxedSlice,
+            other => other,
+        }
+    }
+
+    pub fn optional_variant(self) -> Self {
+        match self {
+            PtrKind::Ref(m) => PtrKind::OptRef(m),
+            PtrKind::Box => PtrKind::OptBox,
+            PtrKind::BoxedSlice => PtrKind::OptBoxedSlice,
+            other => other,
         }
     }
 }
@@ -47,6 +87,7 @@ pub struct DecisionMaker<'tcx> {
     promoted_shared_refs: DenseBitSet<Local>,
     /// Locals that need a SliceCursor because they are offset with potentially-negative values.
     needs_cursor: DenseBitSet<Local>,
+    non_null_params: DenseBitSet<Local>,
 }
 
 impl<'tcx> DecisionMaker<'tcx> {
@@ -59,6 +100,7 @@ impl<'tcx> DecisionMaker<'tcx> {
             return decision;
         }
         match decision {
+            Some(PtrKind::Ref(_)) => Some(PtrKind::Ref(false)),
             Some(PtrKind::OptRef(_)) => Some(PtrKind::OptRef(false)),
             Some(PtrKind::Raw(_)) => Some(PtrKind::Raw(false)),
             Some(PtrKind::Slice(_)) => Some(PtrKind::Slice(false)),
@@ -81,7 +123,12 @@ impl<'tcx> DecisionMaker<'tcx> {
             && is_mut
             && matches!(
                 decision,
-                Some(PtrKind::OptRef(true) | PtrKind::Slice(true) | PtrKind::SliceCursor(true))
+                Some(
+                    PtrKind::Ref(true)
+                        | PtrKind::OptRef(true)
+                        | PtrKind::Slice(true)
+                        | PtrKind::SliceCursor(true)
+                )
             )
         {
             Some(PtrKind::Raw(true))
@@ -134,6 +181,7 @@ impl<'tcx> DecisionMaker<'tcx> {
         if let Some(signs) = fn_offset_signs {
             needs_cursor.union(signs);
         }
+        let non_null_params = stable_non_null_params(analysis, did, tcx, mutable_pointers.len());
         DecisionMaker {
             tcx,
             array_pointers,
@@ -143,6 +191,7 @@ impl<'tcx> DecisionMaker<'tcx> {
             promoted_mut_refs,
             promoted_shared_refs,
             needs_cursor,
+            non_null_params,
         }
     }
 
@@ -210,8 +259,50 @@ impl<'tcx> DecisionMaker<'tcx> {
         };
 
         let decision = self.preserve_original_pointer_constness(decision, m.is_mut());
-        self.force_raw_local_struct_borrows(decision, ty, m.is_mut())
+        let decision = self.force_raw_local_struct_borrows(decision, ty, m.is_mut());
+        if self.non_null_params.contains(local) {
+            decision.map(PtrKind::non_null_variant)
+        } else {
+            decision
+        }
     }
+}
+
+fn stable_non_null_params<'tcx>(
+    analysis: &Analysis,
+    did: LocalDefId,
+    tcx: TyCtxt<'tcx>,
+    len: usize,
+) -> DenseBitSet<Local> {
+    let mut non_null_params = DenseBitSet::new_empty(len);
+    let Some(params) = analysis.nullity_result.non_null_params.get(&did) else {
+        return non_null_params;
+    };
+    for param in params.iter() {
+        non_null_params.insert(param);
+    }
+
+    let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+    for bb in body.basic_blocks.iter() {
+        for stmt in &bb.statements {
+            let StatementKind::Assign(box (place, rvalue)) = &stmt.kind else {
+                continue;
+            };
+            if place.projection.is_empty() {
+                non_null_params.remove(place.local);
+            }
+            match rvalue {
+                Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place)
+                    if place.projection.is_empty() =>
+                {
+                    non_null_params.remove(place.local);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    non_null_params
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -286,6 +377,9 @@ impl SigDecisions {
                 match decision_maker.decide(return_local, return_decl, return_aliases) {
                     Some(kind @ (PtrKind::Raw(_) | PtrKind::OptBox | PtrKind::OptBoxedSlice)) => {
                         Some(kind)
+                    }
+                    Some(kind @ (PtrKind::Box | PtrKind::BoxedSlice)) => {
+                        Some(kind.optional_variant())
                     }
                     _ => None,
                 };
@@ -376,6 +470,7 @@ fn infer_returned_local_box_kind<'tcx>(
     let aliases = aliases.and_then(|aliases| aliases.get(&local));
     match decision_maker.decide(local, decl, aliases) {
         Some(kind @ (PtrKind::OptBox | PtrKind::OptBoxedSlice)) => Some(kind),
+        Some(kind @ (PtrKind::Box | PtrKind::BoxedSlice)) => Some(kind.optional_variant()),
         _ => None,
     }
 }
@@ -413,7 +508,7 @@ mod tests {
         .unwrap();
     }
 
-    fn synthetic_decision_maker<'tcx>(
+    fn synthetic_decision_maker_with_non_null<'tcx>(
         tcx: TyCtxt<'tcx>,
         body: &Body<'tcx>,
         local: Local,
@@ -424,6 +519,7 @@ mod tests {
         promoted_mut: bool,
         promoted_shared: bool,
         needs_cursor: bool,
+        non_null: bool,
     ) -> DecisionMaker<'tcx> {
         let len = body.local_decls.len();
         let mut mutable_pointers = IndexVec::from_elem_n(false, len);
@@ -448,6 +544,10 @@ mod tests {
         if needs_cursor {
             needs_cursor_set.insert(local);
         }
+        let mut non_null_params = DenseBitSet::new_empty(len);
+        if non_null {
+            non_null_params.insert(local);
+        }
 
         DecisionMaker {
             tcx,
@@ -458,6 +558,7 @@ mod tests {
             promoted_mut_refs,
             promoted_shared_refs,
             needs_cursor: needs_cursor_set,
+            non_null_params,
         }
     }
 
@@ -471,6 +572,30 @@ mod tests {
         promoted_shared: bool,
         mutable: bool,
     ) -> PtrKind {
+        decide_for_param_with_ty_and_non_null(
+            pointer_ty,
+            owning,
+            output,
+            is_array,
+            needs_cursor,
+            promoted_mut,
+            promoted_shared,
+            mutable,
+            false,
+        )
+    }
+
+    fn decide_for_param_with_ty_and_non_null(
+        pointer_ty: &str,
+        owning: bool,
+        output: bool,
+        is_array: bool,
+        needs_cursor: bool,
+        promoted_mut: bool,
+        promoted_shared: bool,
+        mutable: bool,
+        non_null: bool,
+    ) -> PtrKind {
         let mut decision = None;
         let code = format!(
             r#"
@@ -481,7 +606,7 @@ pub unsafe fn foo(p: {pointer_ty}) {{
         );
         with_test_fn_body(&code, |tcx, _did, body| {
             let local = Local::from_u32(1);
-            let decision_maker = synthetic_decision_maker(
+            let decision_maker = synthetic_decision_maker_with_non_null(
                 tcx,
                 body,
                 local,
@@ -492,6 +617,7 @@ pub unsafe fn foo(p: {pointer_ty}) {{
                 promoted_mut,
                 promoted_shared,
                 needs_cursor,
+                non_null,
             );
             let decl = &body.local_decls[local];
             decision = Some(
@@ -597,6 +723,46 @@ pub unsafe fn foo(p: {pointer_ty}) {{
     }
 
     #[test]
+    fn non_null_promoted_scalar_param_becomes_ref() {
+        assert_eq!(
+            decide_for_param_with_ty_and_non_null(
+                "*mut i32", false, false, false, false, true, false, true, true,
+            ),
+            PtrKind::Ref(true)
+        );
+        assert_eq!(
+            decide_for_param_with_ty_and_non_null(
+                "*const i32",
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+                true,
+                true,
+            ),
+            PtrKind::Ref(false)
+        );
+    }
+
+    #[test]
+    fn non_null_owning_params_become_non_optional() {
+        assert_eq!(
+            decide_for_param_with_ty_and_non_null(
+                "*mut i32", true, false, false, false, false, false, true, true,
+            ),
+            PtrKind::Box
+        );
+        assert_eq!(
+            decide_for_param_with_ty_and_non_null(
+                "*mut i32", true, false, true, false, false, false, true, true,
+            ),
+            PtrKind::BoxedSlice
+        );
+    }
+
+    #[test]
     fn const_array_pointer_does_not_become_mut_slice() {
         assert_eq!(
             decide_for_param_with_ty("*const i32", false, false, true, false, true, false, true),
@@ -614,8 +780,8 @@ pub unsafe fn foo(p: *mut i32, q: *mut i32) {
 "#;
         with_test_fn_body(code, |tcx, _did, body| {
             let local = Local::from_u32(1);
-            let decision_maker = synthetic_decision_maker(
-                tcx, body, local, true, true, true, true, false, false, false,
+            let decision_maker = synthetic_decision_maker_with_non_null(
+                tcx, body, local, true, true, true, true, false, false, false, true,
             );
             let decl = &body.local_decls[local];
             let aliases = FxHashSet::from_iter([Local::from_u32(2)]);

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -41,6 +41,7 @@ pub struct Analysis {
     output_params: OutputParams,
     ownership_schemes: Option<SolidifiedOwnershipSchemes>,
     offset_sign_result: OffsetSignResult,
+    nullity_result: analyses::nullity::NullityResult,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -85,6 +86,7 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     let mut offset_sign_result = analyses::offset_sign::sign::offset_sign_analysis(&input);
     offset_sign_result.access_signs =
         source_var_groups.postprocess_offset_signs(offset_sign_result.access_signs);
+    let nullity_result = analyses::nullity::analyze(&input);
     let analysis_results = Analysis {
         promoted_mut_ref_result,
         promoted_shared_ref_result,
@@ -94,9 +96,8 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
         output_params,
         ownership_schemes,
         offset_sign_result,
+        nullity_result,
     };
-
-    let _ = analyses::nullity::analyze(&input);
 
     let mut visitor = TransformVisitor::new(&input, &analysis_results, ast_to_hir);
     visitor.visit_crate(&mut krate);

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -4,7 +4,10 @@ use rustc_ast::mut_visit::MutVisitor;
 use rustc_ast_pretty::pprust;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::{ItemKind, OwnerNode};
-use rustc_middle::{mir::Local, ty::TyCtxt};
+use rustc_middle::{
+    mir::Local,
+    ty::{self, TyCtxt},
+};
 use rustc_span::def_id::LocalDefId;
 use serde::Deserialize;
 use transform::TransformVisitor;
@@ -92,6 +95,8 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
         ownership_schemes,
         offset_sign_result,
     };
+
+    let _ = analyses::nullity::analyze(&input);
 
     let mut visitor = TransformVisitor::new(&input, &analysis_results, ast_to_hir);
     visitor.visit_crate(&mut krate);
@@ -206,6 +211,45 @@ fn find_param_aliases<'tcx>(
         }
     }
     param_aliases
+}
+
+#[allow(unused)]
+fn print_nullity_counts(
+    input: &RustProgram<'_>,
+    nullity_result: &analyses::nullity::NullityResult,
+) {
+    for &did in &input.functions {
+        let body = input
+            .tcx
+            .mir_drops_elaborated_and_const_checked(did)
+            .borrow();
+        let raw_pointer_params = body
+            .args_iter()
+            .filter(|&local| matches!(body.local_decls[local].ty.kind(), ty::TyKind::RawPtr(..)))
+            .collect::<Vec<_>>();
+        let total = raw_pointer_params.len();
+        if total == 0 {
+            continue;
+        }
+
+        let non_null = nullity_result
+            .non_null_params
+            .get(&did)
+            .map(|params| {
+                raw_pointer_params
+                    .iter()
+                    .filter(|&&local| params.contains(local))
+                    .count()
+            })
+            .unwrap_or(0);
+
+        println!(
+            "crat_nullity\t{}\t{}\t{}",
+            input.tcx.def_path_str(did.to_def_id()),
+            total,
+            non_null
+        );
+    }
 }
 
 fn slice_cursor_mod_str() -> &'static str {

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -101,6 +101,16 @@ impl MutVisitor for TransformVisitor<'_> {
                     .zip(&mut fn_item.sig.decl.inputs)
                 {
                     match input_dec {
+                        Some(PtrKind::Ref(m)) => {
+                            let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "Expected pointer type, got {ty:?} in {local_decl:?}",
+                                        ty = local_decl.ty
+                                    )
+                                });
+                            *param.ty = mk_ref_ty(inner_ty, *m, self.tcx);
+                        }
                         Some(PtrKind::OptRef(m)) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
                                 .unwrap_or_else(|| {
@@ -110,6 +120,16 @@ impl MutVisitor for TransformVisitor<'_> {
                                     )
                                 });
                             *param.ty = mk_opt_ref_ty(inner_ty, *m, self.tcx);
+                        }
+                        Some(PtrKind::Box) => {
+                            let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "Expected pointer type, got {ty:?} in {local_decl:?}",
+                                        ty = local_decl.ty
+                                    )
+                                });
+                            *param.ty = mk_box_ty(inner_ty, self.tcx);
                         }
                         Some(PtrKind::OptBox) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -152,6 +172,16 @@ impl MutVisitor for TransformVisitor<'_> {
                             *param.ty = mk_cursor_ty(inner_ty, *m, self.tcx);
                             self.slice_cursor.set(true);
                         }
+                        Some(PtrKind::BoxedSlice) => {
+                            let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "Expected pointer type, got {ty:?} in {local_decl:?}",
+                                        ty = local_decl.ty
+                                    )
+                                });
+                            *param.ty = mk_boxed_slice_ty(inner_ty, self.tcx);
+                        }
                         Some(PtrKind::OptBoxedSlice) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
                                 .unwrap_or_else(|| {
@@ -177,7 +207,7 @@ impl MutVisitor for TransformVisitor<'_> {
                     let Some((inner_ty, _)) = unwrap_ptr_from_mir_ty(return_decl.ty) else {
                         return output_dec;
                     };
-                    if matches!(output_dec, PtrKind::OptBox | PtrKind::OptBoxedSlice)
+                    if output_dec.is_owning_box_like()
                         && fn_tail_returns_unsupported_box_binding(
                             self.tcx,
                             &self.sig_decs,
@@ -199,9 +229,12 @@ impl MutVisitor for TransformVisitor<'_> {
                         && let FnRetTy::Ty(ret_ty) = &mut fn_item.sig.decl.output
                     {
                         *ret_ty = P(match output_dec {
+                            PtrKind::Ref(m) => mk_ref_ty(inner_ty, m, self.tcx),
                             PtrKind::OptRef(m) => mk_opt_ref_ty(inner_ty, m, self.tcx),
+                            PtrKind::Box => mk_box_ty(inner_ty, self.tcx),
                             PtrKind::OptBox => mk_opt_box_ty(inner_ty, self.tcx),
                             PtrKind::Raw(m) => mk_raw_ptr_ty(inner_ty, m, self.tcx),
+                            PtrKind::BoxedSlice => mk_boxed_slice_ty(inner_ty, self.tcx),
                             PtrKind::OptBoxedSlice => mk_opt_boxed_slice_ty(inner_ty, self.tcx),
                             PtrKind::Slice(m) => mk_slice_ty(inner_ty, m, self.tcx),
                             PtrKind::SliceCursor(m) => {
@@ -299,13 +332,13 @@ impl MutVisitor for TransformVisitor<'_> {
             {
                 lhs_kind = PtrKind::Raw(lhs_mutability.is_mut());
             }
-            if matches!(lhs_kind, PtrKind::OptBox | PtrKind::OptBoxedSlice)
+            if lhs_kind.is_owning_box_like()
                 && let Some(init) = let_stmt.init
                 && !self.rhs_supports_box_target(init, lhs_kind, lhs_inner_ty)
             {
                 lhs_kind = PtrKind::Raw(true);
             }
-            if matches!(lhs_kind, PtrKind::OptBox | PtrKind::OptBoxedSlice)
+            if lhs_kind.is_owning_box_like()
                 && self.fn_has_unsupported_box_assignment(hir_id, lhs_kind, lhs_inner_ty)
             {
                 lhs_kind = PtrKind::Raw(true);
@@ -316,11 +349,20 @@ impl MutVisitor for TransformVisitor<'_> {
             }
 
             match lhs_kind {
+                PtrKind::Ref(m) => {
+                    local.ty = Some(P(mk_ref_ty(lhs_inner_ty, m, self.tcx)));
+                }
                 PtrKind::OptRef(m) => {
                     local.ty = Some(P(mk_opt_ref_ty(lhs_inner_ty, m, self.tcx)));
                 }
+                PtrKind::Box => {
+                    local.ty = Some(P(mk_box_ty(lhs_inner_ty, self.tcx)));
+                }
                 PtrKind::OptBox => {
                     local.ty = Some(P(mk_opt_box_ty(lhs_inner_ty, self.tcx)));
+                }
+                PtrKind::BoxedSlice => {
+                    local.ty = Some(P(mk_boxed_slice_ty(lhs_inner_ty, self.tcx)));
                 }
                 PtrKind::OptBoxedSlice => {
                     local.ty = Some(P(mk_opt_boxed_slice_ty(lhs_inner_ty, self.tcx)));
@@ -388,11 +430,11 @@ impl MutVisitor for TransformVisitor<'_> {
                 ) {
                     lhs_kind = PtrKind::Raw(m.is_mut());
                 }
-                if matches!(lhs_kind, PtrKind::OptBox | PtrKind::OptBoxedSlice)
+                if lhs_kind.is_owning_box_like()
                     && !self.rhs_supports_box_target(hir_rhs, lhs_kind, lhs_inner_ty)
                 {
                     lhs_kind = PtrKind::Raw(true);
-                } else if matches!(lhs_kind, PtrKind::OptBox) {
+                } else if matches!(lhs_kind, PtrKind::Box | PtrKind::OptBox) {
                     if hir_is_unsupported_scalar_box_allocator_root(self.tcx, lhs_inner_ty, hir_rhs)
                     {
                         lhs_kind = PtrKind::Raw(true);
@@ -450,8 +492,11 @@ impl MutVisitor for TransformVisitor<'_> {
                         }
                     }
                     PtrKind::Slice(_)
+                    | PtrKind::Ref(_)
                     | PtrKind::OptRef(_)
+                    | PtrKind::Box
                     | PtrKind::OptBox
+                    | PtrKind::BoxedSlice
                     | PtrKind::OptBoxedSlice
                     | PtrKind::Raw(_) => {
                         if let Some(lhs_hir_id) = lhs_hir_id
@@ -541,6 +586,9 @@ impl MutVisitor for TransformVisitor<'_> {
                     && let Some(ptr_kind) = self.effective_ptr_kind(hir_id)
                 {
                     match ptr_kind {
+                        PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice => {
+                            *expr = utils::expr!("false");
+                        }
                         PtrKind::OptRef(_) => {
                             seg.ident.name = Symbol::intern("is_none");
                         }
@@ -660,6 +708,7 @@ impl MutVisitor for TransformVisitor<'_> {
                     } else {
                         match self.transform_ptr(e, hir_e, PtrCtx::Deref(m)) {
                             PtrKind::Raw(_) => {}
+                            PtrKind::Ref(_) | PtrKind::Box => {}
                             PtrKind::OptRef(_) => {
                                 **e = utils::expr!("{}.unwrap()", pprust::expr_to_string(e));
                             }
@@ -676,6 +725,9 @@ impl MutVisitor for TransformVisitor<'_> {
                                     pprust::expr_to_string(e),
                                     if m { "_mut" } else { "" },
                                 );
+                            }
+                            PtrKind::BoxedSlice => {
+                                *expr = utils::expr!("({})[0]", pprust::expr_to_string(e));
                             }
                             PtrKind::Slice(_) => {
                                 *expr = utils::expr!("({})[0]", pprust::expr_to_string(e));
@@ -882,8 +934,16 @@ impl<'tcx> TransformVisitor<'tcx> {
             && pe.projs.is_empty()
         {
             match self.ptr_source_kind(&pe) {
+                Some(PtrKind::Box) => {
+                    *rhs = self.raw_from_box_return(pe.base, m, lhs_inner_ty, rhs_inner_ty);
+                    return;
+                }
                 Some(PtrKind::OptBox) => {
                     *rhs = self.raw_from_opt_box_return(pe.base, m, lhs_inner_ty, rhs_inner_ty);
+                    return;
+                }
+                Some(PtrKind::BoxedSlice) => {
+                    *rhs = self.raw_from_boxed_slice_return(pe.base, m, lhs_inner_ty, rhs_inner_ty);
                     return;
                 }
                 Some(PtrKind::OptBoxedSlice) => {
@@ -911,11 +971,19 @@ impl<'tcx> TransformVisitor<'tcx> {
         if hir_call_matches_foreign_name(self.tcx, hir_expr, "free")
             && matches!(
                 self.effective_ptr_kind(hir_id),
-                Some(PtrKind::OptBox | PtrKind::OptBoxedSlice)
+                Some(PtrKind::Box | PtrKind::OptBox | PtrKind::BoxedSlice | PtrKind::OptBoxedSlice)
             )
         {
             let local_name = self.tcx.hir_name(hir_id).to_string();
-            return Some(utils::expr!("drop(({local_name}).take())"));
+            return match self.effective_ptr_kind(hir_id) {
+                Some(PtrKind::Box | PtrKind::BoxedSlice) => {
+                    Some(utils::expr!("drop({local_name})"))
+                }
+                Some(PtrKind::OptBox | PtrKind::OptBoxedSlice) => {
+                    Some(utils::expr!("drop(({local_name}).take())"))
+                }
+                _ => None,
+            };
         }
         let info = self.raw_bridge_bindings.get(&hir_id)?;
         let [arg] = args else { return None };
@@ -974,12 +1042,12 @@ impl<'tcx> TransformVisitor<'tcx> {
         }
 
         match target_kind {
-            PtrKind::OptBox => {
+            PtrKind::Box | PtrKind::OptBox => {
                 if hir_supports_scalar_box_allocator_root(self.tcx, lhs_inner_ty, hir_uncast) {
                     return true;
                 }
             }
-            PtrKind::OptBoxedSlice => {
+            PtrKind::BoxedSlice | PtrKind::OptBoxedSlice => {
                 if hir_is_supported_boxed_slice_allocator_root(self.tcx, hir_uncast) {
                     return true;
                 }
@@ -987,13 +1055,17 @@ impl<'tcx> TransformVisitor<'tcx> {
             _ => return true,
         }
 
-        if self.forced_local_callee_output_kind(hir_expr) == Some(target_kind) {
+        let callee_output = self.forced_local_callee_output_kind(hir_expr);
+        if callee_output == Some(target_kind)
+            || callee_output == Some(target_kind.optional_variant())
+        {
             return true;
         }
 
         if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_expr.kind
             && let Res::Local(hir_id) = path.res
-            && self.effective_ptr_kind(hir_id) == Some(target_kind)
+            && let Some(rhs_kind) = self.effective_ptr_kind(hir_id)
+            && (rhs_kind == target_kind || rhs_kind == target_kind.optional_variant())
         {
             return true;
         }
@@ -1102,6 +1174,13 @@ impl<'tcx> TransformVisitor<'tcx> {
 
         if is_null_ptr_constructor(&allocator_root_expr) {
             match ctx {
+                PtrCtx::Rhs(PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice) => {
+                    *ptr = utils::expr!("panic!()");
+                    return match ctx {
+                        PtrCtx::Rhs(kind) => kind,
+                        PtrCtx::Deref(_) => unreachable!(),
+                    };
+                }
                 PtrCtx::Rhs(PtrKind::SliceCursor(m)) => {
                     self.slice_cursor.set(true);
                     *ptr = if m {
@@ -1139,6 +1218,13 @@ impl<'tcx> TransformVisitor<'tcx> {
             }
         }
 
+        if let PtrCtx::Rhs(kind @ (PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice)) = ctx {
+            debug_assert!(!kind.is_optional());
+            self.transform_ptr(ptr, hir_ptr, PtrCtx::Rhs(kind.optional_variant()));
+            *ptr = utils::expr!("({}).unwrap()", pprust::expr_to_string(ptr));
+            return kind;
+        }
+
         if let PtrCtx::Rhs(kind @ (PtrKind::OptBox | PtrKind::OptBoxedSlice)) = ctx {
             let lhs_ty = self
                 .tcx
@@ -1167,6 +1253,9 @@ impl<'tcx> TransformVisitor<'tcx> {
             let lhs_inner_ty =
                 unwrap_ptr_or_arr_from_mir_ty(lhs_ty, self.tcx).unwrap_or(rhs_inner_ty);
             match ctx {
+                PtrCtx::Rhs(PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice) => {
+                    unreachable!("non-optional pointer targets are handled before raw fallback")
+                }
                 PtrCtx::Rhs(PtrKind::Raw(m)) | PtrCtx::Deref(m) => {
                     if lhs_ty != rhs_ty {
                         *ptr = utils::expr!(
@@ -1216,6 +1305,13 @@ impl<'tcx> TransformVisitor<'tcx> {
         if pe.is_zero() {
             // rhs_ty will be `usize`, not a pointer, so we early return here
             match ctx {
+                PtrCtx::Rhs(PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice) => {
+                    *ptr = utils::expr!("panic!()");
+                    return match ctx {
+                        PtrCtx::Rhs(kind) => kind,
+                        PtrCtx::Deref(_) => unreachable!(),
+                    };
+                }
                 PtrCtx::Rhs(PtrKind::SliceCursor(m)) => {
                     self.slice_cursor.set(true);
                     *ptr = if m {
@@ -1257,6 +1353,9 @@ impl<'tcx> TransformVisitor<'tcx> {
 
         if pe.cast_int {
             match ctx {
+                PtrCtx::Rhs(PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice) => {
+                    unreachable!("non-optional pointer targets are handled before casts")
+                }
                 PtrCtx::Rhs(PtrKind::Raw(m)) => {
                     let mut base = pe.base.clone();
                     // Rewrite inner pointer before integer casting
@@ -1295,8 +1394,11 @@ impl<'tcx> TransformVisitor<'tcx> {
                 matches!(
                     self.effective_ptr_kind(hir_id),
                     Some(
-                        PtrKind::OptRef(_)
+                        PtrKind::Ref(_)
+                            | PtrKind::OptRef(_)
+                            | PtrKind::Box
                             | PtrKind::OptBox
+                            | PtrKind::BoxedSlice
                             | PtrKind::OptBoxedSlice
                             | PtrKind::Slice(_)
                             | PtrKind::SliceCursor(_)
@@ -1316,12 +1418,18 @@ impl<'tcx> TransformVisitor<'tcx> {
                 )
             }) {
                 let m = match ctx {
+                    PtrCtx::Rhs(PtrKind::Ref(m)) => m,
                     PtrCtx::Rhs(PtrKind::Raw(m))
                     | PtrCtx::Rhs(PtrKind::OptRef(m))
                     | PtrCtx::Rhs(PtrKind::Slice(m))
                     | PtrCtx::Rhs(PtrKind::SliceCursor(m))
                     | PtrCtx::Deref(m) => m,
-                    PtrCtx::Rhs(PtrKind::OptBox | PtrKind::OptBoxedSlice) => {
+                    PtrCtx::Rhs(
+                        PtrKind::Box
+                        | PtrKind::OptBox
+                        | PtrKind::BoxedSlice
+                        | PtrKind::OptBoxedSlice,
+                    ) => {
                         panic!("unsupported M4A box target for addr_of arithmetic")
                     }
                 };
@@ -1360,6 +1468,9 @@ impl<'tcx> TransformVisitor<'tcx> {
                 }
                 // Final wrapping depends on the target context
                 match ctx {
+                    PtrCtx::Rhs(PtrKind::Ref(_)) => {
+                        unreachable!("non-optional pointer targets are handled before addr_of")
+                    }
                     PtrCtx::Deref(m) | PtrCtx::Rhs(PtrKind::Slice(m)) => {
                         // slice to slice
                         *ptr = self.plain_slice_from_slice(
@@ -1406,12 +1517,20 @@ impl<'tcx> TransformVisitor<'tcx> {
                         );
                         return PtrKind::Raw(m);
                     }
-                    PtrCtx::Rhs(PtrKind::OptBox | PtrKind::OptBoxedSlice) => {
+                    PtrCtx::Rhs(
+                        PtrKind::Box
+                        | PtrKind::OptBox
+                        | PtrKind::BoxedSlice
+                        | PtrKind::OptBoxedSlice,
+                    ) => {
                         panic!("unsupported M4A box target for addr_of slice wrapping")
                     }
                 }
             }
             match ctx {
+                PtrCtx::Rhs(PtrKind::Ref(_)) => {
+                    unreachable!("non-optional pointer targets are handled before addr_of")
+                }
                 PtrCtx::Rhs(PtrKind::Raw(m)) => {
                     if !need_cast && !ty_updated {
                         *ptr = utils::expr!(
@@ -1546,7 +1665,9 @@ impl<'tcx> TransformVisitor<'tcx> {
                     }
                     return PtrKind::Slice(m);
                 }
-                PtrCtx::Rhs(PtrKind::OptBox | PtrKind::OptBoxedSlice) => {
+                PtrCtx::Rhs(
+                    PtrKind::Box | PtrKind::OptBox | PtrKind::BoxedSlice | PtrKind::OptBoxedSlice,
+                ) => {
                     panic!("unsupported M4A box target for addr_of")
                 }
             }
@@ -1564,6 +1685,9 @@ impl<'tcx> TransformVisitor<'tcx> {
                 )
             };
             match ctx {
+                PtrCtx::Rhs(PtrKind::Ref(_)) => {
+                    unreachable!("non-optional pointer targets are handled before as_ptr")
+                }
                 PtrCtx::Rhs(PtrKind::Raw(m)) => {
                     if !need_cast {
                         *ptr = raw_expr;
@@ -1607,7 +1731,9 @@ impl<'tcx> TransformVisitor<'tcx> {
                     );
                     return PtrKind::Slice(m);
                 }
-                PtrCtx::Rhs(PtrKind::OptBox | PtrKind::OptBoxedSlice) => {
+                PtrCtx::Rhs(
+                    PtrKind::Box | PtrKind::OptBox | PtrKind::BoxedSlice | PtrKind::OptBoxedSlice,
+                ) => {
                     panic!("unsupported M4A box target for as_ptr")
                 }
             }
@@ -1615,6 +1741,9 @@ impl<'tcx> TransformVisitor<'tcx> {
 
         if !pe.as_ptr && matches!(pe.base_ty.kind(), ty::TyKind::Array(..)) {
             match ctx {
+                PtrCtx::Rhs(PtrKind::Ref(_)) => {
+                    unreachable!("non-optional pointer targets are handled before array base")
+                }
                 PtrCtx::Rhs(PtrKind::Raw(m)) => {
                     let base = self.projected_expr(&pe, m, false);
                     *ptr = utils::expr!(
@@ -1667,7 +1796,9 @@ impl<'tcx> TransformVisitor<'tcx> {
                     *ptr = self.plain_slice_from_slice(&base, &pe, m, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::Slice(m);
                 }
-                PtrCtx::Rhs(PtrKind::OptBox | PtrKind::OptBoxedSlice) => {
+                PtrCtx::Rhs(
+                    PtrKind::Box | PtrKind::OptBox | PtrKind::BoxedSlice | PtrKind::OptBoxedSlice,
+                ) => {
                     panic!("unsupported M5 box target for array base")
                 }
             }
@@ -1680,6 +1811,11 @@ impl<'tcx> TransformVisitor<'tcx> {
                         let inner_ty = mir_ty_to_string(lhs_inner_ty, self.tcx);
                         *ptr = utils::expr!("{} as *mut {}", pprust::expr_to_string(ptr), inner_ty);
                     }
+                    return PtrKind::Raw(m);
+                }
+                (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::Ref(m1)) => {
+                    assert!(pe.projs.is_empty());
+                    *ptr = self.raw_from_ref(pe.base, m, m1, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::Raw(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::OptRef(m1)) => {
@@ -1703,11 +1839,27 @@ impl<'tcx> TransformVisitor<'tcx> {
                     *ptr = self.opt_ref_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::OptRef(m);
                 }
+                (PtrCtx::Rhs(PtrKind::OptRef(m)), PtrKind::Ref(m1)) => {
+                    assert!(pe.projs.is_empty());
+                    *ptr =
+                        self.opt_ref_from_ref(pe.base, m, m1, lhs_inner_ty, rhs_inner_ty, def_id);
+                    return PtrKind::OptRef(m);
+                }
+                (PtrCtx::Rhs(PtrKind::OptRef(m)), PtrKind::Box) => {
+                    assert!(pe.projs.is_empty());
+                    *ptr = self.opt_ref_from_box(pe.base, m, lhs_inner_ty, rhs_inner_ty, def_id);
+                    return PtrKind::OptRef(m);
+                }
                 (PtrCtx::Rhs(PtrKind::OptRef(m)), PtrKind::OptBox) => {
                     assert!(pe.projs.is_empty());
                     *ptr =
                         self.opt_ref_from_opt_box(pe.base, m, lhs_inner_ty, rhs_inner_ty, def_id);
                     return PtrKind::OptRef(m);
+                }
+                (PtrCtx::Deref(m), PtrKind::Ref(m1)) => {
+                    assert!(pe.projs.is_empty());
+                    *ptr = self.ref_from_ref(pe.base, m, m1, lhs_inner_ty, rhs_inner_ty, def_id);
+                    return PtrKind::Ref(m);
                 }
                 (PtrCtx::Rhs(PtrKind::OptRef(m)) | PtrCtx::Deref(m), PtrKind::OptRef(m1)) => {
                     assert!(pe.projs.is_empty());
@@ -1716,6 +1868,17 @@ impl<'tcx> TransformVisitor<'tcx> {
                         pe.base,
                         m,
                         m1,
+                        lhs_inner_ty,
+                        rhs_inner_ty,
+                        def_id,
+                    );
+                    return PtrKind::OptRef(m);
+                }
+                (PtrCtx::Rhs(PtrKind::OptRef(m)), PtrKind::BoxedSlice) => {
+                    let base = self.boxed_slice_view_expr(pe.base, m);
+                    *ptr = self.opt_ref_from_slice_or_cursor(
+                        &base,
+                        m,
                         lhs_inner_ty,
                         rhs_inner_ty,
                         def_id,
@@ -1800,10 +1963,30 @@ impl<'tcx> TransformVisitor<'tcx> {
                     *ptr = self.slice_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::Slice(m);
                 }
+                (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::Ref(m1)) => {
+                    assert!(pe.projs.is_empty());
+                    *ptr = self.slice_from_ref(pe.base, m, m1, lhs_inner_ty, rhs_inner_ty, def_id);
+                    return PtrKind::Slice(m);
+                }
+                (PtrCtx::Deref(_m), PtrKind::Box) => {
+                    assert!(pe.projs.is_empty());
+                    *ptr = self.box_from_box(pe.base, lhs_inner_ty, rhs_inner_ty);
+                    return PtrKind::Box;
+                }
                 (PtrCtx::Deref(_m), PtrKind::OptBox) => {
                     assert!(pe.projs.is_empty());
                     *ptr = self.opt_box_from_opt_box(pe.base, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::OptBox;
+                }
+                (PtrCtx::Deref(m), PtrKind::BoxedSlice) => {
+                    if pe.projs.is_empty() {
+                        *ptr =
+                            self.boxed_slice_from_boxed_slice(pe.base, lhs_inner_ty, rhs_inner_ty);
+                        return PtrKind::BoxedSlice;
+                    }
+                    let base = self.boxed_slice_view_expr(pe.base, m);
+                    *ptr = self.plain_slice_from_expr(&base, m, lhs_inner_ty, rhs_inner_ty);
+                    return PtrKind::Slice(m);
                 }
                 (PtrCtx::Deref(m), PtrKind::OptBoxedSlice) => {
                     if pe.projs.is_empty() {
@@ -1824,6 +2007,11 @@ impl<'tcx> TransformVisitor<'tcx> {
                     let base = self.projected_expr(&pe, m, false);
                     // can be used for deref, so type must be specified
                     *ptr = self.plain_slice_from_slice(&base, &pe, m, lhs_inner_ty, rhs_inner_ty);
+                    return PtrKind::Slice(m);
+                }
+                (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::BoxedSlice) => {
+                    let base = self.boxed_slice_view_expr(pe.base, m);
+                    *ptr = self.plain_slice_from_expr(&base, m, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::Slice(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::OptBoxedSlice) => {
@@ -1848,6 +2036,19 @@ impl<'tcx> TransformVisitor<'tcx> {
                     self.slice_cursor.set(true);
                     // to keep offsets, we use `e` instead of `pe.base`
                     *ptr = self.cursor_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty);
+                    return PtrKind::SliceCursor(m);
+                }
+                (PtrCtx::Rhs(PtrKind::SliceCursor(m)), PtrKind::Ref(m1)) => {
+                    self.slice_cursor.set(true);
+                    assert!(pe.projs.is_empty());
+                    *ptr = self.cursor_from_ref(pe.base, &pe, m, m1, lhs_inner_ty, rhs_inner_ty);
+                    return PtrKind::SliceCursor(m);
+                }
+                (PtrCtx::Rhs(PtrKind::SliceCursor(m)), PtrKind::BoxedSlice) => {
+                    self.slice_cursor.set(true);
+                    let base = self.boxed_slice_view_expr(pe.base, m);
+                    *ptr =
+                        self.cursor_from_slice_or_cursor(&base, &pe, m, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::SliceCursor(m);
                 }
                 (PtrCtx::Rhs(PtrKind::SliceCursor(m)), PtrKind::OptBoxedSlice) => {
@@ -1891,12 +2092,26 @@ impl<'tcx> TransformVisitor<'tcx> {
                 (PtrCtx::Rhs(PtrKind::SliceCursor(_) | PtrKind::Slice(_)), PtrKind::OptRef(_)) => {
                     panic!()
                 }
-                (PtrCtx::Rhs(PtrKind::Slice(_) | PtrKind::SliceCursor(_)), PtrKind::OptBox) => {
+                (
+                    PtrCtx::Rhs(PtrKind::Slice(_) | PtrKind::SliceCursor(_)),
+                    PtrKind::Box | PtrKind::OptBox,
+                ) => {
                     panic!("unsupported M4A slice/cursor target from scalar owning box");
+                }
+                (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::Box) => {
+                    assert!(pe.projs.is_empty());
+                    *ptr = self.raw_from_box(pe.base, m, lhs_inner_ty, rhs_inner_ty);
+                    return PtrKind::Raw(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::OptBox) => {
                     assert!(pe.projs.is_empty());
                     *ptr = self.raw_from_opt_box(pe.base, m, lhs_inner_ty, rhs_inner_ty);
+                    return PtrKind::Raw(m);
+                }
+                (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::BoxedSlice) => {
+                    let base = self.boxed_slice_view_expr(pe.base, m);
+                    *ptr =
+                        self.raw_from_slice_or_cursor(&base, m, true, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::Raw(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::OptBoxedSlice) => {
@@ -1912,6 +2127,11 @@ impl<'tcx> TransformVisitor<'tcx> {
                     );
                     return PtrKind::Raw(m);
                 }
+                (PtrCtx::Rhs(PtrKind::OptBox), PtrKind::Box) => {
+                    assert!(pe.projs.is_empty());
+                    *ptr = utils::expr!("Some({})", pprust::expr_to_string(pe.base));
+                    return PtrKind::OptBox;
+                }
                 (PtrCtx::Rhs(PtrKind::OptBox), PtrKind::OptBox) => {
                     assert!(pe.projs.is_empty());
                     *ptr = if matches!(pe.base_kind, PtrExprBaseKind::Path(Res::Local(_))) {
@@ -1925,6 +2145,11 @@ impl<'tcx> TransformVisitor<'tcx> {
                     assert!(pe.projs.is_empty());
                     *ptr = self.opt_box_from_raw(pe.base, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::OptBox;
+                }
+                (PtrCtx::Rhs(PtrKind::OptBoxedSlice), PtrKind::BoxedSlice) => {
+                    assert!(pe.projs.is_empty());
+                    *ptr = utils::expr!("Some({})", pprust::expr_to_string(pe.base));
+                    return PtrKind::OptBoxedSlice;
                 }
                 (PtrCtx::Rhs(PtrKind::OptBoxedSlice), PtrKind::OptBoxedSlice) => {
                     assert!(pe.projs.is_empty());
@@ -1949,11 +2174,17 @@ impl<'tcx> TransformVisitor<'tcx> {
                 | (PtrCtx::Rhs(PtrKind::OptBoxedSlice), other) => {
                     panic!("unsupported M4A box target/source combination: {other:?}");
                 }
+                (PtrCtx::Rhs(PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice), _) => {
+                    unreachable!("non-optional pointer targets are handled before source matching")
+                }
             }
         }
 
         if pe.base_kind == PtrExprBaseKind::ByteStr {
             match ctx {
+                PtrCtx::Rhs(PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice) => {
+                    unreachable!("non-optional pointer targets are handled before byte strings")
+                }
                 PtrCtx::Rhs(PtrKind::Raw(m)) => {
                     return PtrKind::Raw(m);
                 }
@@ -2035,6 +2266,9 @@ impl<'tcx> TransformVisitor<'tcx> {
             m1
         };
         match ctx {
+            PtrCtx::Rhs(PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice) => {
+                unreachable!("non-optional pointer targets are handled before final raw fallback")
+            }
             PtrCtx::Rhs(PtrKind::Raw(m)) | PtrCtx::Deref(m) => {
                 if m && !m1 {
                     let inner_ty = mir_ty_to_string(lhs_inner_ty, self.tcx);
@@ -2191,6 +2425,14 @@ impl<'tcx> TransformVisitor<'tcx> {
         )
     }
 
+    fn boxed_slice_view_expr(&self, e: &Expr, m: bool) -> Expr {
+        utils::expr!(
+            "&{}({})[..]",
+            if m { "mut " } else { "" },
+            pprust::expr_to_string(e),
+        )
+    }
+
     fn try_materialize_box_allocator_root(
         &self,
         ptr: &mut Expr,
@@ -2216,6 +2458,18 @@ impl<'tcx> TransformVisitor<'tcx> {
                 *ptr = utils::expr!("Some(Box::new({default_expr_str}))");
                 Some(PtrKind::OptBox)
             }
+            (PtrKind::Box, _)
+                if hir_expr.is_some_and(|hir_expr| {
+                    hir_supports_scalar_box_allocator_root(self.tcx, lhs_inner_ty, hir_expr)
+                }) || expr_supports_scalar_opt_box_allocator_root(
+                    self.tcx,
+                    expr,
+                    lhs_inner_ty,
+                ) =>
+            {
+                *ptr = utils::expr!("Box::new({default_expr_str})");
+                Some(PtrKind::Box)
+            }
             (PtrKind::OptBoxedSlice, AllocatorRoot::Calloc { count, elem_size }) => {
                 *ptr = utils::expr!(
                     "Some(std::iter::repeat_with(|| {0}).take((({1}) * ({2}) / std::mem::size_of::<{3}>()) as usize).collect::<Vec<{3}>>().into_boxed_slice())",
@@ -2226,6 +2480,16 @@ impl<'tcx> TransformVisitor<'tcx> {
                 );
                 Some(PtrKind::OptBoxedSlice)
             }
+            (PtrKind::BoxedSlice, AllocatorRoot::Calloc { count, elem_size }) => {
+                *ptr = utils::expr!(
+                    "std::iter::repeat_with(|| {0}).take((({1}) * ({2}) / std::mem::size_of::<{3}>()) as usize).collect::<Vec<{3}>>().into_boxed_slice()",
+                    default_expr_str,
+                    pprust::expr_to_string(count),
+                    pprust::expr_to_string(elem_size),
+                    ty,
+                );
+                Some(PtrKind::BoxedSlice)
+            }
             (PtrKind::OptBoxedSlice, AllocatorRoot::Malloc { bytes }) => {
                 *ptr = utils::expr!(
                     "Some(std::iter::repeat_with(|| {0}).take((({1}) / std::mem::size_of::<{2}>()) as usize).collect::<Vec<{2}>>().into_boxed_slice())",
@@ -2234,6 +2498,15 @@ impl<'tcx> TransformVisitor<'tcx> {
                     ty,
                 );
                 Some(PtrKind::OptBoxedSlice)
+            }
+            (PtrKind::BoxedSlice, AllocatorRoot::Malloc { bytes }) => {
+                *ptr = utils::expr!(
+                    "std::iter::repeat_with(|| {0}).take((({1}) / std::mem::size_of::<{2}>()) as usize).collect::<Vec<{2}>>().into_boxed_slice()",
+                    default_expr_str,
+                    pprust::expr_to_string(bytes),
+                    ty,
+                );
+                Some(PtrKind::BoxedSlice)
             }
             _ => None,
         }
@@ -2417,6 +2690,200 @@ impl<'tcx> TransformVisitor<'tcx> {
                 lhs_ty,
             )
         }
+    }
+
+    fn raw_from_ref(
+        &self,
+        e: &Expr,
+        m: bool,
+        m1: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let lhs_ty = mir_ty_to_string(lhs_inner_ty, self.tcx);
+        let rhs_ty = mir_ty_to_string(rhs_inner_ty, self.tcx);
+        let source_mut = if m1 { "mut" } else { "const" };
+        let target_mut = if m { "mut" } else { "const" };
+        if lhs_inner_ty == rhs_inner_ty && m == m1 {
+            utils::expr!(
+                "({}) as *{} {}",
+                pprust::expr_to_string(e),
+                target_mut,
+                lhs_ty,
+            )
+        } else {
+            utils::expr!(
+                "({}) as *{} {} as *{} {}",
+                pprust::expr_to_string(e),
+                source_mut,
+                rhs_ty,
+                target_mut,
+                lhs_ty,
+            )
+        }
+    }
+
+    fn raw_from_box(
+        &self,
+        e: &Expr,
+        m: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let view = if m {
+            utils::expr!("({}).as_mut()", pprust::expr_to_string(e))
+        } else {
+            utils::expr!("({}).as_ref()", pprust::expr_to_string(e))
+        };
+        self.raw_from_ref(&view, m, m, lhs_inner_ty, rhs_inner_ty)
+    }
+
+    fn raw_from_box_return(
+        &self,
+        e: &Expr,
+        m: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let lhs_ty = mir_ty_to_string(lhs_inner_ty, self.tcx);
+        let rhs_ty = mir_ty_to_string(rhs_inner_ty, self.tcx);
+        if lhs_inner_ty == rhs_inner_ty {
+            utils::expr!(
+                "Box::into_raw({}) as *{} {}",
+                pprust::expr_to_string(e),
+                if m { "mut" } else { "const" },
+                lhs_ty,
+            )
+        } else {
+            utils::expr!(
+                "Box::into_raw({}) as *{} {} as *{} {}",
+                pprust::expr_to_string(e),
+                if m { "mut" } else { "const" },
+                rhs_ty,
+                if m { "mut" } else { "const" },
+                lhs_ty,
+            )
+        }
+    }
+
+    fn raw_from_boxed_slice_return(
+        &self,
+        e: &Expr,
+        m: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let lhs_ty = mir_ty_to_string(lhs_inner_ty, self.tcx);
+        let rhs_ty = mir_ty_to_string(rhs_inner_ty, self.tcx);
+        let ptr_method = if m { "as_mut_ptr" } else { "as_ptr" };
+        let ptr_mut = if m { "mut" } else { "const" };
+        if lhs_inner_ty == rhs_inner_ty {
+            utils::expr!("Box::leak({}).{}()", pprust::expr_to_string(e), ptr_method,)
+        } else {
+            utils::expr!(
+                "Box::leak({}).{}() as *{} {} as *{} {}",
+                pprust::expr_to_string(e),
+                ptr_method,
+                ptr_mut,
+                rhs_ty,
+                ptr_mut,
+                lhs_ty,
+            )
+        }
+    }
+
+    fn ref_from_ref(
+        &self,
+        e: &Expr,
+        m: bool,
+        m1: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+        def_id: LocalDefId,
+    ) -> Expr {
+        if lhs_inner_ty == rhs_inner_ty {
+            if m == m1 {
+                return e.clone();
+            }
+            if !m && m1 {
+                return utils::expr!("&*({})", pprust::expr_to_string(e));
+            }
+        }
+        let opt = self.opt_ref_from_ref(e, m, m1, lhs_inner_ty, rhs_inner_ty, def_id);
+        utils::expr!("({}).unwrap()", pprust::expr_to_string(&opt))
+    }
+
+    fn opt_ref_from_ref(
+        &self,
+        e: &Expr,
+        m: bool,
+        m1: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+        def_id: LocalDefId,
+    ) -> Expr {
+        let need_cast = lhs_inner_ty != rhs_inner_ty;
+        let e_str = pprust::expr_to_string(e);
+        if !need_cast {
+            utils::expr!("Some(&{}*({}))", if m && m1 { "mut " } else { "" }, e_str,)
+        } else if lhs_inner_ty.is_numeric()
+            && rhs_inner_ty.is_numeric()
+            && self.same_size(lhs_inner_ty, rhs_inner_ty, def_id)
+        {
+            self.bytemuck.set(true);
+            utils::expr!(
+                "Some(bytemuck::cast_{}::<_, {}>(&{}*({})))",
+                if m && m1 { "mut" } else { "ref" },
+                mir_ty_to_string(lhs_inner_ty, self.tcx),
+                if m && m1 { "mut " } else { "" },
+                e_str,
+            )
+        } else {
+            let raw = self.raw_from_ref(e, m, m1, lhs_inner_ty, rhs_inner_ty);
+            self.opt_ref_from_raw(&raw, m, m, lhs_inner_ty, lhs_inner_ty)
+        }
+    }
+
+    fn opt_ref_from_box(
+        &self,
+        e: &Expr,
+        m: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+        def_id: LocalDefId,
+    ) -> Expr {
+        let view = if m {
+            utils::expr!("({}).as_mut()", pprust::expr_to_string(e))
+        } else {
+            utils::expr!("({}).as_ref()", pprust::expr_to_string(e))
+        };
+        self.opt_ref_from_ref(&view, m, m, lhs_inner_ty, rhs_inner_ty, def_id)
+    }
+
+    fn box_from_box(
+        &self,
+        e: &Expr,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        assert_eq!(
+            lhs_inner_ty, rhs_inner_ty,
+            "M4A does not support casted Box<_> reinterpretation"
+        );
+        e.clone()
+    }
+
+    fn boxed_slice_from_boxed_slice(
+        &self,
+        e: &Expr,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        assert_eq!(
+            lhs_inner_ty, rhs_inner_ty,
+            "M4A does not support casted Box<[_]> reinterpretation"
+        );
+        e.clone()
     }
 
     fn opt_ref_from_opt_box(
@@ -2781,6 +3248,41 @@ impl<'tcx> TransformVisitor<'tcx> {
         }
     }
 
+    fn slice_from_ref(
+        &self,
+        e: &Expr,
+        m: bool,
+        m1: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+        def_id: LocalDefId,
+    ) -> Expr {
+        let need_cast = lhs_inner_ty != rhs_inner_ty;
+        let e_str = pprust::expr_to_string(e);
+        if !need_cast {
+            utils::expr!(
+                "std::slice::from_{}(&{}*({}))",
+                if m && m1 { "mut" } else { "ref" },
+                if m && m1 { "mut " } else { "" },
+                e_str,
+            )
+        } else if lhs_inner_ty.is_numeric()
+            && rhs_inner_ty.is_numeric()
+            && self.same_size(lhs_inner_ty, rhs_inner_ty, def_id)
+        {
+            self.bytemuck.set(true);
+            utils::expr!(
+                "std::slice::from_{0}(bytemuck::cast_{0}(&{1}*({2})))",
+                if m && m1 { "mut" } else { "ref" },
+                if m && m1 { "mut " } else { "" },
+                e_str,
+            )
+        } else {
+            let raw = self.raw_from_ref(e, m, m1, lhs_inner_ty, rhs_inner_ty);
+            self.slice_from_raw(&raw, m, m, lhs_inner_ty, lhs_inner_ty)
+        }
+    }
+
     fn cursor_from_raw(
         &self,
         e: &Expr,
@@ -2883,6 +3385,26 @@ impl<'tcx> TransformVisitor<'tcx> {
         }
     }
 
+    fn cursor_from_ref(
+        &self,
+        e: &Expr,
+        pe: &PtrExpr<'_, 'tcx>,
+        m: bool,
+        m1: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let slice = self.slice_from_ref(
+            e,
+            m,
+            m1,
+            lhs_inner_ty,
+            rhs_inner_ty,
+            pe.hir_base.hir_id.owner.def_id,
+        );
+        self.cursor_from_plain_slice(&slice, pe, m, lhs_inner_ty, lhs_inner_ty)
+    }
+
     // slice -> slice
     fn plain_slice_from_slice(
         &self,
@@ -2897,7 +3419,12 @@ impl<'tcx> TransformVisitor<'tcx> {
             matches!(pe.base_kind, PtrExprBaseKind::Path(Res::Local(_)))
                 && matches!(
                     self.ptr_source_kind(pe),
-                    Some(PtrKind::Slice(_) | PtrKind::SliceCursor(_) | PtrKind::OptBoxedSlice)
+                    Some(
+                        PtrKind::Slice(_)
+                            | PtrKind::SliceCursor(_)
+                            | PtrKind::BoxedSlice
+                            | PtrKind::OptBoxedSlice,
+                    )
                 )
                 && pe.projs.is_empty();
         let get_reference = |use_ref| {
@@ -2967,7 +3494,12 @@ impl<'tcx> TransformVisitor<'tcx> {
             matches!(pe.base_kind, PtrExprBaseKind::Path(Res::Local(_)))
                 && matches!(
                     self.ptr_source_kind(pe),
-                    Some(PtrKind::Slice(_) | PtrKind::SliceCursor(_) | PtrKind::OptBoxedSlice)
+                    Some(
+                        PtrKind::Slice(_)
+                            | PtrKind::SliceCursor(_)
+                            | PtrKind::BoxedSlice
+                            | PtrKind::OptBoxedSlice,
+                    )
                 )
                 && pe.projs.is_empty();
         let get_reference = |use_ref| {
@@ -2991,12 +3523,13 @@ impl<'tcx> TransformVisitor<'tcx> {
                 && let PtrExprProj::Offset(offset) = pe.projs[0]
             {
                 // if there are only offsets, we can use the original slice and let the cursor handle the offsets
-                let cursor_base =
-                    if matches!(self.ptr_source_kind(pe), Some(PtrKind::OptBoxedSlice)) {
-                        self.opt_boxed_slice_view_expr(pe.base, m)
-                    } else {
-                        pe.base.clone()
-                    };
+                let cursor_base = if matches!(self.ptr_source_kind(pe), Some(PtrKind::BoxedSlice)) {
+                    self.boxed_slice_view_expr(pe.base, m)
+                } else if matches!(self.ptr_source_kind(pe), Some(PtrKind::OptBoxedSlice)) {
+                    self.opt_boxed_slice_view_expr(pe.base, m)
+                } else {
+                    pe.base.clone()
+                };
                 utils::expr!(
                     "{}::with_pos({}{}, ({}) as usize)",
                     cursor_ty,
@@ -3096,8 +3629,11 @@ impl<'tcx> TransformVisitor<'tcx> {
             && let Res::Local(hir_id) = path.res
         {
             match self.effective_ptr_kind(hir_id) {
+                Some(PtrKind::Ref(m)) => Some(m),
                 Some(PtrKind::OptRef(m)) => Some(m),
-                Some(PtrKind::OptBox | PtrKind::OptBoxedSlice) => Some(true),
+                Some(
+                    PtrKind::Box | PtrKind::OptBox | PtrKind::BoxedSlice | PtrKind::OptBoxedSlice,
+                ) => Some(true),
                 Some(PtrKind::Slice(m)) | Some(PtrKind::SliceCursor(m)) => Some(m),
                 Some(PtrKind::Raw(m)) => Some(m),
                 None => None,
@@ -3331,8 +3867,11 @@ impl<'tcx> TransformVisitor<'tcx> {
                     matches!(
                         self.effective_ptr_kind(hir_id)
                             .unwrap_or(self.ptr_kinds[&hir_id]),
-                        PtrKind::OptRef(_)
+                        PtrKind::Ref(_)
+                            | PtrKind::OptRef(_)
+                            | PtrKind::Box
                             | PtrKind::OptBox
+                            | PtrKind::BoxedSlice
                             | PtrKind::OptBoxedSlice
                             | PtrKind::Slice(_)
                             | PtrKind::SliceCursor(_)
@@ -3536,6 +4075,13 @@ fn unwrap_ptr_or_arr_from_mir_ty<'tcx>(
 }
 
 #[inline]
+fn mk_ref_ty<'tcx>(ty: ty::Ty<'tcx>, mutability: bool, tcx: TyCtxt<'tcx>) -> Ty {
+    let ty = mir_ty_to_string(ty, tcx);
+    let m = if mutability { "mut " } else { "" };
+    utils::ty!("&{m}{ty}")
+}
+
+#[inline]
 fn mk_opt_ref_ty<'tcx>(ty: ty::Ty<'tcx>, mutability: bool, tcx: TyCtxt<'tcx>) -> Ty {
     let ty = mir_ty_to_string(ty, tcx);
     let m = if mutability { "mut " } else { "" };
@@ -3543,9 +4089,21 @@ fn mk_opt_ref_ty<'tcx>(ty: ty::Ty<'tcx>, mutability: bool, tcx: TyCtxt<'tcx>) ->
 }
 
 #[inline]
+fn mk_box_ty<'tcx>(ty: ty::Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Ty {
+    let ty = mir_ty_to_string(ty, tcx);
+    utils::ty!("Box<{ty}>")
+}
+
+#[inline]
 fn mk_opt_box_ty<'tcx>(ty: ty::Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Ty {
     let ty = mir_ty_to_string(ty, tcx);
     utils::ty!("Option<Box<{ty}>>")
+}
+
+#[inline]
+fn mk_boxed_slice_ty<'tcx>(ty: ty::Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Ty {
+    let ty = mir_ty_to_string(ty, tcx);
+    utils::ty!("Box<[{ty}]>")
 }
 
 #[inline]
@@ -4296,11 +4854,12 @@ fn downgrade_unsupported_box_inputs(
         };
         let body = tcx.hir_body(body);
         for (idx, param) in body.params.iter().enumerate() {
-            let Some(kind @ (PtrKind::OptBox | PtrKind::OptBoxedSlice)) =
-                sig_dec.input_decs.get(idx).copied().flatten()
-            else {
+            let Some(kind) = sig_dec.input_decs.get(idx).copied().flatten() else {
                 continue;
             };
+            if !kind.is_owning_box_like() {
+                continue;
+            }
             let hir::PatKind::Binding(_, hir_id, _, _) = param.pat.kind else {
                 continue;
             };
@@ -4323,10 +4882,12 @@ fn downgrade_unsupported_box_outputs<'tcx>(
 ) -> bool {
     let mut to_raw = Vec::new();
     for (did, sig_dec) in &sig_decs.data {
-        let Some(output_kind @ (PtrKind::OptBox | PtrKind::OptBoxedSlice)) = sig_dec.output_dec
-        else {
+        let Some(output_kind) = sig_dec.output_dec else {
             continue;
         };
+        if !output_kind.is_owning_box_like() {
+            continue;
+        }
         let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
         let Some((inner_ty, _)) =
             unwrap_ptr_from_mir_ty(body.local_decls[rustc_middle::mir::Local::from_u32(0)].ty)
@@ -4496,7 +5057,7 @@ fn effective_callee_output_kind(
         else {
             return Some(output_dec);
         };
-        if matches!(output_dec, PtrKind::OptBox | PtrKind::OptBoxedSlice)
+        if output_dec.is_owning_box_like()
             && (fn_tail_returns_unsupported_box_binding(
                 tcx, sig_decs, ptr_kinds, def_id, output_dec, inner_ty,
             ) || fn_output_has_nonowning_local_consumers(tcx, ptr_kinds, def_id, output_dec))
@@ -5817,10 +6378,9 @@ fn collect_local_raw_param_summaries(
         };
         let body = tcx.hir_body(body);
         let returns_owning_output = sig_decs.data.get(def_id).is_some_and(|sig_dec| {
-            matches!(
-                sig_dec.output_dec,
-                Some(PtrKind::OptBox | PtrKind::OptBoxedSlice)
-            )
+            sig_dec
+                .output_dec
+                .is_some_and(|kind| kind.is_owning_box_like())
         });
         let mut visitor = RawParamSummaryVisitor {
             tcx,
@@ -6328,12 +6888,12 @@ fn hir_rhs_supports_box_target<'tcx>(
     }
 
     match target_kind {
-        PtrKind::OptBox => {
+        PtrKind::Box | PtrKind::OptBox => {
             if hir_supports_scalar_box_allocator_root(tcx, lhs_inner_ty, hir_uncast) {
                 return true;
             }
         }
-        PtrKind::OptBoxedSlice => {
+        PtrKind::BoxedSlice | PtrKind::OptBoxedSlice => {
             if hir_is_supported_boxed_slice_allocator_root(tcx, hir_uncast) {
                 return true;
             }
@@ -6342,14 +6902,16 @@ fn hir_rhs_supports_box_target<'tcx>(
     }
 
     if let hir::ExprKind::Call(..) = hir_expr.kind
-        && hir_callee_output_kind(tcx, sig_decs, ptr_kinds, hir_expr) == Some(target_kind)
+        && let Some(output_kind) = hir_callee_output_kind(tcx, sig_decs, ptr_kinds, hir_expr)
+        && (output_kind == target_kind || output_kind == target_kind.optional_variant())
     {
         return true;
     }
 
     if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_expr.kind
         && let Res::Local(hir_id) = path.res
-        && ptr_kinds.get(&hir_id).copied() == Some(target_kind)
+        && let Some(rhs_kind) = ptr_kinds.get(&hir_id).copied()
+        && (rhs_kind == target_kind || rhs_kind == target_kind.optional_variant())
     {
         return true;
     }
@@ -6374,8 +6936,8 @@ fn collect_unsupported_box_target_bindings(
             if let hir::StmtKind::Let(let_stmt) = stmt.kind
                 && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
                 && let Some(init) = let_stmt.init
-                && let Some(kind @ (PtrKind::OptBox | PtrKind::OptBoxedSlice)) =
-                    self.ptr_kinds.get(&hir_id).copied()
+                && let Some(kind) = self.ptr_kinds.get(&hir_id).copied()
+                && kind.is_owning_box_like()
             {
                 let lhs_ty = self.tcx.typeck(hir_id.owner).node_type(hir_id);
                 let (lhs_inner_ty, _) = unwrap_ptr_from_mir_ty(lhs_ty).unwrap();
@@ -6397,8 +6959,8 @@ fn collect_unsupported_box_target_bindings(
             if let hir::ExprKind::Assign(lhs, rhs, _) = expr.kind
                 && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = lhs.kind
                 && let Res::Local(hir_id) = path.res
-                && let Some(kind @ (PtrKind::OptBox | PtrKind::OptBoxedSlice)) =
-                    self.ptr_kinds.get(&hir_id).copied()
+                && let Some(kind) = self.ptr_kinds.get(&hir_id).copied()
+                && kind.is_owning_box_like()
             {
                 let lhs_ty = self.tcx.typeck(expr.hir_id.owner).expr_ty(lhs);
                 let (lhs_inner_ty, _) = unwrap_ptr_from_mir_ty(lhs_ty).unwrap();
@@ -6459,10 +7021,11 @@ fn collect_unsupported_box_usage_bindings(
 
     impl<'tcx> UnsupportedBoxUsageVisitor<'_, 'tcx> {
         fn owning_root_of(&self, hir_id: HirId) -> Option<HirId> {
-            if matches!(
-                self.ptr_kinds.get(&hir_id),
-                Some(PtrKind::OptBox | PtrKind::OptBoxedSlice)
-            ) {
+            if self
+                .ptr_kinds
+                .get(&hir_id)
+                .is_some_and(PtrKind::is_owning_box_like)
+            {
                 Some(hir_id)
             } else {
                 self.byte_view_roots.get(&hir_id).copied()
@@ -6573,10 +7136,10 @@ fn collect_unsupported_box_usage_bindings(
                 let is_direct_free = hir_call_matches_foreign_name(self.tcx, expr, "free");
                 let direct_box_consume = is_direct_free
                     && hir_id == root
-                    && matches!(
-                        self.ptr_kinds.get(&hir_id),
-                        Some(PtrKind::OptBox | PtrKind::OptBoxedSlice)
-                    );
+                    && self
+                        .ptr_kinds
+                        .get(&hir_id)
+                        .is_some_and(PtrKind::is_owning_box_like);
                 if !direct_box_consume {
                     self.bindings.insert(root);
                 }
@@ -6641,7 +7204,10 @@ fn downgrade_unsupported_allocator_box_kinds(
             let Some((inner_ty, _)) = unwrap_ptr_from_mir_ty(lhs_ty) else {
                 return;
             };
-            if self.ptr_kinds.get(&hir_id).copied() != Some(PtrKind::OptBox) {
+            if !matches!(
+                self.ptr_kinds.get(&hir_id).copied(),
+                Some(PtrKind::Box | PtrKind::OptBox)
+            ) {
                 return;
             }
             if !matches!(
@@ -6986,6 +7552,7 @@ mod tests {
         let mut offset_sign_result = analyses::offset_sign::sign::offset_sign_analysis(&input);
         offset_sign_result.access_signs =
             source_var_groups.postprocess_offset_signs(offset_sign_result.access_signs);
+        let nullity_result = analyses::nullity::analyze(&input);
         let analysis = super::super::Analysis {
             promoted_mut_ref_result,
             promoted_shared_ref_result,
@@ -6995,6 +7562,7 @@ mod tests {
             output_params,
             ownership_schemes,
             offset_sign_result,
+            nullity_result,
         };
 
         (input, analysis)
@@ -7641,11 +8209,11 @@ mod tests {
 
             let final_kind = final_ptr_kinds.get(&site.hir_id).copied();
             match final_kind {
-                Some(PtrKind::OptBox) => {
+                Some(PtrKind::Box | PtrKind::OptBox) => {
                     safe_box_sites.bump(SafetyAllocKind::Scalar);
                     continue;
                 }
-                Some(PtrKind::OptBoxedSlice) => {
+                Some(PtrKind::BoxedSlice | PtrKind::OptBoxedSlice) => {
                     safe_box_sites.bump(SafetyAllocKind::Array);
                     continue;
                 }
@@ -7899,10 +8467,11 @@ mod tests {
             }
 
             fn owning_root_of(&self, hir_id: HirId) -> Option<HirId> {
-                if matches!(
-                    self.ptr_kinds.get(&hir_id),
-                    Some(PtrKind::OptBox | PtrKind::OptBoxedSlice)
-                ) {
+                if self
+                    .ptr_kinds
+                    .get(&hir_id)
+                    .is_some_and(PtrKind::is_owning_box_like)
+                {
                     Some(hir_id)
                 } else {
                     self.byte_view_roots.get(&hir_id).copied()

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -50,6 +50,74 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
 }
 
 #[test]
+fn test_non_null_param_to_ref() {
+    run_test(
+        r#"
+use ::libc;
+pub unsafe extern "C" fn foo(p: *const libc::c_int) -> libc::c_int {
+    return *p;
+}
+"#,
+        &["fn foo(p: &i32)", "return *p;"],
+        &["Option<&i32>", "*const libc::c_int"],
+    );
+}
+
+#[test]
+fn test_param_null_check_before_deref_stays_optional() {
+    run_test(
+        r#"
+use ::libc;
+pub unsafe extern "C" fn foo(p: *const libc::c_int) -> libc::c_int {
+    if p.is_null() {
+        return 0 as libc::c_int;
+    }
+    return *p;
+}
+"#,
+        &["p: Option<&i32>", "p.is_none()"],
+        &["fn foo(p: &i32)"],
+    );
+}
+
+#[test]
+fn test_non_null_param_late_null_check_rewrites_false() {
+    run_test(
+        r#"
+use ::libc;
+pub unsafe extern "C" fn foo(p: *const libc::c_int) -> libc::c_int {
+    let x = *p;
+    if p.is_null() {
+        return 0 as libc::c_int;
+    }
+    return x;
+}
+"#,
+        &["fn foo(p: &i32)", "if false"],
+        &["p.is_none()", "Option<&i32>"],
+    );
+}
+
+#[test]
+fn test_reassigned_non_null_param_stays_optional() {
+    run_test(
+        r#"
+use ::libc;
+pub unsafe extern "C" fn foo(mut p: *const libc::c_int) -> libc::c_int {
+    let x = *p;
+    p = std::ptr::null();
+    if p.is_null() {
+        return x;
+    }
+    return *p;
+}
+"#,
+        &["mut p: Option<&i32>", "p = None", "p.is_none()"],
+        &["fn foo(mut p: &i32)"],
+    );
+}
+
+#[test]
 fn test_rewriter_output_unchanged_when_ownership_analysis_fails() {
     let code = r#"
 use ::libc;
@@ -560,7 +628,7 @@ pub unsafe fn caller() -> i32 {
     return touch_state(s, ((*s).buf).as_mut_ptr());
         }
 	"#,
-        &["pub unsafe fn touch_state(mut s: *mut crate::State, mut buf: Option<&mut i32>)"],
+        &["pub unsafe fn touch_state(mut s: *mut crate::State, mut buf: &mut i32)"],
         &["Option<&mut State>"],
     );
 }
@@ -2642,7 +2710,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
 }
 
 /// Function call with pointer argument — local function, sig_decs lookup succeeds.
-/// bar's parameter is transformed to OptRef, and the call site converts p accordingly.
+/// bar's parameter is proven non-null and the call site unwraps p accordingly.
 #[test]
 fn test_ptr_call_arg() {
     run_test(
@@ -2656,7 +2724,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return bar(p);
 }
 "#,
-        &["Option<&i32>", "as_deref()"],
+        &["fn bar(p: &i32)", "as_deref()).unwrap()"],
         &[],
     );
 }
@@ -3582,8 +3650,8 @@ pub unsafe fn copy_tail(
     );
 }
 "#,
-        &["(&((*(src).as_deref().unwrap()).data))[("],
-        &["&mut ((*(src).as_deref().unwrap()).data)"],
+        &["(&((*src).data))[("],
+        &["&mut ((*src).data)"],
     );
 }
 


### PR DESCRIPTION
## Summary

- Adds a pointer nullity analysis that proves raw pointer parameters are non-null when every path dereferences them or passes them to callees/libc APIs that require non-null arguments.
- Runs that analysis before pointer rewrite decisions and uses the proof to choose non-optional `&T`/`&mut T`, `Box<T>`, and `Box<[T]>` where the previous rewrite would have kept optional forms.
- Extends the pointer transform for those non-optional reference/box kinds, including signature/local type rewriting, call and return bridging, late null-check rewriting, deref handling, and free/drop handling.

## Results

No regression against baseline `transformed`: Test-Corpus results are identical for `transformed` and `transformed-pointer-nullity`.
- Test cases discovered: 338
- Test cases skipped: 2
- Test cases tested: 336
- Test cases failed: 1
- Test vectors passed: 2606
- Test vectors skipped: 155
- Test vectors failed: 8

The single failed case remains `Public-Tests/B02_organic/load_png_mem_lib`, with the same 8 failing vectors.

No change in unsafe feature occurrence counts after `scripts/find_unsafe.py` and `scripts/summarize_unsafe.py`.
- Total remains 74098 for both baseline and nullity output.
- Top buckets are unchanged: `DerefOfRawPointer` 29000, `from_raw_parts_mut` 20754, `from_raw_parts` 12769, `offset` 3847, `as_mut` 2926.

`Option` is reduced in generated public bin output:

```bash
grep 'Option' transformed/bin/Public-Tests/**/*.rs | wc -l
# 6490
grep 'Option' transformed-pointer-nullity/bin/Public-Tests/**/*.rs | wc -l
# 5176
```

Net reduction: 1314 matching lines, about 20.2%.
- `Option<&` matching lines drop from 6018 to 4702.
- `Option<Box` matching lines are unchanged at 57.
- 146 test cases reduce `Option` usage and no test cases increase it.
- By suite: `P01_sphincs_plus` -1280; `B02_organic` -13; `B01_organic` -10; `B01_synthetic` -6; `B02_synthetic` -5.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets` (passes with warnings)
- `cargo test --workspace`
- `python3 scripts/test_all.py transformed-pointer-nullity --verbose`
- `python3 scripts/find_unsafe.py`
- `python3 scripts/summarize_unsafe.py`
- `python3 scripts/test_all.py transformed --verbose`
- `python3 scripts/find_unsafe.py`
- `python3 scripts/summarize_unsafe.py`
