### PR TITLE
Add local pointer nullity analysis

### DIFF
--- a/crates/passes/src/libc_replacer/str_utils.rs
+++ b/crates/passes/src/libc_replacer/str_utils.rs
@@ -8,6 +8,7 @@ use rustc_hir::{
     self as hir,
     def::{DefKind, Res},
 };
+use rustc_middle::ty;
 
 use crate::libc_replacer::LibItem;
 
@@ -22,7 +23,7 @@ impl super::TransformVisitor<'_> {
                 return Some(format!("&({array})"));
             } else if ty == self.tcx.types.i8 {
                 self.bytemuck = true;
-                return Some(format!("bytemuck::cast_slice(&({array}))"));
+                return Some(format!("bytemuck::cast_slice::<_, u8>(&({array}))"));
             }
         }
 
@@ -45,21 +46,39 @@ impl super::TransformVisitor<'_> {
         method_names: &[&str],
     ) -> Option<String> {
         let (array, ty) = utils::ir::array_of_as_ptr(s, &self.ast_to_hir, self.tcx)?;
-        if self.expr_is_static(array) {
+        if expr_is_static_path(array, &self.ast_to_hir, self.tcx) {
             return None;
         }
         if expr_has_with_borrow_call(array) || expr_has_method_call(array, method_names) {
             return None;
         }
+        let already_mut_ref = self.expr_is_mut_ref(array);
         let array = pprust::expr_to_string(array);
+        let array_ref = if already_mut_ref {
+            format!("&mut *({array})")
+        } else {
+            format!("&mut ({array})")
+        };
         if ty == self.tcx.types.u8 {
-            Some(format!("&mut ({array})"))
+            Some(array_ref)
         } else if ty == self.tcx.types.i8 {
             self.bytemuck = true;
-            Some(format!("bytemuck::cast_slice_mut(&mut ({array}))"))
+            Some(format!("bytemuck::cast_slice_mut::<_, u8>({array_ref})"))
         } else {
             None
         }
+    }
+
+    fn expr_is_mut_ref(&self, expr: &Expr) -> bool {
+        self.ast_to_hir
+            .get_expr(expr.id, self.tcx)
+            .is_some_and(|hir_expr| {
+                let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
+                matches!(
+                    typeck.expr_ty(hir_expr).kind(),
+                    ty::TyKind::Ref(_, _, mutability) if mutability.is_mut()
+                )
+            })
     }
 
     pub fn transform_strlen(&mut self, s: &Expr) -> Expr {
@@ -84,27 +103,15 @@ impl super::TransformVisitor<'_> {
 
     pub fn transform_strncpy(&mut self, s1: &Expr, s2: &Expr, n: &Expr) -> Option<Expr> {
         let n_str = pprust::expr_to_string(n);
-        if let Some((array1, ty1)) = utils::ir::array_of_as_ptr(s1, &self.ast_to_hir, self.tcx)
-            && let Some((array2, ty2)) = utils::ir::array_of_as_ptr(s2, &self.ast_to_hir, self.tcx)
-        {
-            if (ty1 == self.tcx.types.u8 && ty2 == self.tcx.types.u8)
-                || (ty1 == self.tcx.types.i8 && ty2 == self.tcx.types.i8)
-            {
-                let array1 = pprust::expr_to_string(array1);
-                let array2 = pprust::expr_to_string(array2);
-                return Some(utils::expr!(
-                    "{{ let ___n = ({n_str}) as usize; let ___dst = (&mut ({array1}))[..___n].as_mut_ptr(); let ___src = &(&({array2}))[..]; let ___len = ___src.iter().position(|&___c| ___c == 0).map_or(___src.len(), |___i| ___i + 1).min(___n); unsafe {{ std::ptr::write_bytes(___dst, 0, ___n); std::ptr::copy_nonoverlapping(___src.as_ptr(), ___dst, ___len); }} }}"
-                ));
-            } else if ty1 == self.tcx.types.u8 || ty1 == self.tcx.types.i8 {
-                self.bytemuck = true;
-                let array1 = pprust::expr_to_string(array1);
-                let array2 = pprust::expr_to_string(array2);
-                return Some(utils::expr!(
-                    "{{ let ___n = ({n_str}) as usize; let ___dst = (&mut ({array1}))[..___n].as_mut_ptr(); let ___src = bytemuck::cast_slice(&(&({array2}))[..]); let ___len = ___src.iter().position(|&___c| ___c == 0).map_or(___src.len(), |___i| ___i + 1).min(___n); unsafe {{ std::ptr::write_bytes(___dst, 0, ___n); std::ptr::copy_nonoverlapping(___src.as_ptr(), ___dst, ___len); }} }}"
-                ));
-            }
+        let (dst_array, _) = utils::ir::array_of_as_ptr(s1, &self.ast_to_hir, self.tcx)?;
+        if self.expr_contains_static(dst_array) {
+            return None;
         }
-        None
+        let dst = self.c_byte_slice_mut(s1)?;
+        let src = self.c_byte_slice(s2)?;
+        Some(utils::expr!(
+            "{{ let ___n = ({n_str}) as usize; let ___dst = &mut ({dst})[..___n]; let ___src = &({src})[..]; let ___len = ___src.iter().position(|&___c| ___c == 0).map_or(___src.len(), |___i| ___i + 1).min(___n); ___dst.fill(0); ___dst[..___len].copy_from_slice(&___src[..___len]); }}"
+        ))
     }
 
     pub fn transform_strcmp(&mut self, s1: &Expr, s2: &Expr) -> Option<Expr> {
@@ -194,22 +201,49 @@ impl super::TransformVisitor<'_> {
         ))
     }
 
-    fn expr_is_static(&self, expr: &Expr) -> bool {
-        self.ast_to_hir
-            .get_expr(expr.id, self.tcx)
-            .is_some_and(|hir_expr| {
-                matches!(
-                    hir_expr.kind,
-                    hir::ExprKind::Path(hir::QPath::Resolved(
-                        _,
-                        hir::Path {
-                            res: Res::Def(DefKind::Static { .. }, _),
-                            ..
-                        }
-                    ))
-                )
-            })
+    fn expr_contains_static(&self, expr: &Expr) -> bool {
+        struct Finder<'a, 'tcx> {
+            ast_to_hir: &'a utils::ir::AstToHir,
+            tcx: ty::TyCtxt<'tcx>,
+            found: bool,
+        }
+
+        impl<'ast, 'tcx> Visitor<'ast> for Finder<'_, 'tcx> {
+            fn visit_expr(&mut self, expr: &'ast Expr) {
+                if self.found {
+                    return;
+                }
+                if expr_is_static_path(expr, self.ast_to_hir, self.tcx) {
+                    self.found = true;
+                    return;
+                }
+                visit::walk_expr(self, expr);
+            }
+        }
+
+        let mut finder = Finder {
+            ast_to_hir: &self.ast_to_hir,
+            tcx: self.tcx,
+            found: false,
+        };
+        finder.visit_expr(expr);
+        finder.found
     }
+}
+
+fn expr_is_static_path(expr: &Expr, ast_to_hir: &utils::ir::AstToHir, tcx: ty::TyCtxt<'_>) -> bool {
+    ast_to_hir.get_expr(expr.id, tcx).is_some_and(|hir_expr| {
+        matches!(
+            hir_expr.kind,
+            hir::ExprKind::Path(hir::QPath::Resolved(
+                _,
+                hir::Path {
+                    res: Res::Def(DefKind::Static { .. }, _),
+                    ..
+                }
+            ))
+        )
+    })
 }
 
 fn expr_has_with_borrow_call(expr: &Expr) -> bool {

--- a/crates/passes/src/libc_replacer/tests.rs
+++ b/crates/passes/src/libc_replacer/tests.rs
@@ -87,13 +87,38 @@ pub unsafe fn copy_name(mut src: &[i8]) {
 }
         "#,
         &[
-            "std::ptr::write_bytes(___dst, 0, ___n)",
-            "std::ptr::copy_nonoverlapping(___src.as_ptr(), ___dst, ___len)",
+            "___dst.fill(0)",
+            "copy_from_slice(&___src[..___len])",
             "position(|&___c|",
             "___c == 0",
             ".min(___n)",
+            "bytemuck::cast_slice::<_, u8>",
+            "bytemuck::cast_slice_mut::<_, u8>",
         ],
-        &["copy_from_slice(&src[..63])"],
+        &[
+            "std::ptr::write_bytes",
+            "std::ptr::copy_nonoverlapping",
+            "copy_from_slice(&src[..63])",
+        ],
+    );
+}
+
+#[test]
+fn test_strncpy_skips_nested_static_destination() {
+    run_test(
+        r#"
+extern "C" {
+    fn strncpy(__dest: *mut i8, __src: *const i8, __n: usize) -> *mut i8;
+}
+
+static mut COMMON: [[i8; 256]; 100] = [[0; 256]; 100];
+
+pub unsafe fn copy_static(mut src: &[i8], idx: usize) {
+    strncpy(COMMON[idx].as_mut_ptr(), src.as_ptr(), 255);
+}
+        "#,
+        &["strncpy(COMMON[idx].as_mut_ptr()"],
+        &["___dst.fill(0)", "copy_from_slice(&___src[..___len])"],
     );
 }
 
@@ -164,6 +189,42 @@ pub unsafe fn foo(mut input: &[i8], mut n: i32) -> i32 {
             "snprintf(buf.as_mut_ptr",
             "sscanf(input.as_ptr",
         ],
+    );
+}
+
+#[test]
+fn test_string_stdio_rewrites_mut_slice_receiver_without_temp_borrow() {
+    run_test(
+        r#"
+extern "C" {
+    fn snprintf(__s: *mut i8, __maxlen: usize, __format: *const i8, ...) -> i32;
+}
+
+pub unsafe fn foo(mut buf: Box<[i8]>, n: i32) -> i32 {
+    snprintf((&mut buf[..]).as_mut_ptr(), 64, b"%d\0" as *const u8 as *const i8, n)
+}
+        "#,
+        &["std::fmt::format(format_args!", "bytemuck::cast_slice_mut"],
+        &["bytemuck::cast_slice_mut(&mut ((&mut", "snprintf((&mut buf"],
+    );
+}
+
+#[test]
+fn test_string_stdio_reborrows_mut_slice_local() {
+    run_test(
+        r#"
+extern "C" {
+    fn sprintf(__s: *mut i8, __format: *const i8, ...) -> i32;
+}
+
+pub unsafe fn foo(mut output_pointer: &mut [u8], n: i32) -> u8 {
+    sprintf(output_pointer.as_mut_ptr() as *mut i8, b"%04x\0" as *const u8 as *const i8, n);
+    output_pointer = &mut output_pointer[1..];
+    output_pointer[0]
+}
+        "#,
+        &["std::fmt::format(format_args!", "&mut *(output_pointer)"],
+        &["let ___dst = ((output_pointer));", "sprintf(output_pointer"],
     );
 }
 

