### PR TITLE
Add enum replacement pass

### DIFF
--- a/crates/passes/src/enum_replacer.rs
+++ b/crates/passes/src/enum_replacer.rs
@@ -1,0 +1,3 @@
+use rustc_middle::ty::TyCtxt;
+
+pub fn replace_enums(_: TyCtxt<'_>) {}

--- a/crates/passes/src/enum_replacer.rs
+++ b/crates/passes/src/enum_replacer.rs
@@ -1,3 +1,0 @@
-use rustc_middle::ty::TyCtxt;
-
-pub fn replace_enums(_: TyCtxt<'_>) {}

--- a/crates/passes/src/enum_replacer/mod.rs
+++ b/crates/passes/src/enum_replacer/mod.rs
@@ -1,0 +1,1055 @@
+use rustc_abi::VariantIdx;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{
+    self as hir, BinOpKind, FnRetTy, HirId, PrimTy, QPath,
+    def::{DefKind, Res},
+    intravisit,
+};
+use rustc_middle::{
+    hir::nested_filter,
+    mir::{ConstValue, interpret::Scalar},
+    ty::{self, Ty, TyCtxt},
+};
+use rustc_span::{
+    Span, Symbol,
+    def_id::{DefId, LocalDefId},
+};
+
+pub fn replace_enums(tcx: TyCtxt<'_>) {
+    let _ = analyze_enums(tcx);
+}
+
+#[derive(Debug, Default)]
+pub struct EnumAnalysis {
+    pub enums: FxHashMap<LocalDefId, EnumInfo>,
+}
+
+#[derive(Debug)]
+pub struct EnumInfo {
+    pub alias: LocalDefId,
+    pub repr: IntegerRepr,
+    pub variants: Vec<VariantInfo>,
+    pub transformable: bool,
+    pub reject_reasons: Vec<RejectReason>,
+    pub enum_to_int_cast_sites: Vec<CastSite>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IntegerRepr {
+    Signed(ty::IntTy),
+    Unsigned(ty::UintTy),
+}
+
+#[derive(Clone, Debug)]
+pub struct VariantInfo {
+    pub const_def_id: LocalDefId,
+    pub name: Symbol,
+    pub value: DiscriminantValue,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiscriminantValue {
+    Signed(i128),
+    Unsigned(u128),
+}
+
+#[derive(Clone, Debug)]
+pub struct RejectReason {
+    pub kind: RejectReasonKind,
+    pub span: Span,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum RejectReasonKind {
+    IntegerLiteralAssignedToEnum,
+    ArithmeticAssignedToEnum,
+    CastAssignedToEnum,
+    UnknownExpressionAssignedToEnum,
+    WrongEnumAssignedToEnum,
+    FunctionArgumentRequiresEnum,
+    ReturnRequiresEnum,
+    DuplicateDiscriminant,
+    UnevaluableDiscriminant,
+    UnsupportedCastSite,
+    CompoundAssignmentToEnum,
+}
+
+#[derive(Clone, Debug)]
+pub struct CastSite {
+    pub enum_alias: LocalDefId,
+    pub hir_id: HirId,
+    pub span: Span,
+    pub kind: CastSiteKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CastSiteKind {
+    AssignmentToInteger,
+    FunctionArgumentToInteger,
+    ReturnToInteger,
+    NumericOperator,
+    ComparisonToInteger,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum HirEnumTy {
+    Enum(LocalDefId),
+    IntLike,
+    Ptr(Box<HirEnumTy>),
+    Ref(Box<HirEnumTy>),
+    Array(Box<HirEnumTy>),
+    Slice(Box<HirEnumTy>),
+    Tuple(Vec<HirEnumTy>),
+    FnPtr {
+        params: Vec<HirEnumTy>,
+        ret: Box<HirEnumTy>,
+    },
+    Other,
+}
+
+impl HirEnumTy {
+    fn exact_enum(&self) -> Option<LocalDefId> {
+        match self {
+            Self::Enum(def_id) => Some(*def_id),
+            _ => None,
+        }
+    }
+
+    fn pointee(&self) -> Option<&HirEnumTy> {
+        match self {
+            Self::Ptr(ty) | Self::Ref(ty) => Some(ty),
+            _ => None,
+        }
+    }
+
+    fn element(&self) -> Option<&HirEnumTy> {
+        match self {
+            Self::Array(ty) | Self::Slice(ty) | Self::Ptr(ty) => Some(ty),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct FnSigEnumTy {
+    params: Vec<HirEnumTy>,
+    ret: HirEnumTy,
+}
+
+#[derive(Default)]
+struct CandidateData<'tcx> {
+    aliases: FxHashMap<LocalDefId, IntegerRepr>,
+    alias_rhs: FxHashMap<LocalDefId, &'tcx hir::Ty<'tcx>>,
+}
+
+struct CandidateVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    data: CandidateData<'tcx>,
+}
+
+impl<'tcx> intravisit::Visitor<'tcx> for CandidateVisitor<'tcx> {
+    type NestedFilter = nested_filter::OnlyBodies;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) -> Self::Result {
+        if let hir::ItemKind::TyAlias(_, _, ty) = item.kind {
+            self.data.alias_rhs.insert(item.owner_id.def_id, ty);
+            if let Some(repr) = integer_repr(
+                self.tcx
+                    .type_of(item.owner_id.def_id)
+                    .instantiate_identity(),
+            ) {
+                self.data.aliases.insert(item.owner_id.def_id, repr);
+            }
+        }
+
+        intravisit::walk_item(self, item)
+    }
+}
+
+struct VariantCollector<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    candidate_aliases: &'a FxHashSet<LocalDefId>,
+    reprs: &'a FxHashMap<LocalDefId, IntegerRepr>,
+    variants: FxHashMap<LocalDefId, Vec<VariantInfo>>,
+    reject_reasons: FxHashMap<LocalDefId, Vec<RejectReason>>,
+}
+
+impl<'tcx> intravisit::Visitor<'tcx> for VariantCollector<'_, 'tcx> {
+    type NestedFilter = nested_filter::OnlyBodies;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) -> Self::Result {
+        if let hir::ItemKind::Const(ident, _, ty, _) = item.kind
+            && let Some(alias) = direct_candidate_alias(ty, self.candidate_aliases)
+        {
+            let repr = self.reprs[&alias];
+            match eval_discriminant(self.tcx, item.owner_id.def_id, repr) {
+                Some(value) => {
+                    self.variants.entry(alias).or_default().push(VariantInfo {
+                        const_def_id: item.owner_id.def_id,
+                        name: ident.name,
+                        value,
+                    });
+                }
+                None => {
+                    self.reject_reasons
+                        .entry(alias)
+                        .or_default()
+                        .push(RejectReason {
+                            kind: RejectReasonKind::UnevaluableDiscriminant,
+                            span: item.span,
+                        });
+                }
+            }
+        }
+
+        intravisit::walk_item(self, item)
+    }
+}
+
+struct TypeModelBuilder<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    enum_aliases: &'a FxHashSet<LocalDefId>,
+    alias_rhs: &'a FxHashMap<LocalDefId, &'tcx hir::Ty<'tcx>>,
+    cache: FxHashMap<LocalDefId, HirEnumTy>,
+    visiting: FxHashSet<LocalDefId>,
+}
+
+impl<'a, 'tcx> TypeModelBuilder<'a, 'tcx> {
+    fn new(
+        tcx: TyCtxt<'tcx>,
+        enum_aliases: &'a FxHashSet<LocalDefId>,
+        alias_rhs: &'a FxHashMap<LocalDefId, &'tcx hir::Ty<'tcx>>,
+    ) -> Self {
+        Self {
+            tcx,
+            enum_aliases,
+            alias_rhs,
+            cache: FxHashMap::default(),
+            visiting: FxHashSet::default(),
+        }
+    }
+
+    fn model_ty(&mut self, ty: &'tcx hir::Ty<'tcx>) -> HirEnumTy {
+        match ty.kind {
+            hir::TyKind::Path(QPath::Resolved(_, path)) => self.model_path(path.res),
+            hir::TyKind::Ptr(mut_ty) => HirEnumTy::Ptr(Box::new(self.model_ty(mut_ty.ty))),
+            hir::TyKind::Ref(_, mut_ty) => HirEnumTy::Ref(Box::new(self.model_ty(mut_ty.ty))),
+            hir::TyKind::Array(ty, _) => HirEnumTy::Array(Box::new(self.model_ty(ty))),
+            hir::TyKind::Slice(ty) => HirEnumTy::Slice(Box::new(self.model_ty(ty))),
+            hir::TyKind::Tup(tys) => {
+                HirEnumTy::Tuple(tys.iter().map(|ty| self.model_ty(ty)).collect())
+            }
+            hir::TyKind::BareFn(bare_fn) => {
+                let params = bare_fn
+                    .decl
+                    .inputs
+                    .iter()
+                    .map(|ty| self.model_ty(ty))
+                    .collect();
+                let ret = Box::new(self.model_ret_ty(bare_fn.decl.output));
+                HirEnumTy::FnPtr { params, ret }
+            }
+            _ => HirEnumTy::Other,
+        }
+    }
+
+    fn model_ret_ty(&mut self, ret: FnRetTy<'tcx>) -> HirEnumTy {
+        match ret {
+            FnRetTy::Return(ty) => self.model_ty(ty),
+            FnRetTy::DefaultReturn(_) => HirEnumTy::Other,
+        }
+    }
+
+    fn model_path(&mut self, res: Res) -> HirEnumTy {
+        match res {
+            Res::Def(DefKind::TyAlias, def_id) => {
+                if let Some(local) = def_id.as_local() {
+                    if self.enum_aliases.contains(&local) {
+                        return HirEnumTy::Enum(local);
+                    }
+                    return self.model_alias(local);
+                }
+
+                if integer_repr(self.tcx.type_of(def_id).instantiate_identity()).is_some() {
+                    HirEnumTy::IntLike
+                } else {
+                    HirEnumTy::Other
+                }
+            }
+            Res::PrimTy(PrimTy::Int(_)) | Res::PrimTy(PrimTy::Uint(_)) => HirEnumTy::IntLike,
+            _ => HirEnumTy::Other,
+        }
+    }
+
+    fn model_alias(&mut self, alias: LocalDefId) -> HirEnumTy {
+        if let Some(ty) = self.cache.get(&alias) {
+            return ty.clone();
+        }
+        if !self.visiting.insert(alias) {
+            return HirEnumTy::Other;
+        }
+
+        let model = self
+            .alias_rhs
+            .get(&alias)
+            .map(|ty| self.model_ty(ty))
+            .unwrap_or(HirEnumTy::Other);
+
+        self.visiting.remove(&alias);
+        self.cache.insert(alias, model.clone());
+        model
+    }
+
+    fn fn_sig(&mut self, decl: &'tcx hir::FnDecl<'tcx>) -> FnSigEnumTy {
+        FnSigEnumTy {
+            params: decl.inputs.iter().map(|ty| self.model_ty(ty)).collect(),
+            ret: self.model_ret_ty(decl.output),
+        }
+    }
+}
+
+#[derive(Default)]
+struct HirData {
+    local_types: FxHashMap<HirId, HirEnumTy>,
+    static_types: FxHashMap<LocalDefId, HirEnumTy>,
+    fn_sigs: FxHashMap<DefId, FnSigEnumTy>,
+    field_types: FxHashMap<DefId, HirEnumTy>,
+    variant_consts: FxHashMap<LocalDefId, LocalDefId>,
+}
+
+struct DeclarationVisitor<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    model: TypeModelBuilder<'a, 'tcx>,
+    data: HirData,
+}
+
+impl<'a, 'tcx> DeclarationVisitor<'a, 'tcx> {
+    fn insert_pat_bindings(&mut self, pat: &'tcx hir::Pat<'tcx>, ty: &HirEnumTy) {
+        if let hir::PatKind::Binding(_, hir_id, _, subpat) = pat.kind {
+            self.data.local_types.insert(hir_id, ty.clone());
+            if let Some(subpat) = subpat {
+                self.insert_pat_bindings(subpat, ty);
+            }
+        } else {
+            intravisit::walk_pat(self, pat);
+        }
+    }
+}
+
+impl<'tcx> intravisit::Visitor<'tcx> for DeclarationVisitor<'_, 'tcx> {
+    type NestedFilter = nested_filter::OnlyBodies;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) -> Self::Result {
+        match item.kind {
+            hir::ItemKind::Const(_, _, ty, _) => {
+                if let Some(alias) = direct_candidate_alias(ty, self.model.enum_aliases) {
+                    self.data.variant_consts.insert(item.owner_id.def_id, alias);
+                }
+            }
+            hir::ItemKind::Static(_, _, ty, _) => {
+                let ty = self.model.model_ty(ty);
+                self.data.static_types.insert(item.owner_id.def_id, ty);
+            }
+            hir::ItemKind::Fn { sig, body, .. } => {
+                let fn_sig = self.model.fn_sig(sig.decl);
+                let body = self.tcx.hir_body(body);
+                for (param, ty) in body.params.iter().zip(&fn_sig.params) {
+                    self.insert_pat_bindings(param.pat, ty);
+                }
+                self.data
+                    .fn_sigs
+                    .insert(item.owner_id.def_id.to_def_id(), fn_sig);
+            }
+            hir::ItemKind::Struct(_, _, vd) | hir::ItemKind::Union(_, _, vd) => {
+                for field in vd.fields() {
+                    let ty = self.model.model_ty(field.ty);
+                    self.data.field_types.insert(field.def_id.to_def_id(), ty);
+                }
+            }
+            _ => {}
+        }
+
+        intravisit::walk_item(self, item)
+    }
+
+    fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) -> Self::Result {
+        match item.kind {
+            hir::ForeignItemKind::Fn(sig, _, _) => {
+                let fn_sig = self.model.fn_sig(sig.decl);
+                self.data
+                    .fn_sigs
+                    .insert(item.owner_id.def_id.to_def_id(), fn_sig);
+            }
+            hir::ForeignItemKind::Static(ty, _, _) => {
+                let ty = self.model.model_ty(ty);
+                self.data.static_types.insert(item.owner_id.def_id, ty);
+            }
+            _ => {}
+        }
+
+        intravisit::walk_foreign_item(self, item)
+    }
+
+    fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) -> Self::Result {
+        if let Some(ty) = local.ty {
+            let ty = self.model.model_ty(ty);
+            self.insert_pat_bindings(local.pat, &ty);
+        }
+
+        intravisit::walk_local(self, local)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ExprEnumClass {
+    Enum(LocalDefId),
+    PtrTo(LocalDefId),
+    IntLike,
+    Other,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RequiredContext {
+    Let,
+    Assignment,
+    FunctionArgument,
+    Return,
+    StructField,
+    Aggregate,
+}
+
+struct BodyVisitor<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    data: &'a HirData,
+    analysis: &'a mut EnumAnalysis,
+    current_ret_ty: Option<HirEnumTy>,
+    enum_required_exprs: FxHashSet<HirId>,
+    cast_sites: FxHashSet<(LocalDefId, HirId, CastSiteKind)>,
+}
+
+impl<'a, 'tcx> BodyVisitor<'a, 'tcx> {
+    fn new(tcx: TyCtxt<'tcx>, data: &'a HirData, analysis: &'a mut EnumAnalysis) -> Self {
+        Self {
+            tcx,
+            data,
+            analysis,
+            current_ret_ty: None,
+            enum_required_exprs: FxHashSet::default(),
+            cast_sites: FxHashSet::default(),
+        }
+    }
+
+    fn check_expr_against_type(
+        &mut self,
+        expr: &'tcx hir::Expr<'tcx>,
+        expected: &HirEnumTy,
+        context: RequiredContext,
+    ) {
+        match expected {
+            HirEnumTy::Enum(alias) => self.require_enum(expr, *alias, context),
+            HirEnumTy::IntLike => {
+                let kind = match context {
+                    RequiredContext::FunctionArgument => CastSiteKind::FunctionArgumentToInteger,
+                    RequiredContext::Return => CastSiteKind::ReturnToInteger,
+                    _ => CastSiteKind::AssignmentToInteger,
+                };
+                self.record_enum_value_cast(expr, kind);
+            }
+            HirEnumTy::Array(elem) | HirEnumTy::Slice(elem) => {
+                let expr = utils::hir::unwrap_drop_temps(expr);
+                match expr.kind {
+                    hir::ExprKind::Array(exprs) => {
+                        for expr in exprs {
+                            self.check_expr_against_type(expr, elem, RequiredContext::Aggregate);
+                        }
+                    }
+                    hir::ExprKind::Repeat(expr, _) => {
+                        self.check_expr_against_type(expr, elem, RequiredContext::Aggregate);
+                    }
+                    _ => {}
+                }
+            }
+            HirEnumTy::Tuple(tys) => {
+                let expr = utils::hir::unwrap_drop_temps(expr);
+                if let hir::ExprKind::Tup(exprs) = expr.kind {
+                    for (expr, ty) in exprs.iter().zip(tys) {
+                        self.check_expr_against_type(expr, ty, RequiredContext::Aggregate);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn require_enum(
+        &mut self,
+        expr: &'tcx hir::Expr<'tcx>,
+        expected: LocalDefId,
+        context: RequiredContext,
+    ) {
+        let expr = utils::hir::unwrap_drop_temps(expr);
+        if let hir::ExprKind::Block(block, _) = expr.kind
+            && let Some(tail) = block.expr
+        {
+            self.require_enum(tail, expected, context);
+            return;
+        }
+
+        self.enum_required_exprs.insert(expr.hir_id);
+        match self.classify_expr(expr) {
+            ExprEnumClass::Enum(alias) if alias == expected => {}
+            ExprEnumClass::Enum(_) => self.add_reject(
+                expected,
+                RejectReasonKind::WrongEnumAssignedToEnum,
+                expr.span,
+            ),
+            _ => {
+                let kind = self.reject_kind_for_expr(expr, context);
+                self.add_reject(expected, kind, expr.span);
+                match context {
+                    RequiredContext::FunctionArgument
+                        if kind != RejectReasonKind::FunctionArgumentRequiresEnum =>
+                    {
+                        self.add_reject(
+                            expected,
+                            RejectReasonKind::FunctionArgumentRequiresEnum,
+                            expr.span,
+                        );
+                    }
+                    RequiredContext::Return if kind != RejectReasonKind::ReturnRequiresEnum => {
+                        self.add_reject(expected, RejectReasonKind::ReturnRequiresEnum, expr.span);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn reject_kind_for_expr(
+        &self,
+        expr: &'tcx hir::Expr<'tcx>,
+        context: RequiredContext,
+    ) -> RejectReasonKind {
+        match utils::hir::unwrap_drop_temps(expr).kind {
+            hir::ExprKind::Lit(_) => RejectReasonKind::IntegerLiteralAssignedToEnum,
+            hir::ExprKind::Cast(_, _) => RejectReasonKind::CastAssignedToEnum,
+            hir::ExprKind::Binary(_, _, _)
+            | hir::ExprKind::Unary(_, _)
+            | hir::ExprKind::AssignOp(_, _, _) => RejectReasonKind::ArithmeticAssignedToEnum,
+            _ => match context {
+                RequiredContext::FunctionArgument => RejectReasonKind::FunctionArgumentRequiresEnum,
+                RequiredContext::Return => RejectReasonKind::ReturnRequiresEnum,
+                _ => RejectReasonKind::UnknownExpressionAssignedToEnum,
+            },
+        }
+    }
+
+    fn add_reject(&mut self, alias: LocalDefId, kind: RejectReasonKind, span: Span) {
+        let info = self.analysis.enums.get_mut(&alias).unwrap();
+        info.transformable = false;
+        info.reject_reasons.push(RejectReason { kind, span });
+    }
+
+    fn add_cast_site(
+        &mut self,
+        alias: LocalDefId,
+        expr: &'tcx hir::Expr<'tcx>,
+        kind: CastSiteKind,
+    ) {
+        if !self.cast_sites.insert((alias, expr.hir_id, kind)) {
+            return;
+        }
+        let info = self.analysis.enums.get_mut(&alias).unwrap();
+        info.enum_to_int_cast_sites.push(CastSite {
+            enum_alias: alias,
+            hir_id: expr.hir_id,
+            span: expr.span,
+            kind,
+        });
+    }
+
+    fn record_enum_value_cast(&mut self, expr: &'tcx hir::Expr<'tcx>, kind: CastSiteKind) {
+        let expr = utils::hir::unwrap_drop_temps(expr);
+        if let ExprEnumClass::Enum(alias) = self.classify_expr(expr) {
+            self.add_cast_site(alias, expr, kind);
+        }
+    }
+
+    fn record_numeric_operand_casts(
+        &mut self,
+        lhs: &'tcx hir::Expr<'tcx>,
+        rhs: Option<&'tcx hir::Expr<'tcx>>,
+        kind: CastSiteKind,
+    ) {
+        self.record_enum_value_cast(lhs, kind);
+        if let Some(rhs) = rhs {
+            self.record_enum_value_cast(rhs, kind);
+        }
+    }
+
+    fn classify_expr(&self, expr: &'tcx hir::Expr<'tcx>) -> ExprEnumClass {
+        let expr = utils::hir::unwrap_drop_temps(expr);
+        match expr.kind {
+            hir::ExprKind::Use(expr, _) => self.classify_expr(expr),
+            hir::ExprKind::Path(QPath::Resolved(_, path)) => self.classify_path(path.res),
+            hir::ExprKind::Field(base, field) => self
+                .field_type(base, field.name)
+                .map_or(ExprEnumClass::Unknown, Self::classify_decl_ty),
+            hir::ExprKind::Index(base, _, _) => self
+                .expr_decl_ty(base)
+                .and_then(|ty| ty.element())
+                .map_or(ExprEnumClass::Unknown, Self::classify_decl_ty),
+            hir::ExprKind::Unary(hir::UnOp::Deref, expr) => self
+                .expr_decl_ty(expr)
+                .and_then(|ty| ty.pointee())
+                .map_or_else(
+                    || match self.classify_expr(expr) {
+                        ExprEnumClass::PtrTo(alias) => ExprEnumClass::Enum(alias),
+                        _ => ExprEnumClass::Unknown,
+                    },
+                    Self::classify_decl_ty,
+                ),
+            hir::ExprKind::Call(callee, _) => self
+                .callee_sig(callee)
+                .map_or(ExprEnumClass::Unknown, |sig| {
+                    Self::classify_decl_ty(&sig.ret)
+                }),
+            hir::ExprKind::Block(block, _) => block
+                .expr
+                .map_or(ExprEnumClass::Other, |expr| self.classify_expr(expr)),
+            hir::ExprKind::If(_, then_expr, Some(else_expr)) => {
+                let then_class = self.classify_expr(then_expr);
+                let else_class = self.classify_expr(else_expr);
+                if then_class == else_class {
+                    then_class
+                } else {
+                    ExprEnumClass::Unknown
+                }
+            }
+            hir::ExprKind::Match(_, arms, _) => {
+                let mut class = None;
+                for arm in arms {
+                    let arm_class = self.classify_expr(arm.body);
+                    if class.is_some_and(|class| class != arm_class) {
+                        return ExprEnumClass::Unknown;
+                    }
+                    class = Some(arm_class);
+                }
+                class.unwrap_or(ExprEnumClass::Other)
+            }
+            hir::ExprKind::Lit(_) | hir::ExprKind::Cast(_, _) => ExprEnumClass::IntLike,
+            hir::ExprKind::Binary(_, _, _) | hir::ExprKind::Unary(_, _) => ExprEnumClass::IntLike,
+            _ => ExprEnumClass::Unknown,
+        }
+    }
+
+    fn classify_path(&self, res: Res) -> ExprEnumClass {
+        match res {
+            Res::Def(DefKind::Const, def_id) => def_id
+                .as_local()
+                .and_then(|def_id| self.data.variant_consts.get(&def_id).copied())
+                .map_or(ExprEnumClass::Unknown, ExprEnumClass::Enum),
+            Res::Def(DefKind::Static { .. }, def_id) => def_id
+                .as_local()
+                .and_then(|def_id| self.data.static_types.get(&def_id))
+                .map_or(ExprEnumClass::Unknown, Self::classify_decl_ty),
+            Res::Local(hir_id) => self
+                .data
+                .local_types
+                .get(&hir_id)
+                .map_or(ExprEnumClass::Unknown, Self::classify_decl_ty),
+            _ => ExprEnumClass::Unknown,
+        }
+    }
+
+    fn classify_decl_ty(ty: &HirEnumTy) -> ExprEnumClass {
+        match ty {
+            HirEnumTy::Enum(alias) => ExprEnumClass::Enum(*alias),
+            HirEnumTy::Ptr(inner) | HirEnumTy::Ref(inner) => {
+                if let HirEnumTy::Enum(alias) = **inner {
+                    ExprEnumClass::PtrTo(alias)
+                } else {
+                    ExprEnumClass::Other
+                }
+            }
+            HirEnumTy::IntLike => ExprEnumClass::IntLike,
+            _ => ExprEnumClass::Other,
+        }
+    }
+
+    fn expr_decl_ty(&self, expr: &'tcx hir::Expr<'tcx>) -> Option<&HirEnumTy> {
+        let expr = utils::hir::unwrap_drop_temps(expr);
+        match expr.kind {
+            hir::ExprKind::Use(expr, _) => self.expr_decl_ty(expr),
+            hir::ExprKind::Path(QPath::Resolved(_, path)) => match path.res {
+                Res::Local(hir_id) => self.data.local_types.get(&hir_id),
+                Res::Def(DefKind::Static { .. }, def_id) => def_id
+                    .as_local()
+                    .and_then(|def_id| self.data.static_types.get(&def_id)),
+                Res::Def(DefKind::Const, _) => None,
+                _ => None,
+            },
+            hir::ExprKind::Field(base, field) => self.field_type(base, field.name),
+            _ => None,
+        }
+    }
+
+    fn field_type(&self, base: &'tcx hir::Expr<'tcx>, field: Symbol) -> Option<&HirEnumTy> {
+        let typeck = self.tcx.typeck(base.hir_id.owner.def_id);
+        let ty = typeck.expr_ty(base);
+        let ty::TyKind::Adt(adt_def, _) = ty.kind() else { return None };
+        let field = adt_def
+            .variant(VariantIdx::from_u32(0))
+            .fields
+            .iter()
+            .find(|field_def| field_def.name == field)?;
+        self.data.field_types.get(&field.did)
+    }
+
+    fn callee_sig(&self, callee: &'tcx hir::Expr<'tcx>) -> Option<&FnSigEnumTy> {
+        let callee = utils::hir::unwrap_drop_temps(callee);
+        match callee.kind {
+            hir::ExprKind::Path(QPath::Resolved(_, path)) => {
+                let Res::Def(_, def_id) = path.res else { return None };
+                self.data.fn_sigs.get(&def_id)
+            }
+            hir::ExprKind::Use(expr, _) => self.callee_sig(expr),
+            _ => {
+                if let Some(HirEnumTy::FnPtr { params, ret }) = self.expr_decl_ty(callee) {
+                    // Function pointer calls are rare in the first enum pass. Keep enough
+                    // information to classify direct uses without manufacturing an owned sig.
+                    let _ = (params, ret);
+                }
+                None
+            }
+        }
+    }
+
+    fn check_call_args(&mut self, callee: &'tcx hir::Expr<'tcx>, args: &'tcx [hir::Expr<'tcx>]) {
+        let Some(sig) = self.callee_sig(callee).cloned() else { return };
+        for (arg, param_ty) in args.iter().zip(&sig.params) {
+            self.check_expr_against_type(arg, param_ty, RequiredContext::FunctionArgument);
+        }
+    }
+
+    fn check_struct_fields(
+        &mut self,
+        expr: &'tcx hir::Expr<'tcx>,
+        fields: &'tcx [hir::ExprField<'tcx>],
+    ) {
+        let typeck = self.tcx.typeck(expr.hir_id.owner.def_id);
+        let ty = typeck.expr_ty(expr);
+        let ty::TyKind::Adt(adt_def, _) = ty.kind() else { return };
+        let variant = adt_def.variant(VariantIdx::from_u32(0));
+        for field in fields {
+            let Some(field_def) = variant
+                .fields
+                .iter()
+                .find(|field_def| field_def.name == field.ident.name)
+            else {
+                continue;
+            };
+            if let Some(ty) = self.data.field_types.get(&field_def.did).cloned() {
+                self.check_expr_against_type(field.expr, &ty, RequiredContext::StructField);
+            }
+        }
+    }
+
+    fn handle_binary(
+        &mut self,
+        expr: &'tcx hir::Expr<'tcx>,
+        op: BinOpKind,
+        lhs: &'tcx hir::Expr<'tcx>,
+        rhs: &'tcx hir::Expr<'tcx>,
+    ) {
+        if self.enum_required_exprs.contains(&expr.hir_id) {
+            return;
+        }
+
+        let lhs_class = self.classify_expr(lhs);
+        let rhs_class = self.classify_expr(rhs);
+        if is_comparison(op) {
+            if matches!(
+                (lhs_class, rhs_class),
+                (ExprEnumClass::Enum(l), ExprEnumClass::Enum(r)) if l == r
+            ) {
+                return;
+            }
+            self.record_numeric_operand_casts(lhs, Some(rhs), CastSiteKind::ComparisonToInteger);
+        } else if is_numeric_binop(op) {
+            self.record_numeric_operand_casts(lhs, Some(rhs), CastSiteKind::NumericOperator);
+        }
+    }
+}
+
+impl<'tcx> intravisit::Visitor<'tcx> for BodyVisitor<'_, 'tcx> {
+    type NestedFilter = nested_filter::OnlyBodies;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) -> Self::Result {
+        match item.kind {
+            hir::ItemKind::Fn { body, .. } => {
+                let old_ret = self.current_ret_ty.clone();
+                self.current_ret_ty = self
+                    .data
+                    .fn_sigs
+                    .get(&item.owner_id.def_id.to_def_id())
+                    .map(|sig| sig.ret.clone());
+                self.visit_body(self.tcx.hir_body(body));
+                self.current_ret_ty = old_ret;
+            }
+            hir::ItemKind::Static(_, _, _, body_id) => {
+                if let Some(ty) = self.data.static_types.get(&item.owner_id.def_id).cloned() {
+                    let body = self.tcx.hir_body(body_id);
+                    self.check_expr_against_type(body.value, &ty, RequiredContext::Assignment);
+                    self.visit_body(body);
+                }
+            }
+            hir::ItemKind::Const(..) => {}
+            _ => intravisit::walk_item(self, item),
+        }
+    }
+
+    fn visit_body(&mut self, body: &hir::Body<'tcx>) -> Self::Result {
+        if let Some(ret) = self.current_ret_ty.clone() {
+            self.check_expr_against_type(body.value, &ret, RequiredContext::Return);
+        }
+
+        intravisit::walk_body(self, body)
+    }
+
+    fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) -> Self::Result {
+        if let Some(ty) = local
+            .ty
+            .and_then(|_| self.data.local_types.get(&local.pat.hir_id).cloned())
+            && let Some(init) = local.init
+        {
+            self.check_expr_against_type(init, &ty, RequiredContext::Let);
+        }
+
+        intravisit::walk_local(self, local)
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+        match expr.kind {
+            hir::ExprKind::Assign(lhs, rhs, _) => {
+                if let Some(ty) = self.expr_decl_ty(lhs).cloned() {
+                    self.check_expr_against_type(rhs, &ty, RequiredContext::Assignment);
+                }
+            }
+            hir::ExprKind::AssignOp(_, lhs, _) => {
+                if let Some(alias) = self.expr_decl_ty(lhs).and_then(HirEnumTy::exact_enum) {
+                    self.add_reject(alias, RejectReasonKind::CompoundAssignmentToEnum, expr.span);
+                }
+            }
+            hir::ExprKind::Ret(Some(ret)) => {
+                if let Some(ty) = self.current_ret_ty.clone() {
+                    self.check_expr_against_type(ret, &ty, RequiredContext::Return);
+                }
+            }
+            hir::ExprKind::Call(callee, args) => {
+                self.check_call_args(callee, args);
+            }
+            hir::ExprKind::MethodCall(_, _receiver, args, _) => {
+                if let Some(def_id) = self
+                    .tcx
+                    .typeck(expr.hir_id.owner.def_id)
+                    .type_dependent_def_id(expr.hir_id)
+                    && let Some(sig) = self.data.fn_sigs.get(&def_id).cloned()
+                {
+                    for (arg, param_ty) in args.iter().zip(sig.params.iter().skip(1)) {
+                        self.check_expr_against_type(
+                            arg,
+                            param_ty,
+                            RequiredContext::FunctionArgument,
+                        );
+                    }
+                }
+            }
+            hir::ExprKind::Struct(_, fields, _) => {
+                self.check_struct_fields(expr, fields);
+            }
+            hir::ExprKind::Binary(op, lhs, rhs) => {
+                self.handle_binary(expr, op.node, lhs, rhs);
+            }
+            hir::ExprKind::Unary(op, operand) => {
+                if matches!(op, hir::UnOp::Neg | hir::UnOp::Not) {
+                    self.record_numeric_operand_casts(operand, None, CastSiteKind::NumericOperator);
+                }
+            }
+            _ => {}
+        }
+
+        intravisit::walk_expr(self, expr)
+    }
+}
+
+fn analyze_enums(tcx: TyCtxt<'_>) -> EnumAnalysis {
+    let mut candidates = CandidateVisitor {
+        tcx,
+        data: CandidateData::default(),
+    };
+    tcx.hir_visit_all_item_likes_in_crate(&mut candidates);
+
+    let candidate_aliases = candidates.data.aliases.keys().copied().collect();
+    let mut variant_collector = VariantCollector {
+        tcx,
+        candidate_aliases: &candidate_aliases,
+        reprs: &candidates.data.aliases,
+        variants: FxHashMap::default(),
+        reject_reasons: FxHashMap::default(),
+    };
+    tcx.hir_visit_all_item_likes_in_crate(&mut variant_collector);
+
+    let enum_aliases: FxHashSet<_> = variant_collector.variants.keys().copied().collect();
+    let mut analysis = EnumAnalysis::default();
+    for (alias, mut variants) in variant_collector.variants {
+        variants.sort_by(|l, r| l.value.cmp(&r.value));
+
+        let mut seen = FxHashSet::default();
+        let mut reasons = variant_collector
+            .reject_reasons
+            .remove(&alias)
+            .unwrap_or_default();
+        for variant in &variants {
+            if !seen.insert(variant.value) {
+                reasons.push(RejectReason {
+                    kind: RejectReasonKind::DuplicateDiscriminant,
+                    span: tcx.def_span(variant.const_def_id),
+                });
+            }
+        }
+
+        analysis.enums.insert(
+            alias,
+            EnumInfo {
+                alias,
+                repr: candidates.data.aliases[&alias],
+                variants,
+                transformable: reasons.is_empty(),
+                reject_reasons: reasons,
+                enum_to_int_cast_sites: vec![],
+            },
+        );
+    }
+
+    if analysis.enums.is_empty() {
+        return analysis;
+    }
+
+    let mut declarations = DeclarationVisitor {
+        tcx,
+        model: TypeModelBuilder::new(tcx, &enum_aliases, &candidates.data.alias_rhs),
+        data: HirData::default(),
+    };
+    tcx.hir_visit_all_item_likes_in_crate(&mut declarations);
+
+    let mut bodies = BodyVisitor::new(tcx, &declarations.data, &mut analysis);
+    tcx.hir_visit_all_item_likes_in_crate(&mut bodies);
+
+    analysis
+}
+
+fn direct_candidate_alias(
+    ty: &hir::Ty<'_>,
+    candidate_aliases: &FxHashSet<LocalDefId>,
+) -> Option<LocalDefId> {
+    let hir::TyKind::Path(QPath::Resolved(_, path)) = ty.kind else {
+        return None;
+    };
+    let Res::Def(DefKind::TyAlias, def_id) = path.res else {
+        return None;
+    };
+    let def_id = def_id.as_local()?;
+    candidate_aliases.contains(&def_id).then_some(def_id)
+}
+
+fn integer_repr(ty: Ty<'_>) -> Option<IntegerRepr> {
+    match ty.kind() {
+        ty::TyKind::Int(int_ty) => Some(IntegerRepr::Signed(*int_ty)),
+        ty::TyKind::Uint(uint_ty) => Some(IntegerRepr::Unsigned(*uint_ty)),
+        _ => None,
+    }
+}
+
+fn eval_discriminant(
+    tcx: TyCtxt<'_>,
+    const_def_id: LocalDefId,
+    repr: IntegerRepr,
+) -> Option<DiscriminantValue> {
+    let value = tcx.const_eval_poly(const_def_id.to_def_id()).ok()?;
+    let ConstValue::Scalar(Scalar::Int(int)) = value else {
+        return None;
+    };
+    Some(match repr {
+        IntegerRepr::Signed(int_ty) => {
+            let value = match int_ty {
+                ty::IntTy::Isize => int.to_i64() as i128,
+                ty::IntTy::I8 => int.to_i8() as i128,
+                ty::IntTy::I16 => int.to_i16() as i128,
+                ty::IntTy::I32 => int.to_i32() as i128,
+                ty::IntTy::I64 => int.to_i64() as i128,
+                ty::IntTy::I128 => int.to_i128(),
+            };
+            DiscriminantValue::Signed(value)
+        }
+        IntegerRepr::Unsigned(uint_ty) => {
+            let value = match uint_ty {
+                ty::UintTy::Usize => int.to_u64() as u128,
+                ty::UintTy::U8 => int.to_u8() as u128,
+                ty::UintTy::U16 => int.to_u16() as u128,
+                ty::UintTy::U32 => int.to_u32() as u128,
+                ty::UintTy::U64 => int.to_u64() as u128,
+                ty::UintTy::U128 => int.to_u128(),
+            };
+            DiscriminantValue::Unsigned(value)
+        }
+    })
+}
+
+fn is_numeric_binop(op: BinOpKind) -> bool {
+    matches!(
+        op,
+        BinOpKind::Add
+            | BinOpKind::Sub
+            | BinOpKind::Mul
+            | BinOpKind::Div
+            | BinOpKind::Rem
+            | BinOpKind::BitAnd
+            | BinOpKind::BitOr
+            | BinOpKind::BitXor
+            | BinOpKind::Shl
+            | BinOpKind::Shr
+    )
+}
+
+fn is_comparison(op: BinOpKind) -> bool {
+    matches!(
+        op,
+        BinOpKind::Eq
+            | BinOpKind::Ne
+            | BinOpKind::Lt
+            | BinOpKind::Le
+            | BinOpKind::Gt
+            | BinOpKind::Ge
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/passes/src/enum_replacer/mod.rs
+++ b/crates/passes/src/enum_replacer/mod.rs
@@ -1,4 +1,10 @@
 use rustc_abi::VariantIdx;
+use rustc_ast::{
+    self as ast,
+    mut_visit::{self, MutVisitor as _},
+    ptr::P,
+};
+use rustc_ast_pretty::pprust;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::{
     self as hir, BinOpKind, FnRetTy, HirId, PrimTy, QPath,
@@ -13,18 +19,32 @@ use rustc_middle::{
 use rustc_span::{
     Span, Symbol,
     def_id::{DefId, LocalDefId},
+    sym,
 };
+use smallvec::{SmallVec, smallvec};
+use utils::ir::AstToHir;
 
-pub fn replace_enums(tcx: TyCtxt<'_>) {
+pub fn replace_enums(tcx: TyCtxt<'_>) -> String {
+    let mut krate = utils::ast::expanded_ast(tcx);
+    let ast_to_hir = utils::ast::make_ast_to_hir(&mut krate, tcx);
     let analysis = analyze_enums(tcx);
-    let total = analysis.enums.len();
-    let transformable = analysis
-        .enums
-        .values()
-        .filter(|info| info.transformable)
-        .count();
-    println!("enum candidates: {total}");
-    println!("transformable enums: {transformable}");
+    utils::ast::remove_unnecessary_items_from_ast(&mut krate);
+
+    let plan = EnumTransformPlan::new(&analysis);
+    if !plan.replacements.is_empty() {
+        add_coverage_feature(&mut krate, tcx);
+    }
+    let mut visitor = AstVisitor {
+        tcx,
+        ast_to_hir,
+        replacements: plan.replacements,
+        variant_consts: plan.variant_consts,
+        cast_sites: plan.cast_sites,
+        inserted_casts: FxHashSet::default(),
+    };
+    visitor.visit_crate(&mut krate);
+
+    pprust::crate_to_string_for_macros(&krate)
 }
 
 #[derive(Debug, Default)]
@@ -97,6 +117,167 @@ pub enum CastSiteKind {
     ReturnToInteger,
     NumericOperator,
     ComparisonToInteger,
+}
+
+#[derive(Clone, Debug)]
+struct EnumReplacement {
+    repr: String,
+    variants: Vec<VariantReplacement>,
+}
+
+#[derive(Clone, Debug)]
+struct VariantReplacement {
+    name: String,
+    value: String,
+}
+
+#[derive(Default)]
+struct EnumTransformPlan {
+    replacements: FxHashMap<LocalDefId, EnumReplacement>,
+    variant_consts: FxHashMap<LocalDefId, LocalDefId>,
+    cast_sites: FxHashMap<HirId, String>,
+}
+
+impl EnumTransformPlan {
+    fn new(analysis: &EnumAnalysis) -> Self {
+        let mut plan = Self::default();
+
+        for (alias, info) in &analysis.enums {
+            if !info.transformable {
+                continue;
+            }
+
+            let repr = repr_name(info.repr).to_string();
+            let variants = info
+                .variants
+                .iter()
+                .map(|variant| VariantReplacement {
+                    name: variant.name.as_str().to_string(),
+                    value: discriminant_literal(variant.value, &repr),
+                })
+                .collect();
+            plan.replacements.insert(
+                *alias,
+                EnumReplacement {
+                    repr: repr.clone(),
+                    variants,
+                },
+            );
+
+            for variant in &info.variants {
+                plan.variant_consts.insert(variant.const_def_id, *alias);
+            }
+
+            for site in &info.enum_to_int_cast_sites {
+                let entry = plan.cast_sites.entry(site.hir_id).or_insert(repr.clone());
+                debug_assert_eq!(entry, &repr);
+            }
+        }
+
+        plan
+    }
+}
+
+struct AstVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    ast_to_hir: AstToHir,
+    replacements: FxHashMap<LocalDefId, EnumReplacement>,
+    variant_consts: FxHashMap<LocalDefId, LocalDefId>,
+    cast_sites: FxHashMap<HirId, String>,
+    inserted_casts: FxHashSet<HirId>,
+}
+
+impl AstVisitor<'_> {
+    fn replacement_for_ty(&self, ty: &ast::Ty) -> Option<&EnumReplacement> {
+        let hir_ty = self.ast_to_hir.get_ty(ty.id, self.tcx)?;
+        let hir::TyKind::Path(QPath::Resolved(_, path)) = hir_ty.kind else {
+            return None;
+        };
+        let Res::Def(DefKind::TyAlias, def_id) = path.res else {
+            return None;
+        };
+        self.replacements.get(&def_id.as_local()?)
+    }
+
+    fn replacement_items(
+        &self,
+        item: &ast::Item,
+        replacement: &EnumReplacement,
+    ) -> SmallVec<[P<ast::Item>; 1]> {
+        let ast::ItemKind::TyAlias(box ast::TyAlias { ident, .. }) = &item.kind else { panic!() };
+        let enum_name = ident.name.as_str();
+        let variants = replacement
+            .variants
+            .iter()
+            .map(|variant| format!("{} = {}", variant.name, variant.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let mut enum_item = P(utils::item!(
+            "#[repr({})] #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)] enum {} {{ {} }}",
+            replacement.repr,
+            enum_name,
+            variants
+        ));
+        enum_item.vis = item.vis.clone();
+
+        let mut attrs = item.attrs.clone();
+        attrs.extend(enum_item.attrs.drain(..));
+        enum_item.attrs = attrs;
+
+        let mut items = SmallVec::new();
+        items.push(enum_item);
+
+        for variant in &replacement.variants {
+            let mut use_item = P(utils::item!("use {}::{};", enum_name, variant.name));
+            use_item.vis = item.vis.clone();
+            items.push(use_item);
+        }
+
+        items
+    }
+}
+
+impl mut_visit::MutVisitor for AstVisitor<'_> {
+    fn flat_map_item(&mut self, item: P<ast::Item>) -> SmallVec<[P<ast::Item>; 1]> {
+        let def_id = self.ast_to_hir.global_map.get(&item.id).copied();
+
+        if let Some(def_id) = def_id
+            && let Some(replacement) = self.replacements.get(&def_id)
+        {
+            return self.replacement_items(&item, replacement);
+        }
+
+        if def_id.is_some_and(|def_id| self.variant_consts.contains_key(&def_id)) {
+            return smallvec![];
+        }
+
+        mut_visit::walk_flat_map_item(self, item)
+    }
+
+    fn visit_expr(&mut self, expr: &mut ast::Expr) {
+        mut_visit::walk_expr(self, expr);
+
+        if let ast::ExprKind::Cast(_, ty) = &mut expr.kind
+            && let Some(repr) = self.replacement_for_ty(ty)
+        {
+            **ty = utils::ty!("{}", repr.repr);
+        }
+
+        let Some(hir_expr) = self.ast_to_hir.get_expr(expr.id, self.tcx) else {
+            return;
+        };
+        let hir_id = hir_expr.hir_id;
+        let Some(repr) = self.cast_sites.get(&hir_id) else {
+            return;
+        };
+        if !self.inserted_casts.insert(hir_id) {
+            return;
+        }
+
+        let expr_str = pprust::expr_to_string(expr);
+        *expr = utils::expr!("({expr_str}) as {repr}");
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -990,6 +1171,53 @@ fn integer_repr(ty: Ty<'_>) -> Option<IntegerRepr> {
         ty::TyKind::Uint(uint_ty) => Some(IntegerRepr::Unsigned(*uint_ty)),
         _ => None,
     }
+}
+
+fn repr_name(repr: IntegerRepr) -> &'static str {
+    match repr {
+        IntegerRepr::Signed(int_ty) => match int_ty {
+            ty::IntTy::Isize => "isize",
+            ty::IntTy::I8 => "i8",
+            ty::IntTy::I16 => "i16",
+            ty::IntTy::I32 => "i32",
+            ty::IntTy::I64 => "i64",
+            ty::IntTy::I128 => "i128",
+        },
+        IntegerRepr::Unsigned(uint_ty) => match uint_ty {
+            ty::UintTy::Usize => "usize",
+            ty::UintTy::U8 => "u8",
+            ty::UintTy::U16 => "u16",
+            ty::UintTy::U32 => "u32",
+            ty::UintTy::U64 => "u64",
+            ty::UintTy::U128 => "u128",
+        },
+    }
+}
+
+fn discriminant_literal(value: DiscriminantValue, repr: &str) -> String {
+    match value {
+        DiscriminantValue::Signed(value) => format!("{value}{repr}"),
+        DiscriminantValue::Unsigned(value) => format!("{value}{repr}"),
+    }
+}
+
+fn add_coverage_feature(krate: &mut ast::Crate, tcx: TyCtxt<'_>) {
+    if krate.attrs.iter().any(|attr| {
+        let ast::AttrKind::Normal(normal) = &attr.kind else {
+            return false;
+        };
+        attr.has_name(sym::feature)
+            && utils::ast::get_attr_arg(&normal.item.args)
+                .is_some_and(|arg| arg.as_str() == "coverage_attribute")
+    }) {
+        return;
+    }
+
+    krate.attrs.push(utils::ast::make_inner_attribute(
+        sym::feature,
+        Symbol::intern("coverage_attribute"),
+        tcx,
+    ));
 }
 
 fn eval_discriminant(

--- a/crates/passes/src/enum_replacer/mod.rs
+++ b/crates/passes/src/enum_replacer/mod.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use rustc_abi::VariantIdx;
 use rustc_ast::{
     self as ast,
@@ -41,6 +43,7 @@ pub fn replace_enums(tcx: TyCtxt<'_>) -> String {
         variant_consts: plan.variant_consts,
         cast_sites: plan.cast_sites,
         match_rewrites: plan.match_rewrites,
+        comparison_rewrites: plan.comparison_rewrites,
         inserted_casts: FxHashSet::default(),
     };
     visitor.visit_crate(&mut krate);
@@ -52,6 +55,7 @@ pub fn replace_enums(tcx: TyCtxt<'_>) -> String {
 pub struct EnumAnalysis {
     pub enums: FxHashMap<LocalDefId, EnumInfo>,
     match_rewrites: Vec<MatchRewriteSite>,
+    comparison_rewrites: Vec<ComparisonRewriteSite>,
 }
 
 #[derive(Debug)]
@@ -134,6 +138,26 @@ struct MatchRewrite {
 }
 
 #[derive(Clone, Debug)]
+struct ComparisonRewriteSite {
+    enum_alias: LocalDefId,
+    expr_hir_id: HirId,
+    lhs: ComparisonOperandRewrite,
+    rhs: ComparisonOperandRewrite,
+}
+
+#[derive(Clone, Debug)]
+struct ComparisonRewrite {
+    lhs: ComparisonOperandRewrite,
+    rhs: ComparisonOperandRewrite,
+}
+
+#[derive(Clone, Debug)]
+enum ComparisonOperandRewrite {
+    StripCasts,
+    ReplaceWithVariantPath(String),
+}
+
+#[derive(Clone, Debug)]
 struct ArmRewrite {
     arm_hir_id: HirId,
     action: ArmRewriteAction,
@@ -164,6 +188,7 @@ struct EnumTransformPlan {
     variant_consts: FxHashMap<LocalDefId, LocalDefId>,
     cast_sites: FxHashMap<HirId, String>,
     match_rewrites: FxHashMap<HirId, MatchRewrite>,
+    comparison_rewrites: FxHashMap<HirId, ComparisonRewrite>,
 }
 
 impl EnumTransformPlan {
@@ -223,6 +248,24 @@ impl EnumTransformPlan {
             );
         }
 
+        for site in &analysis.comparison_rewrites {
+            if !analysis
+                .enums
+                .get(&site.enum_alias)
+                .is_some_and(|info| info.transformable)
+            {
+                continue;
+            }
+
+            plan.comparison_rewrites.insert(
+                site.expr_hir_id,
+                ComparisonRewrite {
+                    lhs: site.lhs.clone(),
+                    rhs: site.rhs.clone(),
+                },
+            );
+        }
+
         plan
     }
 }
@@ -234,6 +277,7 @@ struct AstVisitor<'tcx> {
     variant_consts: FxHashMap<LocalDefId, LocalDefId>,
     cast_sites: FxHashMap<HirId, String>,
     match_rewrites: FxHashMap<HirId, MatchRewrite>,
+    comparison_rewrites: FxHashMap<HirId, ComparisonRewrite>,
     inserted_casts: FxHashSet<HirId>,
 }
 
@@ -328,6 +372,34 @@ impl AstVisitor<'_> {
 
         true
     }
+
+    fn rewrite_comparison_expr(&mut self, expr: &mut ast::Expr) -> bool {
+        let Some(hir_expr) = self.ast_to_hir.get_expr(expr.id, self.tcx) else {
+            return false;
+        };
+        let Some(rewrite) = self.comparison_rewrites.get(&hir_expr.hir_id) else {
+            return false;
+        };
+        let ast::ExprKind::Binary(_, lhs, rhs) = &mut expr.kind else {
+            return false;
+        };
+
+        Self::rewrite_comparison_operand(lhs, &rewrite.lhs);
+        Self::rewrite_comparison_operand(rhs, &rewrite.rhs);
+        true
+    }
+
+    fn rewrite_comparison_operand(operand: &mut P<ast::Expr>, rewrite: &ComparisonOperandRewrite) {
+        match rewrite {
+            ComparisonOperandRewrite::StripCasts => {
+                let base = pprust::expr_to_string(utils::ast::unwrap_cast_and_paren(operand));
+                **operand = utils::expr!("{base}");
+            }
+            ComparisonOperandRewrite::ReplaceWithVariantPath(path) => {
+                **operand = utils::expr!("{path}");
+            }
+        }
+    }
 }
 
 impl mut_visit::MutVisitor for AstVisitor<'_> {
@@ -351,6 +423,10 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
         mut_visit::walk_expr(self, expr);
 
         if self.rewrite_match_expr(expr) {
+            return;
+        }
+
+        if self.rewrite_comparison_expr(expr) {
             return;
         }
 
@@ -724,6 +800,17 @@ struct EnumCastScrutinee {
     target_repr: IntegerRepr,
 }
 
+#[derive(Clone, Debug)]
+struct EnumComparisonOperand {
+    enum_alias: LocalDefId,
+    cast_chain: Vec<IntegerRepr>,
+}
+
+#[derive(Clone, Debug)]
+struct QualifiedVariant {
+    path: String,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RequiredContext {
     Let,
@@ -956,6 +1043,222 @@ impl<'a, 'tcx> BodyVisitor<'a, 'tcx> {
             }
         }
         Some(paths)
+    }
+
+    fn enum_comparison_operand(
+        &self,
+        expr: &'tcx hir::Expr<'tcx>,
+    ) -> Option<EnumComparisonOperand> {
+        let typeck = self.tcx.typeck(expr.hir_id.owner.def_id);
+        let mut base = utils::hir::unwrap_drop_temps(expr);
+        let mut cast_chain = Vec::new();
+
+        loop {
+            match base.kind {
+                hir::ExprKind::Use(expr, _) => {
+                    base = utils::hir::unwrap_drop_temps(expr);
+                }
+                hir::ExprKind::Cast(expr, _) => {
+                    cast_chain.push(integer_repr(typeck.expr_ty(base))?);
+                    base = utils::hir::unwrap_drop_temps(expr);
+                }
+                _ => break,
+            }
+        }
+        cast_chain.reverse();
+
+        let ExprEnumClass::Enum(enum_alias) = self.classify_expr(base) else {
+            return None;
+        };
+        self.analysis
+            .enums
+            .get(&enum_alias)
+            .is_some_and(|info| info.transformable)
+            .then_some(EnumComparisonOperand {
+                enum_alias,
+                cast_chain,
+            })
+    }
+
+    fn casted_variants_for_operand(
+        &self,
+        info: &EnumInfo,
+        cast_chain: &[IntegerRepr],
+    ) -> Option<FxHashMap<CastedIntegerValue, QualifiedVariant>> {
+        let mut variants = FxHashMap::default();
+        for variant in &info.variants {
+            let value =
+                cast_discriminant_through_chain(variant.value, info.repr, cast_chain, self.tcx)?;
+            let path = format!(
+                "crate::{}::{}",
+                self.tcx.def_path_str(info.alias.to_def_id()),
+                variant.name
+            );
+            if variants.insert(value, QualifiedVariant { path }).is_some() {
+                return None;
+            }
+        }
+        Some(variants)
+    }
+
+    fn casted_variant_values_for_operand(
+        &self,
+        info: &EnumInfo,
+        cast_chain: &[IntegerRepr],
+    ) -> Option<Vec<CastedIntegerValue>> {
+        info.variants
+            .iter()
+            .map(|variant| {
+                cast_discriminant_through_chain(variant.value, info.repr, cast_chain, self.tcx)
+            })
+            .collect()
+    }
+
+    fn comparison_casts_compatible(
+        &self,
+        info: &EnumInfo,
+        lhs_cast_chain: &[IntegerRepr],
+        rhs_cast_chain: &[IntegerRepr],
+    ) -> Option<bool> {
+        self.casted_variants_for_operand(info, lhs_cast_chain)?;
+        self.casted_variants_for_operand(info, rhs_cast_chain)?;
+        let lhs_values = self.casted_variant_values_for_operand(info, lhs_cast_chain)?;
+        let rhs_values = self.casted_variant_values_for_operand(info, rhs_cast_chain)?;
+        Some(lhs_values == rhs_values)
+    }
+
+    fn comparison_order_preserved(
+        &self,
+        info: &EnumInfo,
+        cast_chain: &[IntegerRepr],
+    ) -> Option<bool> {
+        let values = self.casted_variant_values_for_operand(info, cast_chain)?;
+        Some(
+            values
+                .windows(2)
+                .all(|values| compare_casted_values(values[0], values[1]) == Some(Ordering::Less)),
+        )
+    }
+
+    fn literal_comparison_target_repr(
+        &self,
+        info: &EnumInfo,
+        enum_operand: &EnumComparisonOperand,
+        literal_expr: &'tcx hir::Expr<'tcx>,
+    ) -> IntegerRepr {
+        enum_operand
+            .cast_chain
+            .last()
+            .copied()
+            .or_else(|| {
+                let typeck = self.tcx.typeck(literal_expr.hir_id.owner.def_id);
+                integer_repr(typeck.expr_ty(literal_expr))
+            })
+            .unwrap_or(info.repr)
+    }
+
+    fn try_record_casted_enum_comparison(
+        &mut self,
+        expr: &'tcx hir::Expr<'tcx>,
+        op: BinOpKind,
+        lhs: &'tcx hir::Expr<'tcx>,
+        rhs: &'tcx hir::Expr<'tcx>,
+    ) -> bool {
+        let Some(lhs_operand) = self.enum_comparison_operand(lhs) else {
+            return false;
+        };
+        let Some(rhs_operand) = self.enum_comparison_operand(rhs) else {
+            return false;
+        };
+        if lhs_operand.enum_alias != rhs_operand.enum_alias {
+            return false;
+        }
+
+        let enum_alias = lhs_operand.enum_alias;
+        let can_rewrite = {
+            let Some(info) = self.analysis.enums.get(&enum_alias) else {
+                return false;
+            };
+            self.comparison_casts_compatible(info, &lhs_operand.cast_chain, &rhs_operand.cast_chain)
+                == Some(true)
+                && (!is_relational_comparison(op)
+                    || self.comparison_order_preserved(info, &lhs_operand.cast_chain) == Some(true))
+        };
+        if !can_rewrite {
+            return false;
+        }
+
+        self.analysis
+            .comparison_rewrites
+            .push(ComparisonRewriteSite {
+                enum_alias,
+                expr_hir_id: expr.hir_id,
+                lhs: ComparisonOperandRewrite::StripCasts,
+                rhs: ComparisonOperandRewrite::StripCasts,
+            });
+        true
+    }
+
+    fn try_record_enum_literal_comparison(
+        &mut self,
+        expr: &'tcx hir::Expr<'tcx>,
+        op: BinOpKind,
+        enum_expr: &'tcx hir::Expr<'tcx>,
+        literal_expr: &'tcx hir::Expr<'tcx>,
+        enum_on_lhs: bool,
+    ) -> bool {
+        let Some(enum_operand) = self.enum_comparison_operand(enum_expr) else {
+            return false;
+        };
+
+        let enum_alias = enum_operand.enum_alias;
+        let variant_path = {
+            let Some(info) = self.analysis.enums.get(&enum_alias) else {
+                return false;
+            };
+            if is_relational_comparison(op)
+                && self.comparison_order_preserved(info, &enum_operand.cast_chain) != Some(true)
+            {
+                return false;
+            }
+
+            let target_repr =
+                self.literal_comparison_target_repr(info, &enum_operand, literal_expr);
+            let variants = match self.casted_variants_for_operand(info, &enum_operand.cast_chain) {
+                Some(variants) => variants,
+                None => return false,
+            };
+            let Some(literal_value) = numeric_expr_value(literal_expr, target_repr, self.tcx)
+            else {
+                return false;
+            };
+            let Some(variant) = variants.get(&literal_value) else {
+                return false;
+            };
+            variant.path.clone()
+        };
+
+        let (lhs, rhs) = if enum_on_lhs {
+            (
+                ComparisonOperandRewrite::StripCasts,
+                ComparisonOperandRewrite::ReplaceWithVariantPath(variant_path),
+            )
+        } else {
+            (
+                ComparisonOperandRewrite::ReplaceWithVariantPath(variant_path),
+                ComparisonOperandRewrite::StripCasts,
+            )
+        };
+
+        self.analysis
+            .comparison_rewrites
+            .push(ComparisonRewriteSite {
+                enum_alias,
+                expr_hir_id: expr.hir_id,
+                lhs,
+                rhs,
+            });
+        true
     }
 
     fn try_record_match_rewrite(
@@ -1211,6 +1514,12 @@ impl<'a, 'tcx> BodyVisitor<'a, 'tcx> {
             ) {
                 return;
             }
+            if self.try_record_casted_enum_comparison(expr, op, lhs, rhs)
+                || self.try_record_enum_literal_comparison(expr, op, lhs, rhs, true)
+                || self.try_record_enum_literal_comparison(expr, op, rhs, lhs, false)
+            {
+                return;
+            }
             self.record_numeric_operand_casts(lhs, Some(rhs), CastSiteKind::ComparisonToInteger);
         } else if is_numeric_binop(op) {
             self.record_numeric_operand_casts(lhs, Some(rhs), CastSiteKind::NumericOperator);
@@ -1450,6 +1759,70 @@ fn numeric_pat_expr_value(
     cast_literal_value(value.get(), negated, target_repr, tcx)
 }
 
+fn numeric_expr_value(
+    expr: &hir::Expr<'_>,
+    target_repr: IntegerRepr,
+    tcx: TyCtxt<'_>,
+) -> Option<CastedIntegerValue> {
+    let value = numeric_expr_value_in_expr_type(expr, tcx)?;
+    let expr_repr = expr_integer_repr(expr, tcx).unwrap_or(target_repr);
+    if expr_repr == target_repr {
+        Some(value)
+    } else {
+        cast_integer_value(value, target_repr, tcx)
+    }
+}
+
+fn numeric_expr_value_in_expr_type(
+    expr: &hir::Expr<'_>,
+    tcx: TyCtxt<'_>,
+) -> Option<CastedIntegerValue> {
+    let expr = utils::hir::unwrap_drop_temps(expr);
+    match expr.kind {
+        hir::ExprKind::Use(expr, _) => numeric_expr_value_in_expr_type(expr, tcx),
+        hir::ExprKind::Cast(inner, _) => {
+            let target_repr = expr_integer_repr(expr, tcx)?;
+            let value = numeric_expr_value_in_expr_type(inner, tcx)?;
+            cast_integer_value(value, target_repr, tcx)
+        }
+        hir::ExprKind::Unary(hir::UnOp::Neg, inner) => numeric_negated_expr_value(expr, inner, tcx),
+        hir::ExprKind::Lit(lit) => {
+            let ast::LitKind::Int(value, _) = lit.node else {
+                return None;
+            };
+            cast_literal_value(value.get(), false, expr_integer_repr(expr, tcx)?, tcx)
+        }
+        _ => None,
+    }
+}
+
+fn numeric_negated_expr_value(
+    neg_expr: &hir::Expr<'_>,
+    expr: &hir::Expr<'_>,
+    tcx: TyCtxt<'_>,
+) -> Option<CastedIntegerValue> {
+    let target_repr = expr_integer_repr(neg_expr, tcx)?;
+    let expr = utils::hir::unwrap_drop_temps(expr);
+    if let hir::ExprKind::Lit(lit) = expr.kind {
+        let ast::LitKind::Int(value, _) = lit.node else {
+            return None;
+        };
+        return cast_literal_value(value.get(), true, target_repr, tcx);
+    }
+
+    let value = numeric_expr_value(expr, target_repr, tcx)?;
+    match value {
+        CastedIntegerValue::Signed(value) => Some(CastedIntegerValue::Signed(value.checked_neg()?)),
+        CastedIntegerValue::Unsigned(_) => None,
+    }
+}
+
+fn expr_integer_repr(expr: &hir::Expr<'_>, tcx: TyCtxt<'_>) -> Option<IntegerRepr> {
+    let expr = utils::hir::unwrap_drop_temps(expr);
+    let typeck = tcx.typeck(expr.hir_id.owner.def_id);
+    integer_repr(typeck.expr_ty(expr))
+}
+
 fn cast_literal_value(
     value: u128,
     negated: bool,
@@ -1489,19 +1862,66 @@ fn cast_literal_value(
 
 fn cast_discriminant_value(
     value: DiscriminantValue,
-    _source_repr: IntegerRepr,
+    source_repr: IntegerRepr,
+    target_repr: IntegerRepr,
+    tcx: TyCtxt<'_>,
+) -> Option<CastedIntegerValue> {
+    cast_discriminant_through_chain(value, source_repr, &[target_repr], tcx)
+}
+
+fn cast_discriminant_through_chain(
+    value: DiscriminantValue,
+    source_repr: IntegerRepr,
+    cast_chain: &[IntegerRepr],
+    tcx: TyCtxt<'_>,
+) -> Option<CastedIntegerValue> {
+    let mut value = discriminant_as_casted_integer(value, source_repr, tcx);
+    for target_repr in cast_chain {
+        value = cast_integer_value(value, *target_repr, tcx)?;
+    }
+    Some(value)
+}
+
+fn discriminant_as_casted_integer(
+    value: DiscriminantValue,
+    source_repr: IntegerRepr,
+    tcx: TyCtxt<'_>,
+) -> CastedIntegerValue {
+    let width = integer_width(source_repr, tcx);
+    let bits = match value {
+        DiscriminantValue::Signed(value) => value as u128,
+        DiscriminantValue::Unsigned(value) => value,
+    } & low_bits_mask(width);
+    match source_repr {
+        IntegerRepr::Signed(_) => CastedIntegerValue::Signed(signed_value_from_bits(bits, width)),
+        IntegerRepr::Unsigned(_) => CastedIntegerValue::Unsigned(bits),
+    }
+}
+
+fn cast_integer_value(
+    value: CastedIntegerValue,
     target_repr: IntegerRepr,
     tcx: TyCtxt<'_>,
 ) -> Option<CastedIntegerValue> {
     let width = integer_width(target_repr, tcx);
     let bits = match value {
-        DiscriminantValue::Signed(value) => value as u128,
-        DiscriminantValue::Unsigned(value) => value,
+        CastedIntegerValue::Signed(value) => value as u128,
+        CastedIntegerValue::Unsigned(value) => value,
     } & low_bits_mask(width);
     Some(match target_repr {
         IntegerRepr::Signed(_) => CastedIntegerValue::Signed(signed_value_from_bits(bits, width)),
         IntegerRepr::Unsigned(_) => CastedIntegerValue::Unsigned(bits),
     })
+}
+
+fn compare_casted_values(lhs: CastedIntegerValue, rhs: CastedIntegerValue) -> Option<Ordering> {
+    match (lhs, rhs) {
+        (CastedIntegerValue::Signed(lhs), CastedIntegerValue::Signed(rhs)) => Some(lhs.cmp(&rhs)),
+        (CastedIntegerValue::Unsigned(lhs), CastedIntegerValue::Unsigned(rhs)) => {
+            Some(lhs.cmp(&rhs))
+        }
+        _ => None,
+    }
 }
 
 fn integer_width(repr: IntegerRepr, tcx: TyCtxt<'_>) -> u32 {
@@ -1653,6 +2073,13 @@ fn is_comparison(op: BinOpKind) -> bool {
             | BinOpKind::Le
             | BinOpKind::Gt
             | BinOpKind::Ge
+    )
+}
+
+fn is_relational_comparison(op: BinOpKind) -> bool {
+    matches!(
+        op,
+        BinOpKind::Lt | BinOpKind::Le | BinOpKind::Gt | BinOpKind::Ge
     )
 }
 

--- a/crates/passes/src/enum_replacer/mod.rs
+++ b/crates/passes/src/enum_replacer/mod.rs
@@ -40,6 +40,7 @@ pub fn replace_enums(tcx: TyCtxt<'_>) -> String {
         replacements: plan.replacements,
         variant_consts: plan.variant_consts,
         cast_sites: plan.cast_sites,
+        match_rewrites: plan.match_rewrites,
         inserted_casts: FxHashSet::default(),
     };
     visitor.visit_crate(&mut krate);
@@ -50,6 +51,7 @@ pub fn replace_enums(tcx: TyCtxt<'_>) -> String {
 #[derive(Debug, Default)]
 pub struct EnumAnalysis {
     pub enums: FxHashMap<LocalDefId, EnumInfo>,
+    match_rewrites: Vec<MatchRewriteSite>,
 }
 
 #[derive(Debug)]
@@ -120,6 +122,31 @@ pub enum CastSiteKind {
 }
 
 #[derive(Clone, Debug)]
+struct MatchRewriteSite {
+    enum_alias: LocalDefId,
+    match_hir_id: HirId,
+    arms: Vec<ArmRewrite>,
+}
+
+#[derive(Clone, Debug)]
+struct MatchRewrite {
+    arms: FxHashMap<HirId, ArmRewriteAction>,
+}
+
+#[derive(Clone, Debug)]
+struct ArmRewrite {
+    arm_hir_id: HirId,
+    action: ArmRewriteAction,
+}
+
+#[derive(Clone, Debug)]
+enum ArmRewriteAction {
+    RewritePattern(Vec<String>),
+    KeepWildcard,
+    RemoveWildcard,
+}
+
+#[derive(Clone, Debug)]
 struct EnumReplacement {
     repr: String,
     variants: Vec<VariantReplacement>,
@@ -136,6 +163,7 @@ struct EnumTransformPlan {
     replacements: FxHashMap<LocalDefId, EnumReplacement>,
     variant_consts: FxHashMap<LocalDefId, LocalDefId>,
     cast_sites: FxHashMap<HirId, String>,
+    match_rewrites: FxHashMap<HirId, MatchRewrite>,
 }
 
 impl EnumTransformPlan {
@@ -174,6 +202,27 @@ impl EnumTransformPlan {
             }
         }
 
+        for site in &analysis.match_rewrites {
+            if !analysis
+                .enums
+                .get(&site.enum_alias)
+                .is_some_and(|info| info.transformable)
+            {
+                continue;
+            }
+
+            plan.match_rewrites.insert(
+                site.match_hir_id,
+                MatchRewrite {
+                    arms: site
+                        .arms
+                        .iter()
+                        .map(|arm| (arm.arm_hir_id, arm.action.clone()))
+                        .collect(),
+                },
+            );
+        }
+
         plan
     }
 }
@@ -184,6 +233,7 @@ struct AstVisitor<'tcx> {
     replacements: FxHashMap<LocalDefId, EnumReplacement>,
     variant_consts: FxHashMap<LocalDefId, LocalDefId>,
     cast_sites: FxHashMap<HirId, String>,
+    match_rewrites: FxHashMap<HirId, MatchRewrite>,
     inserted_casts: FxHashSet<HirId>,
 }
 
@@ -236,6 +286,48 @@ impl AstVisitor<'_> {
 
         items
     }
+
+    fn rewrite_match_expr(&mut self, expr: &mut ast::Expr) -> bool {
+        let Some(hir_expr) = self.ast_to_hir.get_expr(expr.id, self.tcx) else {
+            return false;
+        };
+        let Some(rewrite) = self.match_rewrites.get(&hir_expr.hir_id) else {
+            return false;
+        };
+        let ast::ExprKind::Match(scrutinee, arms, _) = &mut expr.kind else {
+            return false;
+        };
+
+        let base = pprust::expr_to_string(utils::ast::unwrap_cast_and_paren(scrutinee));
+        **scrutinee = utils::expr!("{base}");
+
+        let len = arms.len();
+        let mut remove_last = false;
+        for (index, arm) in arms.iter_mut().enumerate() {
+            let Some(hir_arm) = self.ast_to_hir.get_arm(arm.id, self.tcx) else {
+                continue;
+            };
+            let Some(action) = rewrite.arms.get(&hir_arm.hir_id) else {
+                continue;
+            };
+            match action {
+                ArmRewriteAction::RewritePattern(paths) => {
+                    let pat = paths.join(" | ");
+                    arm.pat = Box::new(utils::pat!("{pat}"));
+                }
+                ArmRewriteAction::KeepWildcard => {}
+                ArmRewriteAction::RemoveWildcard => {
+                    remove_last = index + 1 == len;
+                }
+            }
+        }
+
+        if remove_last {
+            arms.pop();
+        }
+
+        true
+    }
 }
 
 impl mut_visit::MutVisitor for AstVisitor<'_> {
@@ -257,6 +349,10 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
 
     fn visit_expr(&mut self, expr: &mut ast::Expr) {
         mut_visit::walk_expr(self, expr);
+
+        if self.rewrite_match_expr(expr) {
+            return;
+        }
 
         if let ast::ExprKind::Cast(_, ty) = &mut expr.kind
             && let Some(repr) = self.replacement_for_ty(ty)
@@ -610,6 +706,24 @@ enum ExprEnumClass {
     Unknown,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum CastedIntegerValue {
+    Signed(i128),
+    Unsigned(u128),
+}
+
+#[derive(Clone, Debug)]
+enum NumericPatValues {
+    Values(Vec<CastedIntegerValue>),
+    Wildcard,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct EnumCastScrutinee {
+    enum_alias: LocalDefId,
+    target_repr: IntegerRepr,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RequiredContext {
     Let,
@@ -787,6 +901,126 @@ impl<'a, 'tcx> BodyVisitor<'a, 'tcx> {
         if let Some(rhs) = rhs {
             self.record_enum_value_cast(rhs, kind);
         }
+    }
+
+    fn enum_cast_scrutinee(&self, scrutinee: &'tcx hir::Expr<'tcx>) -> Option<EnumCastScrutinee> {
+        let typeck = self.tcx.typeck(scrutinee.hir_id.owner.def_id);
+        let target_repr = integer_repr(typeck.expr_ty(scrutinee))?;
+
+        let mut base = utils::hir::unwrap_drop_temps(scrutinee);
+        let mut saw_cast = false;
+        loop {
+            match base.kind {
+                hir::ExprKind::Use(expr, _) => {
+                    base = utils::hir::unwrap_drop_temps(expr);
+                }
+                hir::ExprKind::Cast(expr, _) => {
+                    saw_cast = true;
+                    base = utils::hir::unwrap_drop_temps(expr);
+                }
+                _ => break,
+            }
+        }
+        if !saw_cast {
+            return None;
+        }
+
+        let ExprEnumClass::Enum(enum_alias) = self.classify_expr(base) else {
+            return None;
+        };
+        self.analysis
+            .enums
+            .get(&enum_alias)
+            .is_some_and(|info| info.transformable)
+            .then_some(EnumCastScrutinee {
+                enum_alias,
+                target_repr,
+            })
+    }
+
+    fn casted_variant_paths(
+        &self,
+        info: &EnumInfo,
+        target_repr: IntegerRepr,
+    ) -> Option<FxHashMap<CastedIntegerValue, String>> {
+        let mut paths = FxHashMap::default();
+        for variant in &info.variants {
+            let value = cast_discriminant_value(variant.value, info.repr, target_repr, self.tcx)?;
+            let path = format!(
+                "crate::{}::{}",
+                self.tcx.def_path_str(info.alias.to_def_id()),
+                variant.name
+            );
+            if paths.insert(value, path).is_some() {
+                return None;
+            }
+        }
+        Some(paths)
+    }
+
+    fn try_record_match_rewrite(
+        &mut self,
+        expr: &'tcx hir::Expr<'tcx>,
+        scrutinee: &'tcx hir::Expr<'tcx>,
+        arms: &'tcx [hir::Arm<'tcx>],
+    ) {
+        let Some(scrutinee) = self.enum_cast_scrutinee(scrutinee) else {
+            return;
+        };
+        let Some(info) = self.analysis.enums.get(&scrutinee.enum_alias) else {
+            return;
+        };
+        let Some(variant_paths) = self.casted_variant_paths(info, scrutinee.target_repr) else {
+            return;
+        };
+
+        let mut rewrites = Vec::new();
+        let mut covered_variants = FxHashSet::default();
+        let mut has_guard = false;
+        for arm in arms {
+            has_guard |= arm.guard.is_some();
+            match numeric_pat_values(arm.pat, scrutinee.target_repr, self.tcx) {
+                Some(NumericPatValues::Values(values)) => {
+                    let mut paths = Vec::with_capacity(values.len());
+                    for value in values {
+                        let Some(path) = variant_paths.get(&value) else {
+                            return;
+                        };
+                        paths.push(path.clone());
+                        if arm.guard.is_none() {
+                            covered_variants.insert(value);
+                        }
+                    }
+                    rewrites.push(ArmRewrite {
+                        arm_hir_id: arm.hir_id,
+                        action: ArmRewriteAction::RewritePattern(paths),
+                    });
+                }
+                Some(NumericPatValues::Wildcard) => {
+                    rewrites.push(ArmRewrite {
+                        arm_hir_id: arm.hir_id,
+                        action: ArmRewriteAction::KeepWildcard,
+                    });
+                }
+                None => return,
+            }
+        }
+
+        let remove_final_wildcard = !has_guard
+            && covered_variants.len() == variant_paths.len()
+            && arms.last().is_some_and(|arm| arm.guard.is_none())
+            && rewrites
+                .last()
+                .is_some_and(|arm| matches!(&arm.action, ArmRewriteAction::KeepWildcard));
+        if remove_final_wildcard && let Some(last) = rewrites.last_mut() {
+            last.action = ArmRewriteAction::RemoveWildcard;
+        }
+
+        self.analysis.match_rewrites.push(MatchRewriteSite {
+            enum_alias: scrutinee.enum_alias,
+            match_hir_id: expr.hir_id,
+            arms: rewrites,
+        });
     }
 
     fn classify_expr(&self, expr: &'tcx hir::Expr<'tcx>) -> ExprEnumClass {
@@ -1070,6 +1304,9 @@ impl<'tcx> intravisit::Visitor<'tcx> for BodyVisitor<'_, 'tcx> {
             hir::ExprKind::Struct(_, fields, _) => {
                 self.check_struct_fields(expr, fields);
             }
+            hir::ExprKind::Match(scrutinee, arms, hir::MatchSource::Normal) => {
+                self.try_record_match_rewrite(expr, scrutinee, arms);
+            }
             hir::ExprKind::Binary(op, lhs, rhs) => {
                 self.handle_binary(expr, op.node, lhs, rhs);
             }
@@ -1170,6 +1407,142 @@ fn integer_repr(ty: Ty<'_>) -> Option<IntegerRepr> {
         ty::TyKind::Int(int_ty) => Some(IntegerRepr::Signed(*int_ty)),
         ty::TyKind::Uint(uint_ty) => Some(IntegerRepr::Unsigned(*uint_ty)),
         _ => None,
+    }
+}
+
+fn numeric_pat_values(
+    pat: &hir::Pat<'_>,
+    target_repr: IntegerRepr,
+    tcx: TyCtxt<'_>,
+) -> Option<NumericPatValues> {
+    match pat.kind {
+        hir::PatKind::Expr(expr) => Some(NumericPatValues::Values(vec![numeric_pat_expr_value(
+            expr,
+            target_repr,
+            tcx,
+        )?])),
+        hir::PatKind::Or(pats) => {
+            let mut values = Vec::new();
+            for pat in pats {
+                match numeric_pat_values(pat, target_repr, tcx)? {
+                    NumericPatValues::Values(pat_values) => values.extend(pat_values),
+                    NumericPatValues::Wildcard => return None,
+                }
+            }
+            Some(NumericPatValues::Values(values))
+        }
+        hir::PatKind::Wild => Some(NumericPatValues::Wildcard),
+        _ => None,
+    }
+}
+
+fn numeric_pat_expr_value(
+    expr: &hir::PatExpr<'_>,
+    target_repr: IntegerRepr,
+    tcx: TyCtxt<'_>,
+) -> Option<CastedIntegerValue> {
+    let hir::PatExprKind::Lit { lit, negated } = expr.kind else {
+        return None;
+    };
+    let ast::LitKind::Int(value, _) = lit.node else {
+        return None;
+    };
+    cast_literal_value(value.get(), negated, target_repr, tcx)
+}
+
+fn cast_literal_value(
+    value: u128,
+    negated: bool,
+    target_repr: IntegerRepr,
+    tcx: TyCtxt<'_>,
+) -> Option<CastedIntegerValue> {
+    let width = integer_width(target_repr, tcx);
+    match target_repr {
+        IntegerRepr::Signed(_) => {
+            let sign_bit = 1u128 << (width - 1);
+            let max = sign_bit - 1;
+            let value = if negated {
+                if value > sign_bit {
+                    return None;
+                }
+                if value == sign_bit && width == 128 {
+                    i128::MIN
+                } else {
+                    -(value as i128)
+                }
+            } else {
+                if value > max {
+                    return None;
+                }
+                value as i128
+            };
+            Some(CastedIntegerValue::Signed(value))
+        }
+        IntegerRepr::Unsigned(_) => {
+            if negated || value > low_bits_mask(width) {
+                return None;
+            }
+            Some(CastedIntegerValue::Unsigned(value))
+        }
+    }
+}
+
+fn cast_discriminant_value(
+    value: DiscriminantValue,
+    _source_repr: IntegerRepr,
+    target_repr: IntegerRepr,
+    tcx: TyCtxt<'_>,
+) -> Option<CastedIntegerValue> {
+    let width = integer_width(target_repr, tcx);
+    let bits = match value {
+        DiscriminantValue::Signed(value) => value as u128,
+        DiscriminantValue::Unsigned(value) => value,
+    } & low_bits_mask(width);
+    Some(match target_repr {
+        IntegerRepr::Signed(_) => CastedIntegerValue::Signed(signed_value_from_bits(bits, width)),
+        IntegerRepr::Unsigned(_) => CastedIntegerValue::Unsigned(bits),
+    })
+}
+
+fn integer_width(repr: IntegerRepr, tcx: TyCtxt<'_>) -> u32 {
+    match repr {
+        IntegerRepr::Signed(int_ty) => match int_ty {
+            ty::IntTy::Isize => tcx.data_layout.pointer_size.bits() as u32,
+            ty::IntTy::I8 => 8,
+            ty::IntTy::I16 => 16,
+            ty::IntTy::I32 => 32,
+            ty::IntTy::I64 => 64,
+            ty::IntTy::I128 => 128,
+        },
+        IntegerRepr::Unsigned(uint_ty) => match uint_ty {
+            ty::UintTy::Usize => tcx.data_layout.pointer_size.bits() as u32,
+            ty::UintTy::U8 => 8,
+            ty::UintTy::U16 => 16,
+            ty::UintTy::U32 => 32,
+            ty::UintTy::U64 => 64,
+            ty::UintTy::U128 => 128,
+        },
+    }
+}
+
+fn low_bits_mask(width: u32) -> u128 {
+    if width == 128 {
+        u128::MAX
+    } else {
+        (1u128 << width) - 1
+    }
+}
+
+fn signed_value_from_bits(bits: u128, width: u32) -> i128 {
+    if width == 128 {
+        bits as i128
+    } else {
+        let sign_bit = 1u128 << (width - 1);
+        if bits & sign_bit == 0 {
+            bits as i128
+        } else {
+            (bits as i128) - (1i128 << width)
+        }
     }
 }
 

--- a/crates/passes/src/enum_replacer/mod.rs
+++ b/crates/passes/src/enum_replacer/mod.rs
@@ -16,7 +16,15 @@ use rustc_span::{
 };
 
 pub fn replace_enums(tcx: TyCtxt<'_>) {
-    let _ = analyze_enums(tcx);
+    let analysis = analyze_enums(tcx);
+    let total = analysis.enums.len();
+    let transformable = analysis
+        .enums
+        .values()
+        .filter(|info| info.transformable)
+        .count();
+    println!("enum candidates: {total}");
+    println!("transformable enums: {transformable}");
 }
 
 #[derive(Debug, Default)]
@@ -827,10 +835,6 @@ impl<'tcx> intravisit::Visitor<'tcx> for BodyVisitor<'_, 'tcx> {
     }
 
     fn visit_body(&mut self, body: &hir::Body<'tcx>) -> Self::Result {
-        if let Some(ret) = self.current_ret_ty.clone() {
-            self.check_expr_against_type(body.value, &ret, RequiredContext::Return);
-        }
-
         intravisit::walk_body(self, body)
     }
 

--- a/crates/passes/src/enum_replacer/tests.rs
+++ b/crates/passes/src/enum_replacer/tests.rs
@@ -826,3 +826,251 @@ fn transform_alias_through_pointer_compiles() {
     assert!(code.contains("pub enum E"));
     assert!(code.contains("pub type EP = *mut E;"));
 }
+
+#[test]
+fn transform_rewrites_enum_match() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(e: E) -> core::ffi::c_int {
+                match e as core::ffi::c_uint {
+                    0 => 10,
+                    1 => 20,
+                    _ => 0,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("match e {"));
+    assert!(code.contains("crate::E::A => 10"));
+    assert!(code.contains("crate::E::B => 20"));
+    assert!(!code.contains("match e as core::ffi::c_uint"));
+}
+
+#[test]
+fn transform_removes_exhaustive_final_wildcard() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = u32;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(e: E) -> u32 {
+                match e as u32 {
+                    0 => 10,
+                    1 => 20,
+                    _ => 30,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("match e {"));
+    assert!(!code.contains("_ => 30"));
+}
+
+#[test]
+fn transform_keeps_partial_final_wildcard() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = u32;
+            pub const A: E = 0;
+            pub const B: E = 1;
+            pub const C: E = 2;
+
+            pub unsafe extern "C" fn f(e: E) -> u32 {
+                match e as u32 {
+                    0 => 10,
+                    1 => 20,
+                    _ => 30,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("match e {"));
+    assert!(code.contains("_ => 30"));
+}
+
+#[test]
+fn transform_rewrites_or_pattern() {
+    let code = transform_and_compile(
+        r#"
+            pub type Token = u32;
+            pub const WORD: Token = 1;
+            pub const IDENT: Token = 6;
+            pub const OTHER: Token = 9;
+
+            pub unsafe extern "C" fn f(token: Token) -> u32 {
+                match token as u32 {
+                    1 | 6 => 10,
+                    9 => 20,
+                    _ => 0,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("crate::Token::WORD | crate::Token::IDENT => 10"));
+}
+
+#[test]
+fn transform_uses_qualified_paths_for_lowercase_variants() {
+    let code = transform_and_compile(
+        r#"
+            pub type c_bool = core::ffi::c_int;
+            pub const false_0: c_bool = 0 as core::ffi::c_int;
+            pub const true_0: c_bool = 1 as core::ffi::c_int;
+
+            pub unsafe extern "C" fn f(b: c_bool) -> core::ffi::c_int {
+                match b as core::ffi::c_int {
+                    0 => 10,
+                    1 => 20,
+                    _ => 0,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("crate::c_bool::false_0 => 10"));
+    assert!(code.contains("crate::c_bool::true_0 => 20"));
+    assert!(!code.contains("{ false_0 => 10"));
+}
+
+#[test]
+fn transform_rewrites_enum_field_match() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub struct S {
+                pub tag: E,
+            }
+
+            pub unsafe extern "C" fn f(s: S) -> core::ffi::c_int {
+                match s.tag as core::ffi::c_uint {
+                    0 => 10,
+                    1 => 20,
+                    _ => 0,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("match s.tag {"));
+    assert!(code.contains("crate::E::A => 10"));
+    assert!(code.contains("crate::E::B => 20"));
+}
+
+#[test]
+fn transform_rewrites_signed_cast_target() {
+    let code = transform_and_compile(
+        r#"
+            pub type Operation = core::ffi::c_uint;
+            pub const OP_ADD: Operation = 1;
+            pub const OP_SUB: Operation = 2;
+
+            pub unsafe extern "C" fn f(op: Operation) -> core::ffi::c_int {
+                match op as core::ffi::c_int {
+                    1 => 10,
+                    2 => 20,
+                    _ => 0,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("match op {"));
+    assert!(code.contains("crate::Operation::OP_ADD => 10"));
+    assert!(code.contains("crate::Operation::OP_SUB => 20"));
+}
+
+#[test]
+fn skip_non_enum_cast_chain_match() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(mode: u8) -> E {
+                match mode as u32 as core::ffi::c_uint {
+                    0 => A,
+                    _ => B,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("match mode as u32 as core::ffi::c_uint"));
+}
+
+#[test]
+fn skip_unknown_numeric_arm() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = u32;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(e: E) -> u32 {
+                match e as u32 {
+                    0 => 10,
+                    2 => 20,
+                    _ => 30,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("match e as u32"));
+    assert!(code.contains("2 => 20"));
+}
+
+#[test]
+fn skip_colliding_casted_discriminants() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = u16;
+            pub const A: E = 0;
+            pub const B: E = 256;
+
+            pub unsafe extern "C" fn f(e: E) -> u8 {
+                match e as u8 {
+                    0 => 10,
+                    _ => 20,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("match e as u8"));
+}
+
+#[test]
+fn keep_wildcard_with_guard() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = u32;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(e: E, cond: bool) -> u32 {
+                match e as u32 {
+                    0 if cond => 10,
+                    1 => 20,
+                    _ => 30,
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("crate::E::A if cond => 10"));
+    assert!(code.contains("_ => 30"));
+}

--- a/crates/passes/src/enum_replacer/tests.rs
+++ b/crates/passes/src/enum_replacer/tests.rs
@@ -1,0 +1,543 @@
+use super::*;
+
+fn analyze(code: &str) -> EnumAnalysis {
+    let code = format!(
+        r#"
+            #![allow(dead_code)]
+            #![allow(non_camel_case_types)]
+            #![allow(non_snake_case)]
+            #![allow(non_upper_case_globals)]
+
+            {code}
+            "#
+    );
+    utils::compilation::run_compiler_on_str(&code, analyze_enums).unwrap()
+}
+
+fn enum_by_name<'a>(analysis: &'a EnumAnalysis, tcx: TyCtxt<'_>, name: &str) -> &'a EnumInfo {
+    analysis
+        .enums
+        .iter()
+        .find_map(|(alias, info)| {
+            (tcx.item_name(alias.to_def_id()).as_str() == name).then_some(info)
+        })
+        .unwrap()
+}
+
+fn analyze_with_tcx<R: Send>(
+    code: &str,
+    f: impl FnOnce(TyCtxt<'_>, EnumAnalysis) -> R + Send,
+) -> R {
+    let code = format!(
+        r#"
+            #![allow(dead_code)]
+            #![allow(non_camel_case_types)]
+            #![allow(non_snake_case)]
+            #![allow(non_upper_case_globals)]
+
+            {code}
+            "#
+    );
+    utils::compilation::run_compiler_on_str(&code, |tcx| f(tcx, analyze_enums(tcx))).unwrap()
+}
+
+fn has_reject(info: &EnumInfo, kind: RejectReasonKind) -> bool {
+    info.reject_reasons.iter().any(|reason| reason.kind == kind)
+}
+
+#[test]
+fn detect_simple_c_enum() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const C: E = 2;
+            pub const B: E = 1;
+            pub const A: E = 0;
+
+            pub unsafe extern "C" fn f() -> E {
+                A
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert_eq!(
+                info.variants
+                    .iter()
+                    .map(|v| (v.name.as_str().to_string(), v.value))
+                    .collect::<Vec<_>>(),
+                vec![
+                    ("A".to_string(), DiscriminantValue::Unsigned(0)),
+                    ("B".to_string(), DiscriminantValue::Unsigned(1)),
+                    ("C".to_string(), DiscriminantValue::Unsigned(2)),
+                ]
+            );
+            assert!(info.reject_reasons.is_empty());
+            assert!(info.enum_to_int_cast_sites.is_empty());
+        },
+    );
+}
+
+#[test]
+fn sort_variants_by_discriminant() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const C: E = 10;
+            pub const A: E = 0;
+            pub const B: E = 3;
+
+            pub unsafe extern "C" fn f() -> E {
+                B
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert_eq!(
+                info.variants
+                    .iter()
+                    .map(|v| v.name.as_str().to_string())
+                    .collect::<Vec<_>>(),
+                vec!["A", "B", "C"]
+            );
+        },
+    );
+}
+
+#[test]
+fn reject_duplicate_discriminants() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const ALSO_A: E = 0;
+
+            pub unsafe extern "C" fn f() -> E {
+                A
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(!info.transformable);
+            assert!(has_reject(info, RejectReasonKind::DuplicateDiscriminant));
+            assert!(info.enum_to_int_cast_sites.is_empty());
+        },
+    );
+}
+
+#[test]
+fn reject_integer_literal_assigned_to_enum() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f() -> E {
+                let mut e: E = 0 as core::ffi::c_uint;
+                e = B;
+                e
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(!info.transformable);
+            assert!(
+                has_reject(info, RejectReasonKind::CastAssignedToEnum)
+                    || has_reject(info, RejectReasonKind::IntegerLiteralAssignedToEnum)
+            );
+        },
+    );
+}
+
+#[test]
+fn reject_arithmetic_assigned_to_enum() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f() -> E {
+                let mut e: E = A;
+                e = A + B;
+                e
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(!info.transformable);
+            assert!(has_reject(info, RejectReasonKind::ArithmeticAssignedToEnum));
+        },
+    );
+}
+
+#[test]
+fn accept_enum_flow_through_locals_params_returns_fields() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub struct S {
+                pub tag: E,
+            }
+
+            pub unsafe extern "C" fn id(mut x: E) -> E {
+                let mut y: E = x;
+                y = B;
+                y
+            }
+
+            pub unsafe extern "C" fn f() -> E {
+                let s: S = S { tag: A };
+                id(s.tag)
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert!(info.reject_reasons.is_empty());
+            assert!(info.enum_to_int_cast_sites.is_empty());
+        },
+    );
+}
+
+#[test]
+fn accept_pointer_dereference_as_enum_source() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(mut p: *mut E) -> E {
+                *p = A;
+                let x: E = *p;
+                x
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert!(info.reject_reasons.is_empty());
+            assert!(info.enum_to_int_cast_sites.is_empty());
+        },
+    );
+}
+
+#[test]
+fn reject_wrong_argument_for_enum_parameter() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn takes_e(mut x: E) -> E {
+                x
+            }
+
+            pub unsafe extern "C" fn f() -> E {
+                takes_e(1 as core::ffi::c_uint)
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(!info.transformable);
+            assert!(
+                has_reject(info, RejectReasonKind::FunctionArgumentRequiresEnum)
+                    || has_reject(info, RejectReasonKind::CastAssignedToEnum)
+            );
+        },
+    );
+}
+
+#[test]
+fn reject_wrong_return_expression() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f() -> E {
+                1 as core::ffi::c_uint
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(!info.transformable);
+            assert!(
+                has_reject(info, RejectReasonKind::ReturnRequiresEnum)
+                    || has_reject(info, RejectReasonKind::CastAssignedToEnum)
+            );
+        },
+    );
+}
+
+#[test]
+fn record_enum_to_integer_assignment_cast() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f() -> core::ffi::c_uint {
+                let e: E = B;
+                let i: core::ffi::c_uint = e;
+                i
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert_eq!(info.enum_to_int_cast_sites.len(), 1);
+        },
+    );
+}
+
+#[test]
+fn record_enum_operands_in_integer_arithmetic() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f() -> core::ffi::c_uint {
+                let e: E = B;
+                e + A + 3 as core::ffi::c_uint
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert_eq!(info.enum_to_int_cast_sites.len(), 2);
+        },
+    );
+}
+
+#[test]
+fn same_enum_comparisons_need_no_casts() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(mut x: E, mut y: E) -> core::ffi::c_int {
+                if x < y && x != A {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert!(info.enum_to_int_cast_sites.is_empty());
+        },
+    );
+}
+
+#[test]
+fn enum_integer_comparison_records_cast() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(mut x: E) -> core::ffi::c_int {
+                if x == 1 as core::ffi::c_uint {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert_eq!(info.enum_to_int_cast_sites.len(), 1);
+        },
+    );
+}
+
+#[test]
+fn function_call_returning_enum_is_accepted() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn g() -> E {
+                A
+            }
+
+            pub unsafe extern "C" fn f() -> E {
+                let x: E = g();
+                x
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert!(info.reject_reasons.is_empty());
+            assert!(info.enum_to_int_cast_sites.is_empty());
+        },
+    );
+}
+
+#[test]
+fn signed_repr_sorting() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_int;
+            pub const NEG: E = -1;
+            pub const ZERO: E = 0;
+            pub const POS: E = 1;
+
+            pub unsafe extern "C" fn f() -> E {
+                NEG
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(matches!(info.repr, IntegerRepr::Signed(_)));
+            assert_eq!(
+                info.variants
+                    .iter()
+                    .map(|v| v.name.as_str().to_string())
+                    .collect::<Vec<_>>(),
+                vec!["NEG", "ZERO", "POS"]
+            );
+            assert!(info.transformable);
+        },
+    );
+}
+
+#[test]
+fn non_enum_integer_alias_is_not_detected() {
+    let analysis = analyze(
+        r#"
+            pub type Count = core::ffi::c_uint;
+            pub static mut LIMIT: Count = 10;
+
+            pub unsafe extern "C" fn f(mut x: Count) -> Count {
+                x
+            }
+            "#,
+    );
+    assert!(analysis.enums.is_empty());
+}
+
+#[test]
+fn alias_through_pointer_type() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub type EP = *mut E;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(mut p: EP) -> E {
+                *p = B;
+                *p
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert!(info.reject_reasons.is_empty());
+            assert!(info.enum_to_int_cast_sites.is_empty());
+        },
+    );
+}
+
+#[test]
+fn two_independent_enums() {
+    analyze_with_tcx(
+        r#"
+            pub type E1 = core::ffi::c_uint;
+            pub const E1_A: E1 = 0;
+            pub const E1_B: E1 = 1;
+
+            pub type E2 = core::ffi::c_uint;
+            pub const E2_A: E2 = 0;
+            pub const E2_B: E2 = 1;
+
+            pub unsafe extern "C" fn f(mut x: E1, mut y: E2) -> E1 {
+                x = E1_A;
+                y = E2_B;
+                x
+            }
+            "#,
+        |tcx, analysis| {
+            let e1 = enum_by_name(&analysis, tcx, "E1");
+            let e2 = enum_by_name(&analysis, tcx, "E2");
+            assert!(e1.transformable);
+            assert!(e2.transformable);
+            assert!(e1.enum_to_int_cast_sites.is_empty());
+            assert!(e2.enum_to_int_cast_sites.is_empty());
+        },
+    );
+}
+
+#[test]
+fn reject_assigning_wrong_enum() {
+    analyze_with_tcx(
+        r#"
+            pub type E1 = core::ffi::c_uint;
+            pub const E1_A: E1 = 0;
+            pub const E1_B: E1 = 1;
+
+            pub type E2 = core::ffi::c_uint;
+            pub const E2_A: E2 = 0;
+            pub const E2_B: E2 = 1;
+
+            pub unsafe extern "C" fn f(mut y: E2) -> E1 {
+                let x: E1 = y;
+                x
+            }
+            "#,
+        |tcx, analysis| {
+            let e1 = enum_by_name(&analysis, tcx, "E1");
+            assert!(!e1.transformable);
+            assert!(has_reject(e1, RejectReasonKind::WrongEnumAssignedToEnum));
+        },
+    );
+}
+
+#[test]
+fn unknown_enum_required_source_rejects() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            unsafe extern "C" {
+                fn unknown() -> core::ffi::c_uint;
+            }
+
+            pub unsafe extern "C" fn f() -> E {
+                unknown()
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(!info.transformable);
+            assert!(
+                has_reject(info, RejectReasonKind::ReturnRequiresEnum)
+                    || has_reject(info, RejectReasonKind::UnknownExpressionAssignedToEnum)
+            );
+        },
+    );
+}

