### PR TITLE
Fix punning aliasing for parent union fields

### DIFF
--- a/crates/union_replacer/src/punning/analysis.rs
+++ b/crates/union_replacer/src/punning/analysis.rs
@@ -1154,14 +1154,28 @@ impl<'tcx, 'a> BodyUnionAccessCollector<'tcx, 'a> {
         implicit_deref_count: usize,
     ) -> Vec<UnionMemoryInstance> {
         let mut out = vec![];
-        for target in alias_target_locs_with_tys(
+        let mut targets = alias_target_locs_with_tys(
             self.context.result,
             body,
             self.tcx,
             def_id,
             place,
             implicit_deref_count,
-        ) {
+        );
+        if targets.is_empty()
+            && implicit_deref_count == 0
+            && let Some(union_place) = self.enclosing_union_place(place)
+        {
+            targets = alias_target_locs_with_tys(
+                self.context.result,
+                body,
+                self.tcx,
+                def_id,
+                union_place,
+                0,
+            );
+        }
+        for target in targets {
             let target_end = self.context.result.ends[target];
             for instance in self.context.union_instances {
                 if ranges_overlap(target, target_end, instance.root, instance.end) {
@@ -1173,6 +1187,26 @@ impl<'tcx, 'a> BodyUnionAccessCollector<'tcx, 'a> {
         let mut seen = FxHashSet::default();
         out.retain(|i| seen.insert(*i));
         out
+    }
+
+    fn enclosing_union_place(&self, place: Place<'tcx>) -> Option<Place<'tcx>> {
+        let mut prefix = Place::from(place.local);
+        let mut current_ty = self.body.local_decls[place.local].ty;
+
+        for elem in place.projection.iter() {
+            if let TyKind::Adt(adt, _) = current_ty.kind()
+                && adt.is_union()
+                && matches!(elem, PlaceElem::Field(_, _))
+            {
+                return Some(prefix);
+            }
+
+            let next_ty = projected_ty(current_ty, elem)?;
+            prefix = prefix.project_deeper(&[elem], self.tcx);
+            current_ty = next_ty;
+        }
+
+        None
     }
 
     fn record_copy<'s, 't>(

--- a/crates/union_replacer/src/punning/test.rs
+++ b/crates/union_replacer/src/punning/test.rs
@@ -498,6 +498,35 @@ mod tests {
     }
 
     #[test]
+    fn pointer_to_parent_union_field() {
+        let code = r#"
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub union OverlapU {
+            pub a: u32,
+            pub b: [u8; 4],
+        }
+
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct ParentOverlap {
+            pub u: OverlapU,
+        }
+
+        pub extern "C" fn pointer_to_parent_union_field() {
+            let mut s = ParentOverlap { u: OverlapU { a: 0 } };
+            unsafe {
+                let p = &mut s as *mut ParentOverlap;
+                (*p).u.a = 0x01020304;
+                use_a((*p).u.b[0] as u32);
+            }
+        }
+        "#;
+
+        run_test(&format!("{BASE}\n{code}"), (2, 2, 1));
+    }
+
+    #[test]
     fn pointer_read_padded_field() {
         let code = r#"
         #[derive(Copy, Clone)]


### PR DESCRIPTION
## Summary

- fixes punning union-use analysis for union fields reached through a pointer to the parent aggregate
- falls back from the projected union field place to the enclosing union place when the direct points-to projection has no targets
- adds a regression test covering `(*p).u.a` / `(*p).u.b` accesses through `*mut ParentOverlap`

## Details

The punning analysis already handled direct pointers to a union field, such as taking `&mut s.u as *mut OverlapU` and then accessing fields through that pointer. The missed case was a pointer to the parent struct, followed by projection into the union field: `(*p).u.a` and `(*p).u.b`.

For those accesses, `aliasing_instances` could fail to find points-to targets for the fully projected field place, so the access was not associated with the overlapping union memory instance. The fix detects when the place projection enters a union via a field projection and, only if the direct lookup is empty and there is no implicit deref fallback already in play, retries the lookup at the enclosing union place.

The added test verifies that this parent-pointer pattern is classified as a punning union use and preserves the expected union-use stats.

## Unsafe Counts

Using the provided `unsafe-old.txt` and `unsafe.txt` summaries:

- total unsafe occurrences: 51,975 -> 51,963 (-12)
- `AccessToUnionField`: 11 -> 0 (-11)
- `assume_init`: 1 -> 0 (-1)
- no unsafe categories increased

I did not run any scripts; these effects are based only on the supplied count files.

## Testing

- Not run, per request not to execute scripts.