--- a/crates/pointer_replacer/src/analyses/mir_variable_grouping.rs
+++ b/crates/pointer_replacer/src/analyses/mir_variable_grouping.rs
@@ -117,6 +117,28 @@ impl SourceVarGroups {
             .filter(|(_, s)| !s.is_empty())
             .collect()
     }
+
+    pub fn postprocess_non_null_locals(
+        &self,
+        non_null_locals: FxHashMap<LocalDefId, DenseBitSet<Local>>,
+    ) -> FxHashMap<LocalDefId, DenseBitSet<Local>> {
+        non_null_locals
+            .into_iter()
+            .map(|(did, mut non_null)| {
+                if let Some(groups) = self.inner.get(&did) {
+                    for locals in groups.values() {
+                        if !locals.iter().all(|&local| non_null.contains(local)) {
+                            for &local in locals {
+                                non_null.remove(local);
+                            }
+                        }
+                    }
+                }
+                (did, non_null)
+            })
+            .filter(|(_, s)| !s.is_empty())
+            .collect()
+    }
 }
 
 fn group_locals_by_source_variable<'tcx>(

--- a/crates/pointer_replacer/src/analyses/nullity/mod.rs
+++ b/crates/pointer_replacer/src/analyses/nullity/mod.rs
@@ -1,15 +1,21 @@
 #![allow(dead_code)]
 
+use points_to::andersen;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::{
     mir::{
         self, BasicBlock, Body, Local, Location, Operand, Place, Rvalue, Statement, StatementKind,
-        Terminator, TerminatorKind,
+        Terminator, TerminatorEdges, TerminatorKind,
     },
     ty::{self, Ty, TyCtxt},
 };