--- a/crates/passes/src/enum_replacer/tests.rs
+++ b/crates/passes/src/enum_replacer/tests.rs
@@ -14,6 +14,26 @@ fn analyze(code: &str) -> EnumAnalysis {
     utils::compilation::run_compiler_on_str(&code, analyze_enums).unwrap()
 }
 
+fn transform(code: &str) -> String {
+    let code = format!(
+        r#"
+            #![allow(dead_code)]
+            #![allow(non_camel_case_types)]
+            #![allow(non_snake_case)]
+            #![allow(non_upper_case_globals)]
+
+            {code}
+            "#
+    );
+    utils::compilation::run_compiler_on_str(&code, replace_enums).unwrap()
+}
+
+fn transform_and_compile(code: &str) -> String {
+    let code = transform(code);
+    utils::compilation::run_compiler_on_str(&code, utils::type_check).unwrap();
+    code
+}
+
 fn enum_by_name<'a>(analysis: &'a EnumAnalysis, tcx: TyCtxt<'_>, name: &str) -> &'a EnumInfo {
     analysis
         .enums
@@ -591,4 +611,218 @@ fn unknown_enum_required_source_rejects() {
             );
         },
     );
+}
+
+#[test]
+fn transform_simple_c_enum() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const C: E = 2;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f() -> E {
+                A
+            }
+            "#,
+    );
+
+    assert!(code.contains("#[repr(u32)]"));
+    assert!(code.contains("#![feature(coverage_attribute)]"));
+    assert!(code.contains("#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]"));
+    assert!(code.contains("pub enum E"));
+    assert!(code.contains("A = 0u32"));
+    assert!(code.contains("B = 1u32"));
+    assert!(code.contains("C = 2u32"));
+    assert!(code.find("A = 0u32").unwrap() < code.find("B = 1u32").unwrap());
+    assert!(code.find("B = 1u32").unwrap() < code.find("C = 2u32").unwrap());
+    assert!(code.contains("pub use E::A;"));
+    assert!(code.contains("pub use E::B;"));
+    assert!(code.contains("pub use E::C;"));
+    assert!(!code.contains("type E ="));
+    assert!(!code.contains("pub const A"));
+    assert!(!code.contains("pub const B"));
+    assert!(!code.contains("pub const C"));
+}
+
+#[test]
+fn transform_signed_repr() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_int;
+            pub const POS: E = 1;
+            pub const NEG: E = -1;
+            pub const ZERO: E = 0;
+
+            pub unsafe extern "C" fn f() -> E {
+                NEG
+            }
+            "#,
+    );
+
+    assert!(code.contains("#[repr(i32)]"));
+    assert!(code.contains("NEG = -1i32"));
+    assert!(code.contains("ZERO = 0i32"));
+    assert!(code.contains("POS = 1i32"));
+    assert!(code.find("NEG = -1i32").unwrap() < code.find("ZERO = 0i32").unwrap());
+    assert!(code.find("ZERO = 0i32").unwrap() < code.find("POS = 1i32").unwrap());
+}
+
+#[test]
+fn transform_inserts_enum_to_integer_casts() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn takes_int(x: core::ffi::c_uint) -> core::ffi::c_uint {
+                x
+            }
+
+            pub unsafe extern "C" fn f() -> core::ffi::c_uint {
+                let e: E = B;
+                let mut i: core::ffi::c_uint = e;
+                i = i + A + e;
+                if e == 1 as core::ffi::c_uint {
+                    i = i + takes_int(e);
+                }
+                return e;
+            }
+            "#,
+    );
+
+    assert!(code.contains("as u32"));
+    assert!(code.contains("takes_int((e) as u32)"));
+    assert!(code.contains("return (e) as u32;"));
+}
+
+#[test]
+fn transform_rewrites_cast_targets_to_repr() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(x: u8) -> core::ffi::c_uint {
+                x as E as core::ffi::c_uint
+            }
+            "#,
+    );
+
+    assert!(code.contains("x as u32 as core::ffi::c_uint"));
+    assert!(!code.contains("x as E as core::ffi::c_uint"));
+}
+
+#[test]
+fn transform_avoids_unnecessary_casts() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(x: E) -> E {
+                let y: E = x;
+                if y == A {
+                    y
+                } else {
+                    B
+                }
+            }
+            "#,
+    );
+
+    assert!(!code.contains(" as u32"));
+}
+
+#[test]
+fn transform_preserves_rejected_aliases() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const ALSO_A: E = 0;
+
+            pub unsafe extern "C" fn f() -> E {
+                A
+            }
+            "#,
+    );
+
+    assert!(code.contains("type E ="));
+    assert!(code.contains("pub const A"));
+    assert!(code.contains("pub const ALSO_A"));
+    assert!(!code.contains("enum E"));
+}
+
+#[test]
+fn transform_exports_variants_inside_module() {
+    let mut code = transform(
+        r#"
+            pub mod m {
+                pub type E = core::ffi::c_uint;
+                pub const A: E = 0;
+                pub const B: E = 1;
+            }
+            "#,
+    );
+
+    assert!(code.contains("pub enum E"));
+    assert!(code.contains("pub use E::A;"));
+    assert!(code.contains("pub use E::B;"));
+    code.push_str(
+        r#"
+            pub fn use_exported_variants() {
+                let _ = m::E::A;
+                let _ = m::A;
+            }
+            "#,
+    );
+    utils::compilation::run_compiler_on_str(&code, utils::type_check).unwrap();
+}
+
+#[test]
+fn transform_preserves_visibility() {
+    let code = transform_and_compile(
+        r#"
+            type Private = core::ffi::c_uint;
+            const PRIVATE_A: Private = 0;
+
+            pub(crate) type CrateVisible = core::ffi::c_uint;
+            pub(crate) const CRATE_A: CrateVisible = 0;
+
+            pub type Public = core::ffi::c_uint;
+            pub const PUBLIC_A: Public = 0;
+            "#,
+    );
+
+    assert!(code.contains("enum Private"));
+    assert!(code.contains("use Private::PRIVATE_A;"));
+    assert!(code.contains("pub(crate) enum CrateVisible"));
+    assert!(code.contains("pub(crate) use CrateVisible::CRATE_A;"));
+    assert!(code.contains("pub enum Public"));
+    assert!(code.contains("pub use Public::PUBLIC_A;"));
+}
+
+#[test]
+fn transform_alias_through_pointer_compiles() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub type EP = *mut E;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(p: EP) -> E {
+                *p = B;
+                *p
+            }
+            "#,
+    );
+
+    assert!(code.contains("pub enum E"));
+    assert!(code.contains("pub type EP = *mut E;"));
 }