-use rustc_span::{Symbol, def_id::LocalDefId};
+use rustc_mir_dataflow::{Analysis as MirDataflowAnalysis, Forward};
+use rustc_span::{
+    Symbol,
+    def_id::{DefId, LocalDefId},
+};
+use utils::graph;
 
 use crate::{
     analyses::mir::{CallGraphPostOrder, CallKind, MirFunctionCall, TerminatorExt},
@@ -19,9 +25,79 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct NullityResult {
     pub non_null_params: FxHashMap<LocalDefId, DenseBitSet<Local>>,
+    pub non_null_locals: FxHashMap<LocalDefId, DenseBitSet<Local>>,
 }
 
-pub fn analyze(program: &RustProgram<'_>) -> NullityResult {
+pub fn analyze<'tcx>(
+    program: &RustProgram<'tcx>,
+    points_to: &andersen::AnalysisResult,
+) -> NullityResult {
+    let non_null_params = analyze_non_null_params(program);
+    let function_set: FxHashSet<_> = program.functions.iter().copied().collect();
+    let null_write_facts = NullWriteFacts::new(program, points_to, &function_set);
+    let call_graph = CallGraphPostOrder::new(program);
+    let mut return_summaries = FxHashMap::default();
+    return_summaries.reserve(program.functions.len());
+    for &did in &program.functions {
+        return_summaries.insert(
+            did,
+            ReturnSummary {
+                may_return_null: false,
+            },
+        );
+    }
+
+    for scc in call_graph.sccs() {
+        loop {
+            let mut scc_changed = false;
+
+            for &did in scc {
+                let did = did.expect_local();
+                let res = run_local_nullity(
+                    program,
+                    did,
+                    points_to,
+                    &non_null_params,
+                    &return_summaries,
+                    &null_write_facts,
+                    &function_set,
+                );
+                let summary = return_summaries.get_mut(&did).unwrap();
+                if res.return_may_null && !summary.may_return_null {
+                    summary.may_return_null = true;
+                    scc_changed = true;
+                }
+            }
+
+            if !scc_changed {
+                break;
+            }
+        }
+    }
+
+    let mut non_null_locals = FxHashMap::default();
+    for &did in &program.functions {
+        let res = run_local_nullity(
+            program,
+            did,
+            points_to,
+            &non_null_params,
+            &return_summaries,
+            &null_write_facts,
+            &function_set,
+        );
+        if !res.non_null_locals.is_empty() {
+            non_null_locals.insert(did, res.non_null_locals);
+        }
+    }
+
+    NullityResult {
+        non_null_params,
+        non_null_locals,
+    }
+}
+
+fn analyze_non_null_params(program: &RustProgram<'_>) -> FxHashMap<LocalDefId, DenseBitSet<Local>> {
     let tcx = program.tcx;
     let function_set: FxHashSet<_> = program.functions.iter().copied().collect();
     let mut summaries = FxHashMap::default();
@@ -76,12 +152,10 @@ pub fn analyze(program: &RustProgram<'_>) -> NullityResult {
         }
     }
 
-    NullityResult {
-        non_null_params: summaries
-            .into_iter()
-            .filter(|(_, params)| !params.is_empty())
-            .collect(),
-    }
+    summaries
+        .into_iter()
+        .filter(|(_, params)| !params.is_empty())
+        .collect()
 }
 
 fn raw_pointer_params(body: &Body<'_>) -> Vec<Local> {
@@ -92,6 +166,624 @@ fn raw_pointer_params(body: &Body<'_>) -> Vec<Local> {
 
 fn is_raw_pointer_ty(ty: Ty<'_>) -> bool {
     matches!(ty.kind(), ty::TyKind::RawPtr(..))
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct GlobalLocal {
+    def_id: LocalDefId,
+    local: Local,
+}
+
+#[derive(Default)]
+struct NullWriteFacts {
+    site_targets: FxHashMap<(LocalDefId, Location), FxHashSet<GlobalLocal>>,
+    fn_effects: FxHashMap<LocalDefId, FxHashSet<GlobalLocal>>,
+}
+
+#[derive(Clone, Copy)]
+struct ReturnSummary {
+    may_return_null: bool,
+}
+
+struct LocalNullityOutput {
+    non_null_locals: DenseBitSet<Local>,
+    return_may_null: bool,
+}
+
+impl NullWriteFacts {
+    fn new<'tcx>(
+        program: &RustProgram<'tcx>,
+        points_to: &andersen::AnalysisResult,
+        function_set: &FxHashSet<LocalDefId>,
+    ) -> Self {
+        let tcx = program.tcx;
+        let reverse_locs = reverse_pointer_local_locs(program, points_to, function_set);
+        let mut site_targets = FxHashMap::default();
+        let mut own_fn_effects: FxHashMap<LocalDefId, FxHashSet<GlobalLocal>> =
+            FxHashMap::default();
+
+        for &did in &program.functions {
+            own_fn_effects.entry(did).or_default();
+            let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+            let mut trivially_non_null = DenseBitSet::new_empty(body.local_decls.len());
+            for (block, block_data) in body.basic_blocks.iter_enumerated() {
+                for (statement_index, statement) in block_data.statements.iter().enumerate() {
+                    let StatementKind::Assign(box (lhs, rhs)) = &statement.kind else {
+                        continue;
+                    };
+                    if lhs.is_indirect_first_projection()
+                        && is_raw_pointer_ty(lhs.ty(&body.local_decls, tcx).ty)
+                        && !rvalue_is_trivially_non_null(rhs, &body, tcx, &trivially_non_null)
+                    {
+                        let location = Location {
+                            block,
+                            statement_index,
+                        };
+                        record_null_write_site(
+                            did,
+                            location,
+                            points_to,
+                            &reverse_locs,
+                            &mut site_targets,
+                            &mut own_fn_effects,
+                        );
+                    }
+
+                    if let Some(local) = lhs.as_local()
+                        && is_raw_pointer_ty(body.local_decls[local].ty)
+                    {
+                        trivially_non_null.remove(local);
+                        if rvalue_is_trivially_non_null(rhs, &body, tcx, &trivially_non_null) {
+                            trivially_non_null.insert(local);
+                        }
+                    }
+                }
+
+                let terminator = block_data.terminator();
+                let Some(call) = terminator.as_call(tcx) else {
+                    continue;
+                };
+                if !call.destination.is_indirect_first_projection()
+                    || !is_raw_pointer_ty(call.destination.ty(&body.local_decls, tcx).ty)
+                    || call_return_is_trivially_non_null(tcx, &call)
+                {
+                    continue;
+                }
+                let location = Location {
+                    block,
+                    statement_index: block_data.statements.len(),
+                };
+                record_null_write_site(
+                    did,
+                    location,
+                    points_to,
+                    &reverse_locs,
+                    &mut site_targets,
+                    &mut own_fn_effects,
+                );
+            }
+        }
+
+        let side_effect_graph = side_effect_call_graph(program, points_to, function_set);
+        let reachables = graph::reflexive_transitive_closure(&side_effect_graph);
+        let mut fn_effects = FxHashMap::default();
+        for &did in &program.functions {
+            let mut effects = FxHashSet::default();
+            if let Some(reachable) = reachables.get(&did) {
+                for callee in reachable {
+                    if let Some(callee_effects) = own_fn_effects.get(callee) {
+                        effects.extend(callee_effects.iter().copied());
+                    }
+                }
+            }
+            fn_effects.insert(did, effects);
+        }
+
+        Self {
+            site_targets,
+            fn_effects,
+        }
+    }
+}
+
+fn reverse_pointer_local_locs<'tcx>(
+    program: &RustProgram<'tcx>,
+    points_to: &andersen::AnalysisResult,
+    function_set: &FxHashSet<LocalDefId>,
+) -> FxHashMap<andersen::Loc, Vec<GlobalLocal>> {
+    let mut reverse = FxHashMap::default();
+    for (&(def_id, local), node) in &points_to.var_nodes {
+        if !function_set.contains(&def_id) {
+            continue;
+        }
+        let body = program
+            .tcx
+            .mir_drops_elaborated_and_const_checked(def_id)
+            .borrow();
+        if !is_raw_pointer_ty(body.local_decls[local].ty) {
+            continue;
+        }
+
+        let global = GlobalLocal { def_id, local };
+        let mut loc = node.index;
+        let end = points_to.ends[node.index];
+        loop {
+            reverse.entry(loc).or_insert_with(Vec::new).push(global);
+            if loc == end {
+                break;
+            }
+            loc += 1;
+        }
+    }
+    reverse
+}
+
+fn record_null_write_site(
+    did: LocalDefId,
+    location: Location,
+    points_to: &andersen::AnalysisResult,
+    reverse_locs: &FxHashMap<andersen::Loc, Vec<GlobalLocal>>,
+    site_targets: &mut FxHashMap<(LocalDefId, Location), FxHashSet<GlobalLocal>>,
+    own_fn_effects: &mut FxHashMap<LocalDefId, FxHashSet<GlobalLocal>>,
+) {
+    let targets = null_write_targets(did, location, points_to, reverse_locs);
+    if targets.is_empty() {
+        return;
+    }
+    own_fn_effects
+        .entry(did)
+        .or_default()
+        .extend(targets.iter().copied());
+    site_targets.insert((did, location), targets);
+}
+
+fn null_write_targets(
+    did: LocalDefId,
+    location: Location,
+    points_to: &andersen::AnalysisResult,
+    reverse_locs: &FxHashMap<andersen::Loc, Vec<GlobalLocal>>,
+) -> FxHashSet<GlobalLocal> {
+    let mut targets = FxHashSet::default();
+    let Some(writes) = points_to
+        .writes
+        .get(&did)
+        .and_then(|writes| writes.get(&location))
+    else {
+        return targets;
+    };
+    for loc in writes.iter() {
+        if let Some(locals) = reverse_locs.get(&loc) {
+            targets.extend(locals.iter().copied());
+        }
+    }
+    targets
+}
+
+fn side_effect_call_graph<'tcx>(
+    program: &RustProgram<'tcx>,
+    points_to: &andersen::AnalysisResult,
+    function_set: &FxHashSet<LocalDefId>,
+) -> FxHashMap<LocalDefId, FxHashSet<LocalDefId>> {
+    let tcx = program.tcx;
+    let mut graph = program
+        .functions
+        .iter()
+        .map(|&did| (did, FxHashSet::default()))
+        .collect::<FxHashMap<_, _>>();
+
+    for &did in &program.functions {
+        let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+        for (block, block_data) in body.basic_blocks.iter_enumerated() {
+            if let Some(call) = block_data.terminator().as_call(tcx) {
+                match call.func {
+                    CallKind::FreeStanding(callee) | CallKind::Impl(callee)
+                        if function_set.contains(&callee) =>
+                    {
+                        graph.entry(did).or_default().insert(callee);
+                    }
+                    _ => {}
+                }
+            }
+
+            if let Some(callees) = points_to
+                .indirect_calls
+                .get(&did)
+                .and_then(|calls| calls.get(&block))
+            {
+                for &callee in callees {
+                    if function_set.contains(&callee) {
+                        graph.entry(did).or_default().insert(callee);
+                    }
+                }
+            }
+        }
+    }
+
+    graph
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_local_nullity<'tcx>(
+    program: &RustProgram<'tcx>,
+    did: LocalDefId,
+    points_to: &andersen::AnalysisResult,
+    non_null_params: &FxHashMap<LocalDefId, DenseBitSet<Local>>,
+    return_summaries: &FxHashMap<LocalDefId, ReturnSummary>,
+    null_write_facts: &NullWriteFacts,
+    function_set: &FxHashSet<LocalDefId>,
+) -> LocalNullityOutput {
+    let tcx = program.tcx;
+    let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+    let mut cursor = LocalNullity {
+        tcx,
+        def_id: did,
+        body: &body,
+        function_set,
+        non_null_params,
+        return_summaries,
+        null_write_facts,
+        points_to,
+    }
+    .iterate_to_fixpoint(tcx, &body, None)
+    .into_results_cursor(&body);
+
+    let mut ever_nullable = DenseBitSet::new_empty(body.local_decls.len());
+    let mut return_may_null = false;
+
+    for (block, block_data) in body.basic_blocks.iter_enumerated() {
+        cursor.seek_to_block_start(block);
+        ever_nullable.union(cursor.get());
+
+        for (statement_index, _) in block_data.statements.iter().enumerate() {
+            let location = Location {
+                block,
+                statement_index,
+            };
+            cursor.seek_before_primary_effect(location);
+            ever_nullable.union(cursor.get());
+            cursor.seek_after_primary_effect(location);
+            ever_nullable.union(cursor.get());
+        }
+
+        let location = Location {
+            block,
+            statement_index: block_data.statements.len(),
+        };
+        cursor.seek_before_primary_effect(location);
+        ever_nullable.union(cursor.get());
+        if matches!(block_data.terminator().kind, TerminatorKind::Return)
+            && cursor.get().contains(Local::ZERO)
+        {
+            return_may_null = true;
+        }
+        cursor.seek_after_primary_effect(location);
+        ever_nullable.union(cursor.get());
+        if matches!(
+            block_data.terminator().kind,
+            TerminatorKind::TailCall { .. }
+        ) && cursor.get().contains(Local::ZERO)
+        {
+            return_may_null = true;
+        }
+    }
+
+    let mut non_null_locals = DenseBitSet::new_empty(body.local_decls.len());
+    for (local, decl) in body.local_decls.iter_enumerated() {
+        if is_raw_pointer_ty(decl.ty) {
+            non_null_locals.insert(local);
+        }
+    }
+    for local in ever_nullable.iter() {
+        non_null_locals.remove(local);
+    }
+
+    LocalNullityOutput {
+        non_null_locals,
+        return_may_null,
+    }
+}
+
+struct LocalNullity<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+    body: &'a Body<'tcx>,
+    function_set: &'a FxHashSet<LocalDefId>,
+    non_null_params: &'a FxHashMap<LocalDefId, DenseBitSet<Local>>,
+    return_summaries: &'a FxHashMap<LocalDefId, ReturnSummary>,
+    null_write_facts: &'a NullWriteFacts,
+    points_to: &'a andersen::AnalysisResult,
+}
+
+impl<'tcx> MirDataflowAnalysis<'tcx> for LocalNullity<'_, 'tcx> {
+    type Direction = Forward;
+    type Domain = DenseBitSet<Local>;
+
+    const NAME: &'static str = "local_nullity";
+
+    fn bottom_value(&self, body: &Body<'tcx>) -> Self::Domain {
+        DenseBitSet::new_empty(body.local_decls.len())
+    }
+
+    fn initialize_start_block(&self, body: &Body<'tcx>, state: &mut Self::Domain) {
+        let non_null_params = self.non_null_params.get(&self.def_id);
+        for arg in body.args_iter() {
+            if is_raw_pointer_ty(body.local_decls[arg].ty)
+                && !non_null_params.is_some_and(|params| params.contains(arg))
+            {
+                state.insert(arg);
+            }
+        }
+    }
+
+    fn apply_primary_statement_effect(
+        &mut self,
+        state: &mut Self::Domain,
+        statement: &Statement<'tcx>,
+        location: Location,
+    ) {
+        let StatementKind::Assign(box (lhs, rhs)) = &statement.kind else {
+            return;
+        };
+
+        if lhs.is_indirect_first_projection() {
+            self.apply_site_targets(state, location);
+            return;
+        }
+
+        if let Some(local) = lhs.as_local()
+            && is_raw_pointer_ty(self.body.local_decls[local].ty)
+        {
+            state.remove(local);
+            if self.rvalue_may_be_null(rhs, state) {
+                state.insert(local);
+            }
+        } else if !lhs.projection.is_empty()
+            && is_raw_pointer_ty(self.body.local_decls[lhs.local].ty)
+        {
+            state.insert(lhs.local);
+        }
+    }
+
+    fn apply_primary_terminator_effect<'mir>(
+        &mut self,
+        state: &mut Self::Domain,
+        terminator: &'mir Terminator<'tcx>,
+        location: Location,
+    ) -> TerminatorEdges<'mir, 'tcx> {
+        let Some(call) = terminator.as_call(self.tcx) else {
+            return terminator.edges();
+        };
+
+        let return_may_be_null = self.call_return_may_be_null(&call, state);
+        for callee in self.callees_for_side_effects(&call, location.block) {
+            if let Some(effects) = self.null_write_facts.fn_effects.get(&callee) {
+                for target in effects {
+                    if target.def_id == self.def_id {
+                        state.insert(target.local);
+                    }
+                }
+            }
+        }
+
+        if call.destination.is_indirect_first_projection() {
+            self.apply_site_targets(state, location);
+        } else if let Some(local) = call.destination.as_local()
+            && is_raw_pointer_ty(self.body.local_decls[local].ty)
+        {
+            state.remove(local);
+            if return_may_be_null {
+                state.insert(local);
+            }
+        }
+
+        terminator.edges()
+    }
+}
+
+impl<'tcx> LocalNullity<'_, 'tcx> {
+    fn apply_site_targets(&self, state: &mut DenseBitSet<Local>, location: Location) {
+        if let Some(targets) = self
+            .null_write_facts
+            .site_targets
+            .get(&(self.def_id, location))
+        {
+            for target in targets {
+                if target.def_id == self.def_id {
+                    state.insert(target.local);
+                }
+            }
+        }
+    }
+
+    fn callees_for_side_effects(
+        &self,
+        call: &MirFunctionCall<'_, 'tcx>,
+        block: BasicBlock,
+    ) -> Vec<LocalDefId> {
+        let mut callees = Vec::new();
+        match &call.func {
+            CallKind::FreeStanding(callee) | CallKind::Impl(callee)
+                if self.function_set.contains(callee) =>
+            {
+                callees.push(*callee);
+            }
+            _ => {}
+        }
+        if let Some(indirect) = self
+            .points_to
+            .indirect_calls
+            .get(&self.def_id)
+            .and_then(|calls| calls.get(&block))
+        {
+            callees.extend(
+                indirect
+                    .iter()
+                    .copied()
+                    .filter(|callee| self.function_set.contains(callee)),
+            );
+        }
+        callees
+    }
+
+    fn rvalue_may_be_null(&self, rvalue: &Rvalue<'tcx>, state: &DenseBitSet<Local>) -> bool {
+        match rvalue {
+            Rvalue::Use(operand) => self.operand_may_be_null(operand, state),
+            Rvalue::Cast(_, operand, ty) if is_raw_pointer_ty(*ty) => {
+                let operand_ty = operand.ty(&self.body.local_decls, self.tcx);
+                if is_raw_pointer_ty(operand_ty) || matches!(operand_ty.kind(), ty::TyKind::Ref(..))
+                {
+                    self.operand_may_be_null(operand, state)
+                } else {
+                    true
+                }
+            }
+            Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) => {
+                !place_address_is_non_null(place, self.body)
+            }
+            Rvalue::ThreadLocalRef(_) => false,
+            Rvalue::CopyForDeref(place) => {
+                if place.projection.is_empty() {
+                    state.contains(place.local)
+                } else {
+                    true
+                }
+            }
+            _ => true,
+        }
+    }
+
+    fn operand_may_be_null(&self, operand: &Operand<'tcx>, state: &DenseBitSet<Local>) -> bool {
+        match operand {
+            Operand::Copy(place) | Operand::Move(place) => {
+                if place.projection.is_empty() {
+                    state.contains(place.local)
+                } else {
+                    true
+                }
+            }
+            Operand::Constant(_) => true,
+        }
+    }
+
+    fn call_return_may_be_null(
+        &self,
+        call: &MirFunctionCall<'_, 'tcx>,
+        state: &DenseBitSet<Local>,
+    ) -> bool {
+        match &call.func {
+            CallKind::FreeStanding(callee) if self.function_set.contains(callee) => self
+                .return_summaries
+                .get(callee)
+                .is_none_or(|summary| summary.may_return_null),
+            CallKind::Impl(callee) if self.function_set.contains(callee) => self
+                .return_summaries
+                .get(callee)
+                .is_none_or(|summary| summary.may_return_null),
+            CallKind::LibC(name) => match name.as_str() {
+                "malloc" | "calloc" => false,
+                "realloc" => call
+                    .args
+                    .first()
+                    .is_none_or(|arg| !operand_is_trivially_null(&arg.node, self.tcx)),
+                _ => true,
+            },
+            CallKind::RustLib(def_id) if is_raw_pointer_null_constructor(self.tcx, *def_id) => true,
+            CallKind::FreeStanding(_)
+            | CallKind::RustLib(_)
+            | CallKind::Impl(_)
+            | CallKind::Closure
+            | CallKind::Dynamic => {
+                let _ = state;
+                true
+            }
+        }
+    }
+}
+
+fn rvalue_is_trivially_non_null<'tcx>(
+    rvalue: &Rvalue<'tcx>,
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    trivially_non_null: &DenseBitSet<Local>,
+) -> bool {
+    match rvalue {
+        Rvalue::Use(operand) => operand_is_trivially_non_null(operand, trivially_non_null),
+        Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) => {
+            place_address_is_non_null(place, body)
+        }
+        Rvalue::ThreadLocalRef(_) => true,
+        Rvalue::Cast(_, operand, ty) if is_raw_pointer_ty(*ty) => {
+            let operand_ty = operand.ty(&body.local_decls, tcx);
+            (is_raw_pointer_ty(operand_ty) || matches!(operand_ty.kind(), ty::TyKind::Ref(..)))
+                && operand_is_trivially_non_null(operand, trivially_non_null)
+        }
+        _ => false,
+    }
+}
+
+fn operand_is_trivially_non_null(
+    operand: &Operand<'_>,
+    trivially_non_null: &DenseBitSet<Local>,
+) -> bool {
+    matches!(
+        operand,
+        Operand::Copy(place) | Operand::Move(place)
+            if place.projection.is_empty() && trivially_non_null.contains(place.local)
+    )
+}
+
+fn place_address_is_non_null(place: &Place<'_>, body: &Body<'_>) -> bool {
+    if !place_has_deref(place) {
+        return true;
+    }
+    matches!(body.local_decls[place.local].ty.kind(), ty::TyKind::Ref(..))
+        && place
+            .projection
+            .iter()
+            .filter(|elem| matches!(elem, mir::ProjectionElem::Deref))
+            .count()
+            == 1
+}
+
+fn call_return_is_trivially_non_null(tcx: TyCtxt<'_>, call: &MirFunctionCall<'_, '_>) -> bool {
+    match &call.func {
+        CallKind::LibC(name) => match name.as_str() {
+            "malloc" | "calloc" => true,
+            "realloc" => call
+                .args
+                .first()
+                .is_some_and(|arg| operand_is_trivially_null(&arg.node, tcx)),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn operand_is_trivially_null(operand: &Operand<'_>, tcx: TyCtxt<'_>) -> bool {
+    let Operand::Constant(constant) = operand else {
+        return false;
+    };
+    const_is_zero(&constant.const_, tcx)
+}
+
+fn const_is_zero(value: &mir::Const<'_>, tcx: TyCtxt<'_>) -> bool {
+    if let Some(scalar) = value.try_to_scalar()
+        && let Ok(int) = scalar.try_to_scalar_int()
+    {
+        return int.to_bits(int.size()) == 0;
+    }
+    if let mir::Const::Unevaluated(unevaluated, _) = value
+        && unevaluated.promoted.is_none()
+        && let Ok(mir::ConstValue::Scalar(scalar)) = tcx.const_eval_poly(unevaluated.def)
+        && let Ok(int) = scalar.try_to_scalar_int()
+    {
+        return int.to_bits(int.size()) == 0;
+    }
+    false
+}
+
+fn is_raw_pointer_null_constructor(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+    matches!(tcx.item_name(def_id).as_str(), "null" | "null_mut")
 }
 
 struct SingleParamAnalyzer<'a, 'tcx> {

--- a/crates/pointer_replacer/src/analyses/nullity/tests.rs
+++ b/crates/pointer_replacer/src/analyses/nullity/tests.rs
@@ -1,3 +1,4 @@
+use points_to::andersen;
 use rustc_hash::FxHashSet;
 use rustc_hir::{ItemKind, OwnerNode};
 use rustc_middle::{mir::VarDebugInfoContents, ty::TyCtxt};
@@ -25,7 +26,13 @@ fn build_rust_program(tcx: TyCtxt<'_>) -> RustProgram<'_> {
     }
 }
 
-fn run_analysis(code: &str) -> FxHashSet<(String, String)> {
+#[derive(Default)]
+struct AnalysisNames {
+    params: FxHashSet<(String, String)>,
+    locals: FxHashSet<(String, String)>,
+}
+
+fn run_analysis(code: &str) -> AnalysisNames {
     let code = format!(
         "
         #![allow(dead_code)]
@@ -40,8 +47,23 @@ fn run_analysis(code: &str) -> FxHashSet<(String, String)> {
 
     ::utils::compilation::run_compiler_on_str(&code, |tcx| {
         let rust_program = build_rust_program(tcx);
-        let result = analyze(&rust_program);
-        let mut params = FxHashSet::default();
+        let arena = typed_arena::Arena::new();
+        let tss = utils::ty_shape::get_ty_shapes(&arena, tcx, false);
+        let andersen_config = andersen::Config {
+            use_optimized_mir: false,
+            c_exposed_fns: FxHashSet::default(),
+        };
+        let pre_points_to = andersen::pre_analyze(&andersen_config, &tss, tcx);
+        let points_to_solutions = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
+        let points_to = andersen::post_analyze(
+            &andersen_config,
+            pre_points_to,
+            points_to_solutions,
+            &tss,
+            tcx,
+        );
+        let result = analyze(&rust_program, &points_to);
+        let mut names = AnalysisNames::default();
 
         for (&did, non_null_params) in &result.non_null_params {
             let fn_name = tcx.item_name(did.to_def_id()).to_string();
@@ -54,12 +76,32 @@ fn run_analysis(code: &str) -> FxHashSet<(String, String)> {
                     continue;
                 };
                 if var_debug_info.argument_index.is_some() && non_null_params.contains(local) {
-                    params.insert((fn_name.clone(), var_debug_info.name.as_str().to_string()));
+                    names
+                        .params
+                        .insert((fn_name.clone(), var_debug_info.name.as_str().to_string()));
                 }
             }
         }
 
-        params
+        for (&did, non_null_locals) in &result.non_null_locals {
+            let fn_name = tcx.item_name(did.to_def_id()).to_string();
+            let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+            for var_debug_info in body.var_debug_info.iter() {
+                let VarDebugInfoContents::Place(place) = &var_debug_info.value else {
+                    continue;
+                };
+                let Some(local) = place.as_local() else {
+                    continue;
+                };
+                if non_null_locals.contains(local) {
+                    names
+                        .locals
+                        .insert((fn_name.clone(), var_debug_info.name.as_str().to_string()));
+                }
+            }
+        }
+
+        names
     })
     .unwrap()
 }
@@ -69,7 +111,27 @@ fn expect_non_null(code: &str, expected: &[(&str, &str)]) {
         .iter()
         .map(|(function, param)| ((*function).to_string(), (*param).to_string()))
         .collect::<FxHashSet<_>>();
-    assert_eq!(run_analysis(code), expected);
+    assert_eq!(run_analysis(code).params, expected);
+}
+
+fn expect_non_null_local_facts(
+    code: &str,
+    expected_present: &[(&str, &str)],
+    expected_absent: &[(&str, &str)],
+) {
+    let locals = run_analysis(code).locals;
+    for (function, local) in expected_present {
+        assert!(
+            locals.contains(&((*function).to_string(), (*local).to_string())),
+            "expected {function}::{local} to be non-null; got {locals:?}",
+        );
+    }
+    for (function, local) in expected_absent {
+        assert!(
+            !locals.contains(&((*function).to_string(), (*local).to_string())),
+            "expected {function}::{local} to be nullable; got {locals:?}",
+        );
+    }
 }
 
 #[test]
@@ -430,5 +492,269 @@ fn unmodeled_libc_call_is_nullable() {
         }
         ",
         &[],
+    );
+}
+
+#[test]
+fn local_address_assignment_is_non_null() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn f() {
+            let mut x = 0;
+            let p: *mut i32 = &mut x;
+            let _ = p;
+        }
+        ",
+        &[("f", "p")],
+        &[],
+    );
+}
+
+#[test]
+fn local_malloc_assignment_is_non_null() {
+    expect_non_null_local_facts(
+        "
+        extern \"C\" {
+            fn malloc(size: usize) -> *mut i32;
+        }
+
+        pub unsafe fn f() {
+            let p: *mut i32 = malloc(std::mem::size_of::<i32>());
+            let _ = p;
+        }
+        ",
+        &[("f", "p")],
+        &[],
+    );
+}
+
+#[test]
+fn local_null_then_address_stays_nullable_for_now() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn f() {
+            let mut x = 0;
+            let mut p: *mut i32 = std::ptr::null_mut();
+            p = &mut x;
+            let _ = p;
+        }
+        ",
+        &[],
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn nullable_param_copy_makes_local_nullable() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn f(p: *mut i32) {
+            let q = p;
+            let _ = q;
+        }
+        ",
+        &[],
+        &[("f", "q")],
+    );
+}
+
+#[test]
+fn non_null_param_copy_keeps_local_non_null() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn f(p: *mut i32) -> i32 {
+            let v = *p;
+            let q = p;
+            let _ = q;
+            v
+        }
+        ",
+        &[("f", "q")],
+        &[],
+    );
+}
+
+#[test]
+fn integer_to_pointer_cast_is_nullable() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn f(n: usize) {
+            let p = n as *mut i32;
+            let _ = p;
+        }
+        ",
+        &[],
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn pointer_to_pointer_cast_preserves_nullity() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn nullable(p: *mut i32) {
+            let q = p as *const i32;
+            let _ = q;
+        }
+
+        pub unsafe fn non_null() {
+            let mut x = 0;
+            let p = &mut x as *mut i32;
+            let q = p as *const i32;
+            let _ = q;
+        }
+        ",
+        &[("non_null", "q")],
+        &[("nullable", "q")],
+    );
+}
+
+#[test]
+fn load_through_pointer_is_nullable() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn f(out: *mut *mut i32) {
+            let p = *out;
+            let _ = p;
+        }
+        ",
+        &[],
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn field_projection_pointer_is_nullable() {
+    expect_non_null_local_facts(
+        "
+        #[repr(C)]
+        pub struct Holder {
+            ptr: *mut i32,
+        }
+
+        pub unsafe fn f(holder: Holder) {
+            let p = holder.ptr;
+            let _ = p;
+        }
+        ",
+        &[],
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn indirect_null_write_marks_target_nullable() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn f() {
+            let mut x = 0;
+            let mut p = &mut x as *mut i32;
+            let out = &mut p as *mut *mut i32;
+            *out = std::ptr::null_mut();
+            let _ = p;
+        }
+        ",
+        &[],
+        &[("f", "p")],
+    );
+}
+
+#[test]
+fn indirect_non_null_write_does_not_mark_target_nullable() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn f() {
+            let mut x = 0;
+            let mut y = 0;
+            let mut p = &mut x as *mut i32;
+            let out = &mut p as *mut *mut i32;
+            *out = &mut y;
+            let _ = p;
+        }
+        ",
+        &[("f", "p")],
+        &[],
+    );
+}
+
+#[test]
+fn callee_indirect_null_write_side_effect_marks_caller_local_nullable() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn set_null(out: *mut *mut i32) {
+            *out = std::ptr::null_mut();
+        }
+
+        pub unsafe fn caller() {
+            let mut x = 0;
+            let mut p = &mut x as *mut i32;
+            set_null(&mut p);
+            let _ = p;
+        }
+        ",
+        &[],
+        &[("caller", "p")],
+    );
+}
+
+#[test]
+fn function_pointer_null_write_side_effect_marks_caller_local_nullable() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn set_null(out: *mut *mut i32) {
+            *out = std::ptr::null_mut();
+        }
+
+        pub unsafe fn caller() {
+            let mut x = 0;
+            let mut p = &mut x as *mut i32;
+            let fp: unsafe fn(*mut *mut i32) = set_null;
+            fp(&mut p);
+            let _ = p;
+        }
+        ",
+        &[],
+        &[("caller", "p")],
+    );
+}
+
+#[test]
+fn direct_non_null_return_summary_keeps_call_result_non_null() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn callee() -> *mut i32 {
+            let mut x = 0;
+            &mut x as *mut i32
+        }
+
+        pub unsafe fn caller() {
+            let q = callee();
+            let _ = q;
+        }
+        ",
+        &[("caller", "q")],
+        &[],
+    );
+}
+
+#[test]
+fn direct_nullable_return_summary_marks_call_result_nullable() {
+    expect_non_null_local_facts(
+        "
+        pub unsafe fn callee(flag: bool) -> *mut i32 {
+            if flag {
+                return std::ptr::null_mut();
+            }
+            let mut x = 0;
+            &mut x as *mut i32
+        }
+
+        pub unsafe fn caller(flag: bool) {
+            let q = callee(flag);
+            let _ = q;
+        }
+        ",
+        &[],
+        &[("caller", "q")],
     );
 }

--- a/crates/pointer_replacer/src/rewriter/decision.rs
+++ b/crates/pointer_replacer/src/rewriter/decision.rs
@@ -87,7 +87,7 @@ pub struct DecisionMaker<'tcx> {
     promoted_shared_refs: DenseBitSet<Local>,
     /// Locals that need a SliceCursor because they are offset with potentially-negative values.
     needs_cursor: DenseBitSet<Local>,
-    non_null_params: DenseBitSet<Local>,
+    non_null_locals: DenseBitSet<Local>,
 }
 
 impl<'tcx> DecisionMaker<'tcx> {
@@ -181,7 +181,12 @@ impl<'tcx> DecisionMaker<'tcx> {
         if let Some(signs) = fn_offset_signs {
             needs_cursor.union(signs);
         }
-        let non_null_params = stable_non_null_params(analysis, did, tcx, mutable_pointers.len());
+        let non_null_locals = analysis
+            .nullity_result
+            .non_null_locals
+            .get(&did)
+            .cloned()
+            .unwrap_or_else(|| DenseBitSet::new_empty(mutable_pointers.len()));
         DecisionMaker {
             tcx,
             array_pointers,
@@ -191,7 +196,7 @@ impl<'tcx> DecisionMaker<'tcx> {
             promoted_mut_refs,
             promoted_shared_refs,
             needs_cursor,
-            non_null_params,
+            non_null_locals,
         }
     }
 
@@ -260,49 +265,12 @@ impl<'tcx> DecisionMaker<'tcx> {
 
         let decision = self.preserve_original_pointer_constness(decision, m.is_mut());
         let decision = self.force_raw_local_struct_borrows(decision, ty, m.is_mut());
-        if self.non_null_params.contains(local) {
+        if self.non_null_locals.contains(local) {
             decision.map(PtrKind::non_null_variant)
         } else {
             decision
         }
     }
-}
-
-fn stable_non_null_params<'tcx>(
-    analysis: &Analysis,
-    did: LocalDefId,
-    tcx: TyCtxt<'tcx>,
-    len: usize,
-) -> DenseBitSet<Local> {
-    let mut non_null_params = DenseBitSet::new_empty(len);
-    let Some(params) = analysis.nullity_result.non_null_params.get(&did) else {
-        return non_null_params;
-    };
-    for param in params.iter() {
-        non_null_params.insert(param);
-    }
-
-    let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
-    for bb in body.basic_blocks.iter() {
-        for stmt in &bb.statements {
-            let StatementKind::Assign(box (place, rvalue)) = &stmt.kind else {
-                continue;
-            };
-            if place.projection.is_empty() {
-                non_null_params.remove(place.local);
-            }
-            match rvalue {
-                Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place)
-                    if place.projection.is_empty() =>
-                {
-                    non_null_params.remove(place.local);
-                }
-                _ => {}
-            }
-        }
-    }
-
-    non_null_params
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -375,12 +343,13 @@ impl SigDecisions {
             let return_aliases = aliases.and_then(|a| a.get(&return_local));
             let direct_output_dec =
                 match decision_maker.decide(return_local, return_decl, return_aliases) {
-                    Some(kind @ (PtrKind::Raw(_) | PtrKind::OptBox | PtrKind::OptBoxedSlice)) => {
-                        Some(kind)
-                    }
-                    Some(kind @ (PtrKind::Box | PtrKind::BoxedSlice)) => {
-                        Some(kind.optional_variant())
-                    }
+                    Some(
+                        kind @ (PtrKind::Raw(_)
+                        | PtrKind::OptBox
+                        | PtrKind::OptBoxedSlice
+                        | PtrKind::Box
+                        | PtrKind::BoxedSlice),
+                    ) => Some(kind),
                     _ => None,
                 };
             let returned_local_output_dec =
@@ -388,12 +357,18 @@ impl SigDecisions {
             let output_dec = match (direct_output_dec, returned_local_output_dec) {
                 (
                     Some(PtrKind::Raw(_)),
-                    Some(kind @ (PtrKind::OptBox | PtrKind::OptBoxedSlice)),
+                    Some(
+                        kind @ (PtrKind::OptBox
+                        | PtrKind::OptBoxedSlice
+                        | PtrKind::Box
+                        | PtrKind::BoxedSlice),
+                    ),
                 ) => Some(kind),
                 (Some(PtrKind::Raw(m)), _) => Some(PtrKind::Raw(m)),
-                (Some(PtrKind::OptBox), Some(PtrKind::OptBoxedSlice)) => {
-                    Some(PtrKind::OptBoxedSlice)
-                }
+                (
+                    Some(PtrKind::OptBox | PtrKind::Box),
+                    Some(kind @ (PtrKind::OptBoxedSlice | PtrKind::BoxedSlice)),
+                ) => Some(kind),
                 (Some(kind), None) | (None, Some(kind)) => Some(kind),
                 (Some(kind), Some(_)) => Some(kind),
                 (None, None) => None,
@@ -468,8 +443,10 @@ fn infer_returned_local_box_kind<'tcx>(
     let local = candidate?;
     let decl = &body.local_decls[local];
     let aliases = aliases.and_then(|aliases| aliases.get(&local));
+    let return_non_null = decision_maker.non_null_locals.contains(return_local);
     match decision_maker.decide(local, decl, aliases) {
         Some(kind @ (PtrKind::OptBox | PtrKind::OptBoxedSlice)) => Some(kind),
+        Some(kind @ (PtrKind::Box | PtrKind::BoxedSlice)) if return_non_null => Some(kind),
         Some(kind @ (PtrKind::Box | PtrKind::BoxedSlice)) => Some(kind.optional_variant()),
         _ => None,
     }
@@ -508,6 +485,7 @@ mod tests {
         .unwrap();
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn synthetic_decision_maker_with_non_null<'tcx>(
         tcx: TyCtxt<'tcx>,
         body: &Body<'tcx>,
@@ -544,9 +522,9 @@ mod tests {
         if needs_cursor {
             needs_cursor_set.insert(local);
         }
-        let mut non_null_params = DenseBitSet::new_empty(len);
+        let mut non_null_locals = DenseBitSet::new_empty(len);
         if non_null {
-            non_null_params.insert(local);
+            non_null_locals.insert(local);
         }
 
         DecisionMaker {
@@ -558,10 +536,11 @@ mod tests {
             promoted_mut_refs,
             promoted_shared_refs,
             needs_cursor: needs_cursor_set,
-            non_null_params,
+            non_null_locals,
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn decide_for_param_with_ty(
         pointer_ty: &str,
         owning: bool,
@@ -585,6 +564,7 @@ mod tests {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn decide_for_param_with_ty_and_non_null(
         pointer_ty: &str,
         owning: bool,

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -66,8 +66,15 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
         c_exposed_fns: config.c_exposed_fns.clone(),
     };
     let pre_points_to = andersen::pre_analyze(&andersen_config, &tss, tcx);
-    let points_to = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
-    let aliases = find_param_aliases(&pre_points_to, &points_to, tcx);
+    let points_to_solutions = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
+    let aliases = find_param_aliases(&pre_points_to, &points_to_solutions, tcx);
+    let points_to = andersen::post_analyze(
+        &andersen_config,
+        pre_points_to,
+        points_to_solutions,
+        &tss,
+        tcx,
+    );
 
     let mutability_result =
         analyses::type_qualifier::foster::mutability::mutability_analysis(&input);
@@ -86,7 +93,9 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     let mut offset_sign_result = analyses::offset_sign::sign::offset_sign_analysis(&input);
     offset_sign_result.access_signs =
         source_var_groups.postprocess_offset_signs(offset_sign_result.access_signs);
-    let nullity_result = analyses::nullity::analyze(&input);
+    let mut nullity_result = analyses::nullity::analyze(&input, &points_to);
+    nullity_result.non_null_locals =
+        source_var_groups.postprocess_non_null_locals(nullity_result.non_null_locals);
     let analysis_results = Analysis {
         promoted_mut_ref_result,
         promoted_shared_ref_result,

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -1875,12 +1875,14 @@ impl<'tcx> TransformVisitor<'tcx> {
                     return PtrKind::OptRef(m);
                 }
                 (PtrCtx::Rhs(PtrKind::OptRef(m)), PtrKind::BoxedSlice) => {
-                    let base = self.boxed_slice_view_expr(pe.base, m);
+                    let (base, source_inner_ty) = self
+                        .projected_boxed_slice_expr(&pe, m)
+                        .unwrap_or_else(|| panic!("{}", pprust::expr_to_string(ptr)));
                     *ptr = self.opt_ref_from_slice_or_cursor(
                         &base,
                         m,
                         lhs_inner_ty,
-                        rhs_inner_ty,
+                        source_inner_ty,
                         def_id,
                     );
                     return PtrKind::OptRef(m);
@@ -1984,8 +1986,10 @@ impl<'tcx> TransformVisitor<'tcx> {
                             self.boxed_slice_from_boxed_slice(pe.base, lhs_inner_ty, rhs_inner_ty);
                         return PtrKind::BoxedSlice;
                     }
-                    let base = self.boxed_slice_view_expr(pe.base, m);
-                    *ptr = self.plain_slice_from_expr(&base, m, lhs_inner_ty, rhs_inner_ty);
+                    let (base, source_inner_ty) = self
+                        .projected_boxed_slice_expr(&pe, m)
+                        .unwrap_or_else(|| panic!("{}", pprust::expr_to_string(ptr)));
+                    *ptr = self.plain_slice_from_expr(&base, m, lhs_inner_ty, source_inner_ty);
                     return PtrKind::Slice(m);
                 }
                 (PtrCtx::Deref(m), PtrKind::OptBoxedSlice) => {
@@ -2010,8 +2014,10 @@ impl<'tcx> TransformVisitor<'tcx> {
                     return PtrKind::Slice(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::BoxedSlice) => {
-                    let base = self.boxed_slice_view_expr(pe.base, m);
-                    *ptr = self.plain_slice_from_expr(&base, m, lhs_inner_ty, rhs_inner_ty);
+                    let (base, source_inner_ty) = self
+                        .projected_boxed_slice_expr(&pe, m)
+                        .unwrap_or_else(|| panic!("{}", pprust::expr_to_string(ptr)));
+                    *ptr = self.plain_slice_from_expr(&base, m, lhs_inner_ty, source_inner_ty);
                     return PtrKind::Slice(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::OptBoxedSlice) => {
@@ -2109,9 +2115,16 @@ impl<'tcx> TransformVisitor<'tcx> {
                     return PtrKind::Raw(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::BoxedSlice) => {
-                    let base = self.boxed_slice_view_expr(pe.base, m);
-                    *ptr =
-                        self.raw_from_slice_or_cursor(&base, m, true, lhs_inner_ty, rhs_inner_ty);
+                    let (base, source_inner_ty) = self
+                        .projected_boxed_slice_expr(&pe, m)
+                        .unwrap_or_else(|| panic!("{}", pprust::expr_to_string(ptr)));
+                    *ptr = self.raw_from_slice_or_cursor(
+                        &base,
+                        m,
+                        true,
+                        lhs_inner_ty,
+                        source_inner_ty,
+                    );
                     return PtrKind::Raw(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::OptBoxedSlice) => {
@@ -2565,26 +2578,44 @@ impl<'tcx> TransformVisitor<'tcx> {
         m: bool,
     ) -> Option<(Expr, ty::Ty<'tcx>)> {
         let mut expr = self.opt_boxed_slice_view_expr(pe.base, m);
+        self.apply_boxed_slice_projections(pe, m, &mut expr)
+    }
+
+    fn projected_boxed_slice_expr(
+        &self,
+        pe: &PtrExpr<'_, 'tcx>,
+        m: bool,
+    ) -> Option<(Expr, ty::Ty<'tcx>)> {
+        let mut expr = self.boxed_slice_view_expr(pe.base, m);
+        self.apply_boxed_slice_projections(pe, m, &mut expr)
+    }
+
+    fn apply_boxed_slice_projections(
+        &self,
+        pe: &PtrExpr<'_, 'tcx>,
+        m: bool,
+        expr: &mut Expr,
+    ) -> Option<(Expr, ty::Ty<'tcx>)> {
         let mut from_ty = unwrap_ptr_or_arr_from_mir_ty(pe.base_ty, self.tcx)?;
         for proj in &pe.projs {
             match proj {
                 PtrExprProj::Offset(offset) => {
-                    expr = utils::expr!(
+                    *expr = utils::expr!(
                         "({})[({}) as usize..]",
-                        pprust::expr_to_string(&expr),
+                        pprust::expr_to_string(expr),
                         pprust::expr_to_string(offset),
                     );
                 }
                 PtrExprProj::Cast(ty) if ty.is_usize() => return None,
                 PtrExprProj::Cast(ty) => {
                     let (to_ty, _) = unwrap_ptr_from_mir_ty(*ty)?;
-                    expr = self.plain_slice_from_expr(&expr, m, to_ty, from_ty);
+                    *expr = self.plain_slice_from_expr(expr, m, to_ty, from_ty);
                     from_ty = to_ty;
                 }
                 PtrExprProj::IntegerOp(..) | PtrExprProj::IntegerBinOp(..) => return None,
             }
         }
-        Some((expr, from_ty))
+        Some((expr.clone(), from_ty))
     }
 
     fn raw_from_opt_box(
@@ -3522,19 +3553,31 @@ impl<'tcx> TransformVisitor<'tcx> {
 
         if !need_cast {
             let reference = get_reference(
-                pe.base_kind != PtrExprBaseKind::Alloca && !is_rewritten_slice_like_local,
+                pe.base_kind != PtrExprBaseKind::Alloca
+                    && !is_rewritten_slice_like_local
+                    && !is_slice_ref_expr(e),
             );
             if pe.projs.len() == 1
                 && let PtrExprProj::Offset(offset) = pe.projs[0]
             {
                 // if there are only offsets, we can use the original slice and let the cursor handle the offsets
-                let cursor_base = if matches!(self.ptr_source_kind(pe), Some(PtrKind::BoxedSlice)) {
+                let source_kind = self.ptr_source_kind(pe);
+                let cursor_base = if matches!(source_kind, Some(PtrKind::BoxedSlice)) {
                     self.boxed_slice_view_expr(pe.base, m)
-                } else if matches!(self.ptr_source_kind(pe), Some(PtrKind::OptBoxedSlice)) {
+                } else if matches!(source_kind, Some(PtrKind::OptBoxedSlice)) {
                     self.opt_boxed_slice_view_expr(pe.base, m)
                 } else {
                     pe.base.clone()
                 };
+                let reference = get_reference(
+                    pe.base_kind != PtrExprBaseKind::Alloca
+                        && !is_rewritten_slice_like_local
+                        && !matches!(
+                            source_kind,
+                            Some(PtrKind::BoxedSlice | PtrKind::OptBoxedSlice)
+                        )
+                        && !is_slice_ref_expr(&cursor_base),
+                );
                 utils::expr!(
                     "{}::with_pos({}{}, ({}) as usize)",
                     cursor_ty,
@@ -7328,6 +7371,9 @@ fn is_plain_slice_expr(expr: &Expr) -> bool {
     if matches!(expr.kind, ExprKind::Index(..) | ExprKind::Array(..)) {
         return true;
     }
+    if is_slice_ref_expr(expr) {
+        return true;
+    }
     if let ExprKind::MethodCall(call) = &expr.kind
         && matches!(call.seg.ident.name.as_str(), "as_slice" | "as_slice_mut")
     {
@@ -7337,6 +7383,21 @@ fn is_plain_slice_expr(expr: &Expr) -> bool {
         return true;
     }
     false
+}
+
+fn is_slice_ref_expr(expr: &Expr) -> bool {
+    let expr = unwrap_paren(expr);
+    matches!(
+        expr.kind,
+        ExprKind::AddrOf(
+            _,
+            _,
+            box Expr {
+                kind: ExprKind::Index(..),
+                ..
+            },
+        )
+    )
 }
 
 fn hoist_opt_ref_borrow(expr: &mut Expr) {
@@ -7554,8 +7615,16 @@ mod tests {
             c_exposed_fns: FxHashSet::default(),
         };
         let pre_points_to = points_to::andersen::pre_analyze(&andersen_config, &tss, tcx);
-        let points_to = points_to::andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
-        let aliases = super::super::find_param_aliases(&pre_points_to, &points_to, tcx);
+        let points_to_solutions =
+            points_to::andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
+        let aliases = super::super::find_param_aliases(&pre_points_to, &points_to_solutions, tcx);
+        let points_to = points_to::andersen::post_analyze(
+            &andersen_config,
+            pre_points_to,
+            points_to_solutions,
+            &tss,
+            tcx,
+        );
 
         let input = collect_program(tcx);
         let mutability_result =
@@ -7579,7 +7648,9 @@ mod tests {
         let mut offset_sign_result = analyses::offset_sign::sign::offset_sign_analysis(&input);
         offset_sign_result.access_signs =
             source_var_groups.postprocess_offset_signs(offset_sign_result.access_signs);
-        let nullity_result = analyses::nullity::analyze(&input);
+        let mut nullity_result = analyses::nullity::analyze(&input, &points_to);
+        nullity_result.non_null_locals =
+            source_var_groups.postprocess_non_null_locals(nullity_result.non_null_locals);
         let analysis = super::super::Analysis {
             promoted_mut_ref_result,
             promoted_shared_ref_result,

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -157,10 +157,10 @@ pub unsafe fn foo() -> *mut i32 {
 }
 "#,
         &[
-            "-> Option<Box<i32>>",
-            "Option<Box<i32>>",
+            "-> Box<i32>",
+            "let mut p: Box<i32>",
             "Some(Box::new(<i32 as Default>::default()))",
-            "as_deref_mut().unwrap()",
+            "return (Some(p)).unwrap();",
         ],
         &["Box::<i32>::new(", "Box::into_raw(", "Box::leak("],
     );
@@ -213,8 +213,8 @@ pub unsafe fn make_state() -> *mut State {
 }
 "#,
         &[
-            "pub unsafe fn make_state() -> Option<Box<crate::State>>",
-            "Option<Box<crate::State>>",
+            "pub unsafe fn make_state() -> Box<crate::State>",
+            "let mut state: Box<crate::State>",
             "Some(Box::new(crate::State {",
         ],
         &[
@@ -246,8 +246,8 @@ pub unsafe fn make_state() -> *mut State {
 }
 "#,
         &[
-            "pub unsafe fn make_state() -> Option<Box<crate::State>>",
-            "Option<Box<crate::State>>",
+            "pub unsafe fn make_state() -> Box<crate::State>",
+            "let mut state: Box<crate::State>",
             "Some(Box::new(crate::State {",
         ],
         &[
@@ -273,10 +273,10 @@ pub unsafe fn foo() -> *mut i32 {
 }
 "#,
         &[
-            "pub unsafe fn foo() -> Option<Box<[i32]>>",
-            "Option<Box<[i32]>>",
+            "pub unsafe fn foo() -> Box<[i32]>",
+            "let mut p: Box<[i32]>",
             "collect::<Vec<i32>>().into_boxed_slice()",
-            "as_deref_mut().unwrap_or(&mut [])",
+            "(&mut ((&mut (p)[..])[(1) as usize..]))[0] = 7;",
         ],
         &[
             "Box::leak(",
@@ -301,7 +301,7 @@ pub unsafe fn make_buf(len: usize) -> *mut core::ffi::c_char {
 }
 "#,
         &[
-            "pub unsafe fn make_buf(len: usize) -> Option<Box<[i8]>>",
+            "pub unsafe fn make_buf(len: usize) -> Box<[i8]>",
             ".take(((1) * (len) /",
             "std::mem::size_of::<i8>()) as",
         ],
@@ -324,10 +324,10 @@ pub unsafe fn foo() -> *mut i32 {
 }
 "#,
         &[
-            "pub unsafe fn foo() -> Option<Box<[i32]>>",
-            "Option<Box<[i32]>>",
+            "pub unsafe fn foo() -> Box<[i32]>",
+            "let mut p: Box<[i32]>",
             "collect::<Vec<i32>>().into_boxed_slice()",
-            "as_deref_mut().unwrap_or(&mut [])",
+            "(&mut ((&mut (p)[..])[(1) as usize..]))[0] = 7;",
         ],
         &[
             "Box::leak(",
@@ -362,8 +362,8 @@ pub unsafe fn foo() -> i32 {
 "#,
         &[
             "pub unsafe fn alloc_one() -> *mut i32",
-            "Option<Box<i32>>",
-            "map_or(std::ptr::null_mut::<i32>()",
+            "let mut p: Box<i32>",
+            "Box::into_raw(p) as *mut i32",
         ],
         &[],
     );
@@ -391,7 +391,7 @@ pub unsafe fn foo() -> i32 {
     return take_raw(alloc_one());
 }
 "#,
-        &["-> Option<Box<i32>>", ".as_deref()", "take_raw"],
+        &["-> Box<i32>", ".as_ref()", "take_raw"],
         &[],
     );
 }
@@ -419,9 +419,9 @@ pub unsafe fn foo() -> i32 {
 }
 "#,
         &[
-            "pub unsafe fn alloc_many() -> Option<Box<[i32]>>",
+            "pub unsafe fn alloc_many() -> Box<[i32]>",
             "pub unsafe fn take_raw(p: &[i32])",
-            "return take_raw((alloc_many()).as_deref().unwrap_or(&[]));",
+            "return take_raw(&(alloc_many())[..]);",
         ],
         &["std::slice::from_raw_parts(", "Box::leak("],
     );
@@ -449,7 +449,7 @@ pub unsafe fn foo() -> *mut i32 {
         &[
             "pub unsafe fn id(mut p: Option<Box<i32>>) -> Option<Box<i32>>",
             "pub unsafe fn foo() -> Option<Box<i32>>",
-            "let mut q: Option<Box<i32>> = id((p).take());",
+            "let mut q: Option<Box<i32>> = id(Some(p));",
         ],
         &[],
     );
@@ -476,8 +476,8 @@ pub unsafe fn foo() {
 "#,
         &[
             "pub unsafe fn keep_raw() -> *mut i32",
-            "Option<Box<i32>>",
-            "Box::into_raw(_x) as *mut i32",
+            "let mut p: Box<i32>",
+            "Box::into_raw(p) as *mut i32",
             "let fp: unsafe fn() -> *mut i32 = keep_raw;",
         ],
         &[],
@@ -505,8 +505,8 @@ pub unsafe fn foo() {
 "#,
         &[
             "pub unsafe fn keep_raw_arr() -> *mut i32",
-            "Option<Box<[i32]>>",
-            "as_deref_mut().unwrap_or(&mut [])",
+            "let mut p: Box<[i32]>",
+            "Box::leak(p).as_mut_ptr()",
             "let fp: unsafe fn() -> *mut i32 = keep_raw_arr;",
         ],
         &["-> Option<Box<[i32]>>", "Box::into_raw("],
@@ -534,9 +534,9 @@ pub unsafe fn caller() -> *mut i32 {
 }
 "#,
         &[
-            "fn alloc_one() -> Option<Box<i32>>",
-            "fn caller() -> Option<Box<i32>>",
-            "let mut q: Option<Box<i32>> = alloc_one();",
+            "fn alloc_one() -> Box<i32>",
+            "fn caller() -> Box<i32>",
+            "let mut q: Box<i32> = (Some(alloc_one())).unwrap();",
         ],
         &[],
     );
@@ -557,7 +557,7 @@ pub unsafe fn move_owner() -> *mut i32 {
     return q;
 }
 "#,
-        &["let mut q: Option<Box<i32>> = (p).take();", ".take()"],
+        &["let mut q: Box<i32> = (Some(p)).unwrap();"],
         &[],
     );
 }
@@ -929,7 +929,8 @@ pub unsafe fn caller(count: i32) {
 "#,
         &[
             "alloc_array(count)",
-            "(*arr.as_deref_mut().unwrap()).buffers =\n        malloc((count as usize) * std::mem::size_of::<i32>())",
+            "let mut arr: Box<crate::BufferArray>",
+            "(*arr).buffers =\n        malloc((count as usize) * std::mem::size_of::<i32>())",
         ],
         &["let mut arr: *mut crate::BufferArray = Box::into_raw(Box::new"],
     );
@@ -963,10 +964,10 @@ pub unsafe fn copy_and_sum(src: *mut i32, count: usize) -> i32 {
 "#,
         &[
             "pub unsafe fn copy_and_sum(src: &[i32], count: usize) -> i32",
-            "let mut dest: Option<Box<[i32]>>",
+            "let mut dest: Box<[i32]>",
             "collect::<Vec<i32>>().into_boxed_slice()",
-            "memcpy(((dest).as_deref_mut().unwrap_or(&mut [])).as_mut_ptr() as *mut _,",
-            "drop((dest).take());",
+            "memcpy((&mut (dest)[..]).as_mut_ptr() as *mut _,",
+            "drop(dest);",
         ],
         &[
             "malloc(count * std::mem::size_of::<i32>())",
@@ -975,6 +976,45 @@ pub unsafe fn copy_and_sum(src: *mut i32, count: usize) -> i32 {
             "slice_from_raw_parts_mut",
             "Box::from_raw(",
         ],
+    );
+}
+
+#[test]
+fn test_rewriter_preserves_boxed_slice_offset_projection() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe fn copy_and_sum(src: *mut i32, count: i32) -> i32 {
+    let dest: *mut i32 =
+        malloc(count as usize * std::mem::size_of::<i32>()) as *mut i32;
+    if dest.is_null() {
+        return -1;
+    }
+    let mut i = 0;
+    while i < count {
+        *dest.offset(i as isize) = *src.offset(i as isize);
+        i += 1;
+    }
+    let mut sum = 0;
+    let mut j = 0;
+    while j < count {
+        sum += *dest.offset(j as isize);
+        j += 1;
+    }
+    free(dest as *mut core::ffi::c_void);
+    sum
+}
+"#,
+        &[
+            "let mut dest: Box<[i32]>",
+            "[(i as isize) as usize..]",
+            "[(j as isize) as usize..]",
+        ],
+        &["(&mut (dest)[..])[0]", "sum += (&(dest)[..])[0]"],
     );
 }
 
@@ -1046,10 +1086,10 @@ pub unsafe fn caller(out: *mut core::ffi::c_char) -> i32 {
 "#,
         &[
             "pub unsafe fn helper(out: &[i8]) -> i32",
-            "let mut buf: Option<Box<[i8]>>",
+            "let mut buf: Box<[i8]>",
             "collect::<Vec<i8>>().into_boxed_slice()",
-            "puts(((buf).as_deref_mut().unwrap_or(&mut [])).as_mut_ptr());",
-            "drop((buf).take());",
+            "puts((&mut (buf)[..]).as_mut_ptr());",
+            "drop(buf);",
         ],
         &[
             "malloc(len)",
@@ -1152,10 +1192,11 @@ pub unsafe fn helper() -> i32 {
 }
 "#,
         &[
-            "let mut s: Option<Box<crate::State>>",
-            "Some(Box::new(crate::State { value: <i32 as Default>::default() }))",
-            "touch((s).as_deref_mut().map_or(std::ptr::null_mut::<crate::State>(),",
-            "drop((s).take());",
+            "let mut s: Box<crate::State>",
+            "Some(Box::new(crate::State {",
+            "value: <i32 as Default>::default()",
+            "touch(((s).as_mut()) as *mut crate::State)",
+            "drop(s);",
         ],
         &[
             "calloc(1, std::mem::size_of::<State>())",
@@ -1432,10 +1473,10 @@ pub unsafe fn free_state() {
 }
 "#,
         &[
-            "let mut state: Option<Box<crate::State>>",
-            "if state.is_none() { return; }",
-            "(*state.as_deref_mut().unwrap()).value = 7;",
-            "drop((state).take());",
+            "let mut state: Box<crate::State>",
+            "if false { return; }",
+            "(*state).value = 7;",
+            "drop(state);",
         ],
         &[
             "malloc(std::mem::size_of::<State>())",
@@ -1583,9 +1624,9 @@ pub unsafe fn free_many() {
 }
 "#,
         &[
-            "let mut buf: Option<Box<[i32]>>",
-            "if buf.is_none() { return; }",
-            "drop((buf).take());",
+            "let mut buf: Box<[i32]>",
+            "if false { return; }",
+            "drop(buf);",
         ],
         &[
             "malloc(4 * std::mem::size_of::<i32>())",
@@ -1890,8 +1931,8 @@ pub unsafe fn caller() -> *mut i32 {
 "#,
         &[
             "fn alloc_one() -> *mut i32",
-            "let mut p: Option<Box<i32>>",
-            "Box::into_raw(_x) as *mut i32",
+            "let mut p: Box<i32>",
+            "Box::into_raw(p) as *mut i32",
         ],
         &[],
     );
@@ -1918,8 +1959,8 @@ pub unsafe fn caller() -> *mut i32 {
 "#,
         &[
             "fn alloc_arr() -> *mut i32",
-            "Option<Box<[i32]>>",
-            "as_deref_mut().unwrap_or(&mut [])",
+            "let mut p: Box<[i32]>",
+            "Box::leak(p).as_mut_ptr()",
             "let f: unsafe fn() -> *mut i32 = alloc_arr;",
         ],
         &["-> Option<Box<[i32]>>", "Box::into_raw("],
@@ -1946,7 +1987,7 @@ pub unsafe fn maybe_alloc(flag: bool) -> *mut i32 {
         &[
             "fn maybe_alloc(flag: bool) -> *const i32",
             "std::ptr::null()",
-            "Box::into_raw(_x) as *const i32",
+            "Box::into_raw(p) as *const i32",
         ],
         &["-> Option<Box<i32>>"],
     );
@@ -1970,7 +2011,10 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *q;
 }
 "#,
-        &["null", "Option<&mut"],
+        &[
+            "let mut p: &mut i32",
+            "let mut q: *const i32 = (p) as *mut i32",
+        ],
         &[],
     );
 }
@@ -1992,7 +2036,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *q;
 }
 "#,
-        &["unsafe {", ".as_ref()", "Option<&i32>"],
+        &["unsafe {", ".as_ref()", "let mut q: &i32"],
         &[],
     );
 }
@@ -2103,7 +2147,11 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *q as libc::c_int;
 }
 "#,
-        &["bytemuck::cast_ref", "Option<&u32>", "Option<&mut i32>"],
+        &[
+            "bytemuck::cast_ref",
+            "let mut q: &u32",
+            "let mut p: &mut i32",
+        ],
         &["*mut"],
     );
 }
@@ -2182,7 +2230,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *q as libc::c_int;
 }
 "#,
-        &["as *mut _ as *mut _", "null_mut", "Option<&mut i32>"],
+        &["q = (p) as *mut i32 as *mut i16", "let mut p: &mut i32"],
         &["bytemuck"],
     );
 }
@@ -2232,7 +2280,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *q as libc::c_int;
 }
 "#,
-        &["unsafe {", "as *const i16", ".as_ref()", "Option<&i16>"],
+        &["unsafe {", "as *const i16", ".as_ref()", "let mut q: &i16"],
         &["bytemuck"],
     );
 }
@@ -2253,7 +2301,7 @@ pub fn foo() -> i32 {
     unsafe { *q }
 }
 "#,
-        &["Option<&i32>", "unsafe {", ".as_ref()"],
+        &["let mut q: &i32", "unsafe {", ".as_ref()"],
         &[],
     );
 }
@@ -2274,11 +2322,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *q as libc::c_int;
 }
 "#,
-        &[
-            "as *const _ as *const i16",
-            "Option<&i16>",
-            "Option<&mut i32>",
-        ],
+        &["as *const i16", "let mut q: &i16", "let mut p: &mut i32"],
         &["bytemuck"],
     );
 }
@@ -2530,7 +2574,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p;
 }
 "#,
-        &["Some(&mut", "Option<&mut i32>"],
+        &["let mut p: &mut i32", "Some(&mut"],
         &["*mut", "bytemuck"],
     );
 }
@@ -2548,7 +2592,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p as libc::c_int;
 }
 "#,
-        &["bytemuck::cast_ref", "Option<&u32>"],
+        &["bytemuck::cast_ref", "let mut p: &u32"],
         &["*mut"],
     );
 }
@@ -2704,7 +2748,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return 0 as libc::c_int;
 }
 "#,
-        &["Option<&mut i32>", "null_mut"],
+        &["let mut p: &mut i32", "as *mut i32 =="],
         &[],
     );
 }
@@ -2724,7 +2768,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return bar(p);
 }
 "#,
-        &["fn bar(p: &i32)", "as_deref()).unwrap()"],
+        &["fn bar(p: &i32)", "bar((Some(&*(p))).unwrap())"],
         &[],
     );
 }