--- a/crates/passes/src/enum_replacer/tests.rs
+++ b/crates/passes/src/enum_replacer/tests.rs
@@ -344,7 +344,7 @@ fn accept_c_bool_style_flag_with_explicit_returns() {
             let info = enum_by_name(&analysis, tcx, "c_bool");
             assert!(info.transformable);
             assert!(info.reject_reasons.is_empty());
-            assert_eq!(info.enum_to_int_cast_sites.len(), 1);
+            assert!(info.enum_to_int_cast_sites.is_empty());
         },
     );
 }
@@ -417,7 +417,7 @@ fn same_enum_comparisons_need_no_casts() {
 }
 
 #[test]
-fn enum_integer_comparison_records_cast() {
+fn enum_integer_comparison_rewrites_directly() {
     analyze_with_tcx(
         r#"
             pub type E = core::ffi::c_uint;
@@ -435,7 +435,7 @@ fn enum_integer_comparison_records_cast() {
         |tcx, analysis| {
             let info = enum_by_name(&analysis, tcx, "E");
             assert!(info.transformable);
-            assert_eq!(info.enum_to_int_cast_sites.len(), 1);
+            assert!(info.enum_to_int_cast_sites.is_empty());
         },
     );
 }
@@ -696,6 +696,8 @@ fn transform_inserts_enum_to_integer_casts() {
     assert!(code.contains("as u32"));
     assert!(code.contains("takes_int((e) as u32)"));
     assert!(code.contains("return (e) as u32;"));
+    assert!(code.contains("if e == crate::E::B"));
+    assert!(!code.contains("if (e) as u32 == 1"));
 }
 
 #[test]
@@ -736,6 +738,259 @@ fn transform_avoids_unnecessary_casts() {
     );
 
     assert!(!code.contains(" as u32"));
+}
+
+#[test]
+fn transform_rewrites_casted_enum_variant_comparison() {
+    let code = transform_and_compile(
+        r#"
+            pub type Token = core::ffi::c_uint;
+            pub const TOKEN_EOF: Token = 0;
+            pub const TOKEN_WORD: Token = 1;
+
+            pub struct TokenState {
+                pub type_0: Token,
+            }
+
+            pub unsafe extern "C" fn f(token: TokenState) -> core::ffi::c_int {
+                if token.type_0 as core::ffi::c_uint !=
+                    TOKEN_EOF as core::ffi::c_int as core::ffi::c_uint
+                {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("token.type_0 != TOKEN_EOF"));
+    assert!(!code.contains("token.type_0 as core::ffi::c_uint !="));
+    assert!(!code.contains("TOKEN_EOF as core::ffi::c_int as core::ffi::c_uint"));
+}
+
+#[test]
+fn transform_rewrites_enum_literal_comparison() {
+    let code = transform_and_compile(
+        r#"
+            pub type c_bool = core::ffi::c_int;
+            pub const false_0: c_bool = 0 as core::ffi::c_int;
+            pub const true_0: c_bool = 1 as core::ffi::c_int;
+
+            pub unsafe extern "C" fn f(has_decimal_point: c_bool) -> core::ffi::c_int {
+                if (has_decimal_point) as i32 != 0 {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("has_decimal_point != crate::c_bool::false_0"));
+    assert!(!code.contains("(has_decimal_point) as i32 != 0"));
+}
+
+#[test]
+fn transform_rewrites_uncast_enum_literal_comparison() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(x: E) -> core::ffi::c_int {
+                if x == 1 as core::ffi::c_uint {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("if x == crate::E::B"));
+    assert!(!code.contains("x == 1 as core::ffi::c_uint"));
+    assert!(!code.contains("(x) as u32"));
+}
+
+#[test]
+fn transform_rewrites_literal_on_left() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(x: E) -> core::ffi::c_int {
+                if 0 as core::ffi::c_uint == x as core::ffi::c_uint {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("if crate::E::A == x"));
+    assert!(!code.contains("0 as core::ffi::c_uint == x as core::ffi::c_uint"));
+}
+
+#[test]
+fn transform_rewrites_lowercase_literal_variant() {
+    let code = transform_and_compile(
+        r#"
+            pub type c_bool = core::ffi::c_int;
+            pub const false_0: c_bool = 0 as core::ffi::c_int;
+            pub const true_0: c_bool = 1 as core::ffi::c_int;
+
+            pub unsafe extern "C" fn f(x: c_bool) -> core::ffi::c_int {
+                if x == 0 as core::ffi::c_int {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("x == crate::c_bool::false_0"));
+    assert!(!code.contains("if x == false_0"));
+}
+
+#[test]
+fn skip_enum_literal_comparison_unknown_value() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(x: E) -> core::ffi::c_int {
+                if x == 2 as core::ffi::c_uint {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("if (x) as u32 == 2 as core::ffi::c_uint"));
+    assert!(!code.contains("x == crate::E::"));
+}
+
+#[test]
+fn skip_enum_literal_comparison_colliding_cast() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = u16;
+            pub const A: E = 0;
+            pub const B: E = 256;
+
+            pub unsafe extern "C" fn f(x: E) -> core::ffi::c_int {
+                if x as u8 == 0 as u8 {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("if x as u8 == 0 as u8"));
+    assert!(!code.contains("x == crate::E::A"));
+}
+
+#[test]
+fn skip_casted_enum_comparison_different_cast_semantics() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = u32;
+            pub const A: E = 0;
+            pub const B: E = 2147483648;
+
+            pub unsafe extern "C" fn f(x: E, y: E) -> core::ffi::c_int {
+                if x as i32 as i64 == y as u32 as i64 {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("if x as i32 as i64 == y as u32 as i64"));
+    assert!(!code.contains("if x == y"));
+}
+
+#[test]
+fn skip_casted_enum_relational_when_order_changes() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = u32;
+            pub const A: E = 0;
+            pub const B: E = 2147483648;
+
+            pub unsafe extern "C" fn f(x: E, y: E) -> core::ffi::c_int {
+                if (x as i32) < (y as i32) {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("if (x as i32) < (y as i32)"));
+    assert!(!code.contains("if x < y"));
+}
+
+#[test]
+fn skip_different_enum_comparison() {
+    let code = transform_and_compile(
+        r#"
+            pub type E1 = u32;
+            pub const E1_A: E1 = 0;
+            pub const E1_B: E1 = 1;
+
+            pub type E2 = u32;
+            pub const E2_A: E2 = 0;
+            pub const E2_B: E2 = 1;
+
+            pub unsafe extern "C" fn f(x: E1, y: E2) -> core::ffi::c_int {
+                if x as u32 == y as u32 {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("if x as u32 == y as u32"));
+    assert!(!code.contains("if x == y"));
+}
+
+#[test]
+fn skip_non_enum_cast_chain_comparison() {
+    let code = transform_and_compile(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(mode: u8) -> core::ffi::c_int {
+                if mode as u32 as core::ffi::c_uint != 0 {
+                    1
+                } else {
+                    0
+                }
+            }
+            "#,
+    );
+
+    assert!(code.contains("if mode as u32 as core::ffi::c_uint != 0"));
 }
 
 #[test]

--- a/crates/passes/src/enum_replacer/tests.rs
+++ b/crates/passes/src/enum_replacer/tests.rs
@@ -264,7 +264,7 @@ fn reject_wrong_return_expression() {
             pub const B: E = 1;
 
             pub unsafe extern "C" fn f() -> E {
-                1 as core::ffi::c_uint
+                return 1 as core::ffi::c_uint;
             }
             "#,
         |tcx, analysis| {
@@ -274,6 +274,57 @@ fn reject_wrong_return_expression() {
                 has_reject(info, RejectReasonKind::ReturnRequiresEnum)
                     || has_reject(info, RejectReasonKind::CastAssignedToEnum)
             );
+        },
+    );
+}
+
+#[test]
+fn accept_explicit_return_variants_without_tail_expr() {
+    analyze_with_tcx(
+        r#"
+            pub type E = core::ffi::c_uint;
+            pub const A: E = 0;
+            pub const B: E = 1;
+
+            pub unsafe extern "C" fn f(mut cond: core::ffi::c_int) -> E {
+                if cond != 0 as core::ffi::c_int {
+                    return A;
+                }
+                return B;
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "E");
+            assert!(info.transformable);
+            assert!(info.reject_reasons.is_empty());
+        },
+    );
+}
+
+#[test]
+fn accept_c_bool_style_flag_with_explicit_returns() {
+    analyze_with_tcx(
+        r#"
+            pub type c_bool = core::ffi::c_int;
+            pub const true_0: c_bool = 1 as core::ffi::c_int;
+            pub const false_0: c_bool = 0 as core::ffi::c_int;
+
+            pub unsafe extern "C" fn f(mut cond: core::ffi::c_int) -> c_bool {
+                let mut seen: c_bool = false_0;
+                if cond != 0 as core::ffi::c_int {
+                    seen = true_0;
+                }
+                if seen != 0 as core::ffi::c_int {
+                    return true_0;
+                }
+                return false_0;
+            }
+            "#,
+        |tcx, analysis| {
+            let info = enum_by_name(&analysis, tcx, "c_bool");
+            assert!(info.transformable);
+            assert!(info.reject_reasons.is_empty());
+            assert_eq!(info.enum_to_int_cast_sites.len(), 1);
         },
     );
 }
@@ -528,7 +579,7 @@ fn unknown_enum_required_source_rejects() {
             }
 
             pub unsafe extern "C" fn f() -> E {
-                unknown()
+                return unknown();
             }
             "#,
         |tcx, analysis| {

--- a/crates/passes/src/extern_resolver/mod.rs
+++ b/crates/passes/src/extern_resolver/mod.rs
@@ -129,6 +129,7 @@ fn make_resolve_map(
         .values()
         .chain(result.equiv_tys.values())
         .chain(result.equiv_fns.values())
+        .chain(result.equiv_consts.values())
         .chain(result.equiv_statics.values())
         .chain(std::iter::once(&result.equiv_unnameds))
     {
@@ -380,6 +381,8 @@ struct ResolveResult {
     equiv_fns: FxHashMap<Symbol, EquivClasses<LocalDefId>>,
     extern_fns: Vec<(LocalDefId, Vec<EquivClassId>)>,
 
+    equiv_consts: FxHashMap<Symbol, EquivClasses<LocalDefId>>,
+
     equiv_statics: FxHashMap<Symbol, EquivClasses<LocalDefId>>,
     extern_statics: Vec<(LocalDefId, Vec<EquivClassId>)>,
 }
@@ -506,6 +509,16 @@ fn resolve(ignore_return_type: bool, ignore_param_type: bool, tcx: TyCtxt<'_>) -
         extern_fns.push((def_id, link_candidates));
     }
 
+    let mut equiv_consts: FxHashMap<_, EquivClasses<LocalDefId>> = FxHashMap::default();
+    for def_id in hir_data.consts {
+        let name = utils::ir::def_id_to_symbol(def_id, tcx).unwrap();
+        let classes = equiv_consts.entry(name).or_insert_with(EquivClasses::new);
+        classes.insert(def_id, |id1, id2| {
+            cmp.with_equiv_unnameds_update(|cmp| cmp.cmp_type_of(*id1, *id2))
+                && const_body_eq(*id1, *id2, tcx)
+        });
+    }
+
     let mut equiv_statics: FxHashMap<_, EquivClasses<LocalDefId>> = FxHashMap::default();
     for def_id in hir_data.statics {
         let name = utils::ir::def_id_to_symbol(def_id, tcx).unwrap();
@@ -548,9 +561,23 @@ fn resolve(ignore_return_type: bool, ignore_param_type: bool, tcx: TyCtxt<'_>) -
         equiv_tys,
         equiv_fns,
         extern_fns,
+        equiv_consts,
         equiv_statics,
         extern_statics,
     }
+}
+
+fn const_body_eq(def_id1: LocalDefId, def_id2: LocalDefId, tcx: TyCtxt<'_>) -> bool {
+    let hir::Node::Item(item1) = tcx.hir_node_by_def_id(def_id1) else { panic!() };
+    let hir::Node::Item(item2) = tcx.hir_node_by_def_id(def_id2) else { panic!() };
+    let hir::ItemKind::Const(_, _, _, body_id1) = item1.kind else { panic!() };
+    let hir::ItemKind::Const(_, _, _, body_id2) = item2.kind else { panic!() };
+
+    let source_map = tcx.sess.source_map();
+    let body1 = tcx.hir_body(body_id1).value;
+    let body2 = tcx.hir_body(body_id2).value;
+    source_map.span_to_snippet(body1.span).unwrap()
+        == source_map.span_to_snippet(body2.span).unwrap()
 }
 
 fn filter_by_common_def_path(
@@ -839,6 +866,7 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
     fn flat_map_item(&mut self, item: P<ast::Item>) -> SmallVec<[P<ast::Item>; 1]> {
         let hir_item = self.ast_to_hir.get_item(item.id, self.tcx).unwrap();
         if let ast::ItemKind::Fn(..)
+        | ast::ItemKind::Const(..)
         | ast::ItemKind::Static(..)
         | ast::ItemKind::Struct(..)
         | ast::ItemKind::Union(..)
@@ -988,6 +1016,7 @@ impl<'tcx> HirVisitor<'tcx> {
 #[derive(Default)]
 struct HirData {
     fns: Vec<LocalDefId>,
+    consts: Vec<LocalDefId>,
     statics: Vec<LocalDefId>,
     adts: Vec<LocalDefId>,
     tys: Vec<LocalDefId>,
@@ -1006,6 +1035,7 @@ impl<'tcx> intravisit::Visitor<'tcx> for HirVisitor<'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) -> Self::Result {
         let vec = match item.kind {
             hir::ItemKind::Fn { .. } => Some(&mut self.data.fns),
+            hir::ItemKind::Const(..) => Some(&mut self.data.consts),
             hir::ItemKind::Static(..) => Some(&mut self.data.statics),
             hir::ItemKind::Struct(..) | hir::ItemKind::Union(..) => Some(&mut self.data.adts),
             hir::ItemKind::TyAlias(..) => Some(&mut self.data.tys),

--- a/crates/passes/src/extern_resolver/tests.rs
+++ b/crates/passes/src/extern_resolver/tests.rs
@@ -333,6 +333,66 @@ fn run_extern_test(code: &str, config: super::Config, includes: &[&str], exclude
     }
 }
 
+fn run_const_test(code1: &str, code2: &str, same: bool) {
+    let code = format!("mod a {{ {code1} }} mod b {{ {code2} }}");
+    utils::compilation::run_compiler_on_str(&code, |tcx| {
+        let res = super::resolve(false, false, tcx);
+        assert!(!res.equiv_consts.is_empty());
+        for classes in res.equiv_consts.values() {
+            if same {
+                assert_eq!(classes.0.len(), 1);
+            } else {
+                for class in &classes.0 {
+                    assert_eq!(class.len(), 1);
+                }
+            }
+        }
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_const() {
+    let code1 = "
+    pub const B: core::ffi::c_uint = 1;
+";
+    let code2 = "
+    pub const B: core::ffi::c_uint = 1;
+";
+    run_const_test(code1, code2, true);
+}
+
+#[test]
+fn test_const_diff_body() {
+    let code1 = "
+    pub const B: core::ffi::c_uint = 1;
+";
+    let code2 = "
+    pub const B: core::ffi::c_uint = 2;
+";
+    run_const_test(code1, code2, false);
+}
+
+#[test]
+fn test_const_resolved_use() {
+    run_extern_test(
+        "
+    mod a {
+        pub const B: core::ffi::c_uint = 1;
+    }
+    mod b {
+        pub const B: core::ffi::c_uint = 1;
+        pub unsafe extern \"C\" fn bar() -> core::ffi::c_uint {
+            return B;
+        }
+    }
+",
+        super::Config::default(),
+        &["use crate::a::B;"],
+        &["mod b {\n        pub const B"],
+    );
+}
+
 #[test]
 fn test_ignore_param_type() {
     run_extern_test(

--- a/crates/passes/src/lib.rs
+++ b/crates/passes/src/lib.rs
@@ -19,6 +19,7 @@ extern crate smallvec;
 extern crate thin_vec;
 
 pub mod bin_file_adder;
+pub mod enum_replacer;
 pub mod expander;
 pub mod extern_resolver;
 pub mod formatter;

--- a/crates/passes/src/simplifier.rs
+++ b/crates/passes/src/simplifier.rs
@@ -172,24 +172,74 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
             }
         }
     }
+
+    fn visit_pat(&mut self, pat: &mut Pat) {
+        mut_visit::walk_pat(self, pat);
+
+        if let Some(hir_pat) = self.ast_to_hir.get_pat(pat.id, self.tcx) {
+            match &mut pat.kind {
+                PatKind::Path(None, path) => self.shorten_variant_pat_path(path, hir_pat.hir_id),
+                PatKind::TupleStruct(None, path, _) => {
+                    self.shorten_variant_pat_path(path, hir_pat.hir_id);
+                }
+                PatKind::Struct(None, path, _, _) => {
+                    self.shorten_variant_pat_path(path, hir_pat.hir_id);
+                }
+                _ => {}
+            }
+        }
+    }
 }
 
 impl<'tcx> AstVisitor<'tcx> {
+    fn is_available(&self, def_id: LocalDefId, mod_id: LocalModDefId) -> bool {
+        mod_id == self.tcx.parent_module_from_def_id(def_id)
+            || self
+                .imports
+                .get(&mod_id)
+                .is_some_and(|s| s.contains(&def_id))
+    }
+
     fn shorten_path(&self, path: &mut Path, hir_id: hir::HirId) {
         if let Some(&res) = self.ast_to_hir.path_span_to_res.get(&path.span)
             && let Res::Def(_, def_id) = res
             && let Some(local_def_id) = def_id.as_local()
             && let mod_id = self.tcx.parent_module(hir_id)
-            && (mod_id == self.tcx.parent_module_from_def_id(local_def_id)
-                || self
-                    .imports
-                    .get(&mod_id)
-                    .is_some_and(|s| s.contains(&local_def_id)))
+            && self.is_available(local_def_id, mod_id)
             && let Some(last_seg) = path.segments.last().cloned()
         {
             path.segments.clear();
             path.segments.push(last_seg);
         }
+    }
+
+    fn shorten_variant_pat_path(&self, path: &mut Path, hir_id: hir::HirId) {
+        if path.segments.len() < 2 {
+            return;
+        }
+        if let Some(&res) = self.ast_to_hir.path_span_to_res.get(&path.span)
+            && let Some(enum_def_id) = self.enum_def_id_for_variant_res(res)
+            && let mod_id = self.tcx.parent_module(hir_id)
+            && self.is_available(enum_def_id, mod_id)
+        {
+            let enum_seg = path.segments[path.segments.len() - 2].clone();
+            let variant_seg = path.segments[path.segments.len() - 1].clone();
+            path.segments.clear();
+            path.segments.push(enum_seg);
+            path.segments.push(variant_seg);
+        }
+    }
+
+    fn enum_def_id_for_variant_res(&self, res: Res) -> Option<LocalDefId> {
+        let Res::Def(kind, def_id) = res else {
+            return None;
+        };
+        let variant_def_id = match kind {
+            hir::def::DefKind::Variant => def_id,
+            hir::def::DefKind::Ctor(hir::def::CtorOf::Variant, _) => self.tcx.parent(def_id),
+            _ => return None,
+        };
+        self.tcx.parent(variant_def_id).as_local()
     }
 
     fn hir_expr_to_loc(&self, expr: &hir::Expr<'tcx>) -> Option<Location> {
@@ -737,6 +787,24 @@ mod tests {
             "mod m { pub fn g() {} } use crate::m::g; fn f() { crate::m::g(); }",
             &["g()"],
             &["crate::m::g()"],
+        )
+    }
+
+    #[test]
+    fn test_shorten_enum_variant_pat_with_imported_enum() {
+        run_test(
+            "mod m { pub enum E { A, B } } use crate::m::E; fn f(e: E) -> i32 { match e { crate::m::E::A => 1, crate::m::E::B => 2 } }",
+            &["E::A => 1", "E::B => 2"],
+            &["crate::m::E::A", "crate::m::E::B"],
+        )
+    }
+
+    #[test]
+    fn test_shorten_enum_variant_pat_with_local_enum() {
+        run_test(
+            "enum E { A } fn f(e: E) -> i32 { match e { crate::E::A => 1 } }",
+            &["E::A => 1"],
+            &["crate::E::A", "{ A => 1"],
         )
     }
 }

--- a/crates/passes/src/unsafe_resolver/mod.rs
+++ b/crates/passes/src/unsafe_resolver/mod.rs
@@ -9,7 +9,7 @@ use rustc_ast_pretty::pprust;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::{
     self as hir, HirId,
-    def::Res,
+    def::{DefKind, Res},
     def_id::{DefId, LocalModDefId},
     intravisit::{self, VisitorExt},
 };
@@ -100,11 +100,17 @@ pub fn resolve_unsafe(config: &Config, tcx: TyCtxt<'_>) -> String {
                 .iter()
                 .all(|def_id| {
                     def_id.as_local().is_some_and(|def_id| {
-                        !used_inv.get(&def_id).is_some_and(|using_items| {
+                        let used_same_module = used_inv.get(&def_id).is_some_and(|using_items| {
                             using_items.iter().any(|item| {
                                 used_items.contains(item) && use_mod == visitor.item_mods.get(item)
                             })
-                        })
+                        });
+                        let used_variant_reexport =
+                            matches!(tcx.def_kind(def_id), DefKind::Ctor(..) | DefKind::Variant)
+                                && used_inv.get(&def_id).is_some_and(|using_items| {
+                                    using_items.iter().any(|item| used_items.contains(item))
+                                });
+                        !used_same_module && !used_variant_reexport
                     })
                 })
                 .then_some(*use_def_id)

--- a/crates/passes/src/unsafe_resolver/tests.rs
+++ b/crates/passes/src/unsafe_resolver/tests.rs
@@ -100,6 +100,35 @@ mod b {
 }
 
 #[test]
+fn test_transformation_variant_reexport_used_from_other_module() {
+    let code = r#"
+mod a {
+    pub enum E {
+        A,
+        B,
+    }
+    pub use E::A;
+    pub use E::B;
+}
+mod b {
+    use crate::a::A;
+    pub fn f() -> crate::a::E {
+        A
+    }
+}
+fn main() {
+    b::f();
+}
+"#;
+    run_transformation_test(
+        code,
+        true,
+        &["pub use E::A;", "fn f() -> crate::a::E"],
+        &["pub use E::B;"],
+    );
+}
+
+#[test]
 fn test_transformation_unused_method() {
     let code = r#"
 trait A {

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -2387,6 +2387,11 @@ impl<'tcx> TransformVisitor<'tcx> {
                     .join(", ");
                 utils::expr!("{} {{ {} }}", ty_name, fields)
             }
+            ty::TyKind::Adt(adt_def, _) if adt_def.did().is_local() && adt_def.is_enum() => {
+                let ty_name = mir_ty_to_string(ty, self.tcx);
+                let variant_name = fieldless_enum_zero_variant(self.tcx, *adt_def).unwrap();
+                utils::expr!("{}::{}", ty_name, variant_name)
+            }
             ty::TyKind::Adt(adt_def, _) if adt_def.did().is_local() && adt_def.is_union() => {
                 let ty_name = mir_ty_to_string(ty, self.tcx);
                 utils::expr!(
@@ -5412,6 +5417,9 @@ fn ty_supports_raw_bridge_default_expr<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>
         ty::TyKind::Tuple(elems) => elems
             .iter()
             .all(|elem| ty_supports_raw_bridge_default_expr(tcx, elem)),
+        ty::TyKind::Adt(adt_def, _) if adt_def.did().is_local() && adt_def.is_enum() => {
+            fieldless_enum_zero_variant(tcx, *adt_def).is_some()
+        }
         ty::TyKind::Adt(adt_def, args) if adt_def.did().is_local() && adt_def.is_struct() => {
             adt_def
                 .all_fields()
@@ -5419,6 +5427,25 @@ fn ty_supports_raw_bridge_default_expr<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>
         }
         _ => false,
     }
+}
+
+fn fieldless_enum_zero_variant<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    adt_def: ty::AdtDef<'tcx>,
+) -> Option<Symbol> {
+    if !adt_def.is_enum()
+        || !adt_def
+            .variants()
+            .iter()
+            .all(|variant| variant.fields.is_empty())
+    {
+        return None;
+    }
+
+    adt_def
+        .discriminants(tcx)
+        .find(|(_, discr)| discr.val == 0)
+        .map(|(idx, _)| adt_def.variant(idx).name)
 }
 
 fn raw_array_len_expr_from_bytes<'tcx>(
@@ -9144,6 +9171,68 @@ pub struct UnionHolderProbe {{
 
 pub fn check() {{
     let _: Option<Box<crate::UnionHolderProbe>> = {emitted};
+}}
+"#
+            );
+            ::utils::compilation::run_compiler_on_str(&check_code, ::utils::type_check)
+                .expect(&check_code);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn raw_bridge_default_materialization_handles_fieldless_enum_fields() {
+        let code = r#"
+#[repr(i32)]
+pub enum StatusCode {
+    STATUS_ERROR = -1,
+    STATUS_SUCCESS = 0,
+    STATUS_WARNING = 1,
+}
+
+#[repr(C)]
+pub struct ComputationResult {
+    pub value: i32,
+    pub status: StatusCode,
+}
+"#;
+
+        ::utils::compilation::run_compiler_on_str(code, |tcx| {
+            let struct_ty = find_struct_ty(tcx, "ComputationResult");
+            assert!(ty_supports_raw_bridge_default_expr(tcx, struct_ty));
+
+            let visitor = synthetic_transform_visitor(tcx);
+            let raw_expr = visitor.raw_bridge_expr(
+                struct_ty,
+                true,
+                &RawBridgeInfo::Array {
+                    len_expr: "count".to_string(),
+                },
+            );
+            let emitted = pprust::expr_to_string(&raw_expr);
+            assert!(emitted.contains("Box::leak("), "{emitted}");
+            assert!(
+                emitted.contains("status: crate::StatusCode::STATUS_SUCCESS"),
+                "{emitted}"
+            );
+
+            let check_code = format!(
+                r#"
+#[repr(i32)]
+pub enum StatusCode {{
+    STATUS_ERROR = -1,
+    STATUS_SUCCESS = 0,
+    STATUS_WARNING = 1,
+}}
+
+#[repr(C)]
+pub struct ComputationResult {{
+    pub value: i32,
+    pub status: StatusCode,
+}}
+
+pub fn check(count: usize) {{
+    let _: *mut crate::ComputationResult = {emitted};
 }}
 "#
             );

--- a/src/bin/crat.rs
+++ b/src/bin/crat.rs
@@ -164,6 +164,7 @@ enum Pass {
     Lock,
     Union,
     Punning,
+    Enum,
     Io,
     Pointer,
     Static,
@@ -526,6 +527,9 @@ fn main() {
                 }
 
                 std::fs::write(&file, res.code).unwrap();
+            }
+            Pass::Enum => {
+                run_compiler_on_path(&file, enum_replacer::replace_enums).unwrap();
             }
             Pass::Io => {
                 let res =

--- a/src/bin/crat.rs
+++ b/src/bin/crat.rs
@@ -529,7 +529,8 @@ fn main() {
                 std::fs::write(&file, res.code).unwrap();
             }
             Pass::Enum => {
-                run_compiler_on_path(&file, enum_replacer::replace_enums).unwrap();
+                let s = run_compiler_on_path(&file, enum_replacer::replace_enums).unwrap();
+                std::fs::write(&file, s).unwrap();
             }
             Pass::Io => {
                 let res =


### PR DESCRIPTION
## Summary
- Add an `Enum` pass that replaces C2Rust integer aliases plus typed constants that model C enums with `#[repr(...)]` fieldless Rust enums, derived comparison/copy traits, and same-visibility variant reexports.
- Analyze enum-like aliases through declarations and bodies, accepting only aliases with typed const variants and rejecting ambiguous or unsafe flows such as duplicate or unevaluable discriminants, integer literals/arithmetic/casts assigned to enum contexts, wrong enum values, wrong enum arguments/returns, and compound assignments.
- Rewrite enum-to-integer boundaries, cast targets, matches, and casted/literal comparisons so transformed code either compares variants directly or casts enum values back to the integer representation where required.
- Add the supporting pass interactions: duplicate extern const resolution, preserving used variant reexports in the unsafe resolver, pointer raw-bridge defaults for fieldless enums with a zero discriminant, and simplification of qualified enum variant pattern paths.

## Transformed output comparison
Compared the already-generated `transformed/bin` baseline from `master` with `transformed-enum/bin` from this branch.

- File lists match exactly: both trees contain 5,843 files across 338 public test cases.
- Content changes are limited to Rust sources: 1,272 `.rs` files differ across 161 generated projects, with no added or removed files.
- 27 generated enum-like alias/const groups now become real Rust enums. Examples include `C2_TYPE`, `qboolean`, `token_type_t`, and `StatusCode`.
- Code that previously matched or compared raw discriminant integers now uses enum variants directly, and exhaustive final wildcard arms are removed where all variants are covered.
- Constants duplicated across translated modules are now imported from their chosen representative instead of being redefined locally, which accounts for many of the SPHINCS+ diffs.
- Pointer raw-bridge default materialization for structs with enum fields now uses the zero-discriminant variant, for example `STATUS_SUCCESS`, instead of an integer default.

## Validation
I did not rerun `test_all.py`, `summarize_unsafe.py`, or the transform scripts for this PR body.

Recorded `test.txt` results for both transformed trees:
- Test cases discovered: 338
- Test cases skipped: 2
- Test cases tested: 336
- Test cases failed: 1
- Test vectors passed: 2606
- Test vectors skipped: 155
- Test vectors failed: 8

Recorded `unsafe.txt` summary for both transformed trees:
- Total unsafe occurrences: 73074
- The per-feature unsafe counts are unchanged between `transformed` and `transformed-enum`.