@@ -2743,8 +2787,8 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p;
 }
 "#,
-        &["is_none", "Option<&mut i32>"],
-        &["is_null"],
+        &["if false", "let mut p: &mut i32"],
+        &["is_null", "is_none"],
     );
 }
 
@@ -2800,7 +2844,7 @@ pub unsafe extern "C" fn foo() -> (libc::c_int, *mut libc::c_int) {
     return (0 as libc::c_int, p);
 }
 "#,
-        &["Option<&mut"],
+        &["let mut p: &mut i32", "(p) as *mut i32"],
         &[],
     );
 }
@@ -3008,7 +3052,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p;
 }
 "#,
-        &["Option<&mut i32>", "Some(&mut"],
+        &["let mut p: &mut i32", "Some(&mut"],
         &["*mut"],
     );
 }
@@ -3028,7 +3072,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p;
 }
 "#,
-        &["Option<&mut i32>", "Some(&mut"],
+        &["let mut p: &mut i32", "Some(&mut"],
         &["*mut"],
     );
 }
@@ -3531,9 +3575,9 @@ pub unsafe fn foo() -> i32 {
 }
 "#,
         &[
-            "let mut data_array: Option<Box<[i32]>>",
-            "SliceCursor::with_pos(",
-            ".as_deref().unwrap_or(&[])",
+            "let mut data_array: Box<[i32]>",
+            "SliceCursor::with_pos(&(data_array)[..]",
+            "if false { return -1; }",
         ],
         &["SliceCursor::with_pos(&data_array"],
     );
@@ -3562,9 +3606,9 @@ pub unsafe fn foo() -> i32 {
 }
 "#,
         &[
-            "let mut data_array: Option<Box<[i32]>>",
-            "SliceCursor::with_pos(",
-            ".as_deref().unwrap_or(&[])",
+            "let mut data_array: Box<[i32]>",
+            "SliceCursor::with_pos(&(data_array)[..]",
+            "if false { return -1; }",
         ],
         &[
             "let mut data_array: *mut i32",
@@ -3611,9 +3655,9 @@ pub unsafe fn foo() -> i32 {
 }
 "#,
         &[
-            "let mut data_array: Option<Box<[i32]>>",
-            "consume(crate::slice_cursor::SliceCursor::with_pos(",
-            ".as_deref().unwrap_or(&[])",
+            "let mut data_array: Box<[i32]>",
+            "consume(crate::slice_cursor::SliceCursor::with_pos(&(data_array)[..]",
+            "if false { return -1; }",
         ],
         &[
             "let mut last_element:",


### PR DESCRIPTION
## Summary

Adds a local pointer nullity analysis to the pointer replacement pass and uses it to emit non-optional local pointer rewrites when the raw pointer is proven never null.

The previous nullity analysis only identified non-null raw pointer parameters. This change keeps that parameter analysis, then adds a MIR forward dataflow pass for raw pointer locals:

- locals start nullable when they come from nullable params, pointer loads, projections, integer casts, unknown calls, or explicit null constructors
- locals become non-null when they come from addresses/references, known allocation constructors, or already-proven non-null pointer values
- return summaries are solved across call graph SCCs so direct local calls can propagate nullable/non-null raw pointer return behavior
- indirect writes through pointer-to-pointer locations are modeled with Andersen write facts, including direct and function-pointer callee side effects

The rewriter now consumes `non_null_locals` instead of only stable non-null parameters. That lets it rewrite provably non-null owning locals and references as `Box<T>`, `Box<[T]>`, `&T`, or `&mut T` instead of wrapping them in `Option`. Source-variable grouping postprocessing keeps the rewrite conservative: if one MIR local in a grouped source variable may be null, the whole group stays nullable.

This also fixes boxed-slice projection handling while making those rewrites non-optional, so offsets/casts are preserved when projecting from boxed slices into slices, cursors, raw pointers, or references.

## Libc Rewrite Adjustments

The corpus exposed string rewrite cases that needed to move with the pointer-nullity output:

- `strncpy` array rewrites now use safe slice operations, `fill(0)` and `copy_from_slice`, instead of `std::ptr::write_bytes` and `std::ptr::copy_nonoverlapping`
- byte-slice casts use explicit `bytemuck::cast_slice::<_, u8>` / `cast_slice_mut::<_, u8>` calls
- mutable slice receivers are reborrowed correctly when the receiver is already `&mut [T]`
- `strncpy` skips static destinations even when the static is nested under an index/projection

## Generated Output Impact

Using the existing generated outputs:

```bash
grep -R "let .*Option" transformed/bin --include='*.rs' | wc -l
# 227

grep -R "let .*Option" transformed-pointer-nullity/bin --include='*.rs' | wc -l
# 183
```

There are 44 fewer `let ... Option<...>` local declarations in the pointer-nullity output, with no new `let ... Option<...>` lines. Examples:

- `reverse_collide_lib` changes `let mut iterations: Option<&mut i32> = Some(&mut iterations___v);` to `let mut iterations: &mut i32 = Some(&mut iterations___v).unwrap();`
- `pinflate_lib` changes `let mut s: Option<Box<cp_state_t>> = ...` to `let mut s: Box<cp_state_t> = ...`, replacing repeated `as_deref(_mut).unwrap()` / `map_or(null_mut)` access with direct `Box` access

Using the existing unsafe summaries, which were produced by `scripts/find_unsafe.py` followed by `scripts/summarize_unsafe.py`:

```text
total:              73074 -> 73035  (-39)
DerefOfRawPointer:  29000 -> 29001  (+1)
write_bytes:           19 -> 0      (-19)
copy_nonoverlapping:   19 -> 0      (-19)
snprintf:              10 -> 9      (-1)
strncpy:                8 -> 7      (-1)
```

The total unsafe occurrence count drops by 39. Most of that comes from the safe `strncpy` rewrite eliminating `write_bytes` and `copy_nonoverlapping` occurrences. The pointer-nullity rewrite also removes many unnecessary `Option` wrappers in generated locals while preserving nullable cases such as uninitialized pointers, function pointers, FILE handles, and optional allocations.

## Validation

I did not rerun Crat for this PR. Validation here is based on the checked-in commit tests plus the existing generated-output artifacts:

- inspected the commit diff against `origin/master`
- compared `unsafe.txt` and `unsafe2.txt`
- compared `let ... Option` declarations between `transformed/bin` and `transformed-pointer-nullity/bin`
