### PR TITLE
Add lifetime flow analysis to borrow inference

### DIFF
--- a/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
@@ -5,8 +5,8 @@ use rustc_index::{
 };
 use rustc_middle::{
     mir::{
-        BinOp, Body, Local, Operand, Place, PlaceElem, RETURN_PLACE, Rvalue, Terminator,
-        visit::Visitor,
+        BinOp, Body, Local, Location, Operand, Place, PlaceElem, RETURN_PLACE, Rvalue, Statement,
+        StatementKind, Terminator, visit::Visitor,
     },
     ty::{Ty, TyCtxt, TyKind},
 };
@@ -140,6 +140,7 @@ pub fn analyze_body_lifetime_flow_result<'tcx>(
     program_functions: &FxHashSet<LocalDefId>,
 ) -> LifetimeFlowResult {
     let mut body_flow = BodyLifetimeFlow::new(body);
+    let derived_place_sources = compute_derived_place_sources(tcx, body, &body_flow);
 
     FlowVisitor {
         tcx,
@@ -147,7 +148,7 @@ pub fn analyze_body_lifetime_flow_result<'tcx>(
         flow: &mut body_flow,
         callee_summaries,
         program_functions,
-        derived_place_sources: FxHashMap::default(),
+        derived_place_sources,
     }
     .visit_body(body);
 
@@ -199,6 +200,314 @@ impl PartialEq for LifetimeFlowResult {
 }
 
 impl Eq for LifetimeFlowResult {}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct DerivedPlaceSourceState {
+    sources: FxHashMap<DerivedPlaceKey, FxHashSet<LifetimeSlot>>,
+}
+
+impl DerivedPlaceSourceState {
+    fn union_from(&mut self, other: &Self) -> bool {
+        let mut changed = false;
+        for (key, sources) in &other.sources {
+            let target = self.sources.entry(key.clone()).or_default();
+            let old_len = target.len();
+            target.extend(sources.iter().copied());
+            changed |= target.len() != old_len;
+        }
+        changed
+    }
+
+    fn kill_place_prefix(&mut self, place: Place<'_>) {
+        let Some(prefix) = derived_place_key_prefix(place) else {
+            return;
+        };
+        self.sources.retain(|key, _| !key.starts_with(&prefix));
+    }
+
+    fn insert_sources<I>(&mut self, key: DerivedPlaceKey, sources: I)
+    where I: IntoIterator<Item = LifetimeSlot> {
+        let sources = sources.into_iter().collect::<FxHashSet<_>>();
+        if sources.is_empty() {
+            return;
+        }
+        self.sources.entry(key).or_default().extend(sources);
+    }
+
+    fn sources_for_key(&self, key: &DerivedPlaceKey) -> Vec<LifetimeSlot> {
+        self.sources
+            .get(key)
+            .map(|sources| sources.iter().copied().collect())
+            .unwrap_or_default()
+    }
+}
+
+impl DerivedPlaceKey {
+    fn starts_with(&self, prefix: &Self) -> bool {
+        self.local == prefix.local && self.projection.starts_with(&prefix.projection)
+    }
+
+    fn rebase_from_prefix(
+        &self,
+        source_prefix: &Self,
+        target_prefix: &Self,
+    ) -> Option<DerivedPlaceKey> {
+        if !self.starts_with(source_prefix) {
+            return None;
+        }
+
+        let suffix = &self.projection[source_prefix.projection.len()..];
+        let mut projection = target_prefix.projection.clone();
+        projection.extend_from_slice(suffix);
+        Some(DerivedPlaceKey {
+            local: target_prefix.local,
+            projection,
+        })
+    }
+}
+
+struct DerivedPlaceDataflow<'flow, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    body: &'flow Body<'tcx>,
+    flow: &'flow BodyLifetimeFlow,
+}
+
+impl<'flow, 'tcx> DerivedPlaceDataflow<'flow, 'tcx> {
+    fn compute(&self) -> FxHashMap<Location, DerivedPlaceSourceState> {
+        let mut in_states =
+            IndexVec::from_elem(DerivedPlaceSourceState::default(), &self.body.basic_blocks);
+
+        loop {
+            let mut changed = false;
+
+            for (block, block_data) in self.body.basic_blocks.iter_enumerated() {
+                let mut state = in_states[block].clone();
+
+                for statement in &block_data.statements {
+                    self.apply_statement_effect(&mut state, statement);
+                }
+
+                if let Some(terminator) = &block_data.terminator {
+                    self.apply_terminator_effect(&mut state, terminator);
+                    for successor in terminator.successors() {
+                        changed |= in_states[successor].union_from(&state);
+                    }
+                }
+            }
+
+            if !changed {
+                break;
+            }
+        }
+
+        let mut by_location = FxHashMap::default();
+        for (block, block_data) in self.body.basic_blocks.iter_enumerated() {
+            let mut state = in_states[block].clone();
+
+            for (statement_index, statement) in block_data.statements.iter().enumerate() {
+                by_location.insert(
+                    Location {
+                        block,
+                        statement_index,
+                    },
+                    state.clone(),
+                );
+                self.apply_statement_effect(&mut state, statement);
+            }
+
+            if let Some(terminator) = &block_data.terminator {
+                by_location.insert(
+                    Location {
+                        block,
+                        statement_index: block_data.statements.len(),
+                    },
+                    state.clone(),
+                );
+                self.apply_terminator_effect(&mut state, terminator);
+            }
+        }
+
+        by_location
+    }
+
+    fn apply_statement_effect(
+        &self,
+        state: &mut DerivedPlaceSourceState,
+        statement: &Statement<'tcx>,
+    ) {
+        let StatementKind::Assign(box (place, rvalue)) = &statement.kind else {
+            return;
+        };
+        self.apply_assign_effect(state, *place, rvalue);
+    }
+
+    fn apply_assign_effect(
+        &self,
+        state: &mut DerivedPlaceSourceState,
+        target: Place<'tcx>,
+        rvalue: &Rvalue<'tcx>,
+    ) {
+        match rvalue {
+            Rvalue::Use(operand)
+            | Rvalue::Cast(_, operand, _)
+            | Rvalue::ShallowInitBox(operand, _)
+            | Rvalue::WrapUnsafeBinder(operand, _) => {
+                self.apply_operand_assign_effect(state, target, operand);
+            }
+            Rvalue::CopyForDeref(place) => {
+                self.apply_place_assign_effect(state, target, *place);
+            }
+            Rvalue::BinaryOp(BinOp::Offset, operands) => {
+                self.apply_operand_assign_effect(state, target, &operands.0);
+            }
+            Rvalue::Ref(..)
+            | Rvalue::RawPtr(..)
+            | Rvalue::ThreadLocalRef(_)
+            | Rvalue::Repeat(..)
+            | Rvalue::Len(..)
+            | Rvalue::BinaryOp(..)
+            | Rvalue::NullaryOp(..)
+            | Rvalue::UnaryOp(..)
+            | Rvalue::Discriminant(..)
+            | Rvalue::Aggregate(..) => {
+                state.kill_place_prefix(target);
+            }
+        }
+    }
+
+    fn apply_operand_assign_effect(
+        &self,
+        state: &mut DerivedPlaceSourceState,
+        target: Place<'tcx>,
+        operand: &Operand<'tcx>,
+    ) {
+        let before = state.clone();
+        state.kill_place_prefix(target);
+
+        let Some(source_place) = operand.place() else {
+            return;
+        };
+
+        self.copy_derived_descendants(&before, state, target, source_place);
+        if let Some(target_key) = derived_place_key(target) {
+            state.insert_sources(
+                target_key,
+                self.place_sources_from_state(&before, source_place),
+            );
+        }
+    }
+
+    fn apply_place_assign_effect(
+        &self,
+        state: &mut DerivedPlaceSourceState,
+        target: Place<'tcx>,
+        source: Place<'tcx>,
+    ) {
+        let before = state.clone();
+        state.kill_place_prefix(target);
+
+        self.copy_derived_descendants(&before, state, target, source);
+        if let Some(target_key) = derived_place_key(target) {
+            state.insert_sources(target_key, self.place_sources_from_state(&before, source));
+        }
+    }
+
+    fn apply_terminator_effect(
+        &self,
+        state: &mut DerivedPlaceSourceState,
+        terminator: &Terminator<'tcx>,
+    ) {
+        let Some(call) = terminator.as_call(self.tcx) else {
+            return;
+        };
+
+        let before = state.clone();
+        state.kill_place_prefix(call.destination);
+
+        let Some(arg0) = call.args.first() else {
+            return;
+        };
+        if !is_known_slice_split_return_call(&call.func, self.tcx)
+            || !self.operand_is_slice_like_ref(&arg0.node)
+            || !place_is_slice_pair_ref(self.body, self.tcx, call.destination)
+        {
+            return;
+        }
+
+        let sources = self.operand_sources_from_state(&before, &arg0.node);
+        for field_index in [0, 1] {
+            if let Some(key) = derived_field_key(call.destination, field_index) {
+                state.insert_sources(key, sources.iter().copied());
+            }
+        }
+    }
+
+    fn copy_derived_descendants(
+        &self,
+        before: &DerivedPlaceSourceState,
+        state: &mut DerivedPlaceSourceState,
+        target: Place<'tcx>,
+        source: Place<'tcx>,
+    ) {
+        let Some(source_prefix) = derived_place_key_prefix(source) else {
+            return;
+        };
+        let Some(target_prefix) = derived_place_key_prefix(target) else {
+            return;
+        };
+
+        for (key, sources) in &before.sources {
+            let Some(target_key) = key.rebase_from_prefix(&source_prefix, &target_prefix) else {
+                continue;
+            };
+            state.insert_sources(target_key, sources.iter().copied());
+        }
+    }
+
+    fn operand_sources_from_state(
+        &self,
+        state: &DerivedPlaceSourceState,
+        operand: &Operand<'tcx>,
+    ) -> Vec<LifetimeSlot> {
+        match operand {
+            Operand::Copy(place) | Operand::Move(place) => {
+                self.place_sources_from_state(state, *place)
+            }
+            Operand::Constant(_) => vec![],
+        }
+    }
+
+    fn place_sources_from_state(
+        &self,
+        state: &DerivedPlaceSourceState,
+        place: Place<'tcx>,
+    ) -> Vec<LifetimeSlot> {
+        if let Some(slot) = self.flow.slot_for_place(place, 0) {
+            return vec![slot];
+        }
+        let Some(key) = derived_place_key(place) else {
+            return vec![];
+        };
+        state.sources_for_key(&key)
+    }
+
+    fn operand_is_slice_like_ref(&self, operand: &Operand<'tcx>) -> bool {
+        match operand {
+            Operand::Copy(place) | Operand::Move(place) => {
+                is_slice_like_ref_ty(place.ty(self.body, self.tcx).ty)
+            }
+            Operand::Constant(_) => false,
+        }
+    }
+}
+
+fn compute_derived_place_sources<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    flow: &BodyLifetimeFlow,
+) -> FxHashMap<Location, DerivedPlaceSourceState> {
+    DerivedPlaceDataflow { tcx, body, flow }.compute()
+}
 
 impl BodyLifetimeFlow {
     fn new(body: &Body<'_>) -> Self {
@@ -399,47 +708,47 @@ struct FlowVisitor<'flow, 'summary, 'tcx> {
     flow: &'flow mut BodyLifetimeFlow,
     callee_summaries: &'summary FxHashMap<LocalDefId, LifetimeFlowSummary>,
     program_functions: &'summary FxHashSet<LocalDefId>,
-    derived_place_sources: FxHashMap<DerivedPlaceKey, LifetimeSlot>,
+    derived_place_sources: FxHashMap<Location, DerivedPlaceSourceState>,
 }
 
 impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
-    fn assign_from_operand(&mut self, target: LifetimeSlot, operand: &Operand<'tcx>) {
-        let Some(source) = self.operand_slot(operand) else {
-            return;
-        };
-        self.flow.add_flow(source, target);
-        self.flow.add_descendant_aliases(source, target);
-    }
-
-    fn operand_slot(&self, operand: &Operand<'tcx>) -> Option<LifetimeSlot> {
-        match operand {
-            Operand::Copy(place) | Operand::Move(place) => self.place_slot_or_derived(*place),
-            Operand::Constant(_) => None,
+    fn assign_from_operand(
+        &mut self,
+        target: LifetimeSlot,
+        operand: &Operand<'tcx>,
+        location: Location,
+    ) {
+        for source in self.operand_slots(operand, location) {
+            self.flow.add_flow(source, target);
+            self.flow.add_descendant_aliases(source, target);
         }
     }
 
-    fn place_slot_or_derived(&self, place: Place<'tcx>) -> Option<LifetimeSlot> {
-        self.flow
-            .slot_for_place(place, 0)
-            .or_else(|| self.derived_place_source(place))
+    fn operand_slots(&self, operand: &Operand<'tcx>, location: Location) -> Vec<LifetimeSlot> {
+        match operand {
+            Operand::Copy(place) | Operand::Move(place) => {
+                self.place_slots_or_derived(*place, location)
+            }
+            Operand::Constant(_) => vec![],
+        }
     }
 
-    fn derived_place_source(&self, place: Place<'tcx>) -> Option<LifetimeSlot> {
-        let key = derived_place_key(place)?;
-        self.derived_place_sources.get(&key).copied()
+    fn place_slots_or_derived(&self, place: Place<'tcx>, location: Location) -> Vec<LifetimeSlot> {
+        if let Some(slot) = self.flow.slot_for_place(place, 0) {
+            return vec![slot];
+        }
+        self.derived_place_sources(place, location)
     }
 
-    fn record_derived_field_source(
-        &mut self,
-        place: Place<'tcx>,
-        field_index: usize,
-        source: LifetimeSlot,
-    ) -> bool {
-        let Some(key) = derived_field_key(place, field_index) else {
-            return false;
+    fn derived_place_sources(&self, place: Place<'tcx>, location: Location) -> Vec<LifetimeSlot> {
+        let Some(key) = derived_place_key(place) else {
+            return vec![];
         };
-        self.derived_place_sources.insert(key, source);
-        true
+        self.derived_place_sources
+            .get(&location)
+            .and_then(|state| state.sources.get(&key))
+            .map(|sources| sources.iter().copied().collect())
+            .unwrap_or_default()
     }
 
     fn operand_is_slice_like_ref(&self, operand: &Operand<'tcx>) -> bool {
@@ -487,7 +796,11 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
         }
     }
 
-    fn apply_known_input_return_call(&mut self, call: &MirFunctionCall<'_, 'tcx>) -> bool {
+    fn apply_known_input_return_call(
+        &mut self,
+        call: &MirFunctionCall<'_, 'tcx>,
+        location: Location,
+    ) -> bool {
         let Some(arg0) = call.args.first() else {
             return false;
         };
@@ -501,33 +814,33 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
         };
 
         if is_provenance_preserving_pointer_method(&call.func, self.tcx) {
-            self.assign_known_return_from_operand(destination, &arg0.node);
+            self.assign_known_return_from_operand(destination, &arg0.node, location);
             return true;
         }
 
         if is_known_slice_view_return_call(&call.func, self.tcx)
             && self.place_is_slice_like_ref(call.destination)
         {
-            self.assign_known_return_from_operand(destination, &arg0.node);
+            self.assign_known_return_from_operand(destination, &arg0.node, location);
             return true;
         }
 
         if is_known_slice_index_return_call(&call.func, self.tcx)
             && self.operand_is_slice_like_ref(&arg0.node)
         {
-            self.assign_known_return_from_operand(destination, &arg0.node);
+            self.assign_known_return_from_operand(destination, &arg0.node, location);
             return true;
         }
 
         if is_known_c_string_search_return_call(&call.func, self.tcx) {
-            self.assign_known_return_from_operand(destination, &arg0.node);
+            self.assign_known_return_from_operand(destination, &arg0.node, location);
             return true;
         }
 
         if is_known_memchr_return_call(&call.func, self.tcx)
             && self.operand_is_slice_like_ref(&arg0.node)
         {
-            self.assign_known_return_from_operand(destination, &arg0.node);
+            self.assign_known_return_from_operand(destination, &arg0.node, location);
             return true;
         }
 
@@ -546,19 +859,22 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
             return false;
         }
 
-        let Some(source) = self.operand_slot(arg0) else {
-            return false;
-        };
-
-        self.record_derived_field_source(call.destination, 0, source)
-            | self.record_derived_field_source(call.destination, 1, source)
+        true
     }
 
-    fn assign_known_return_from_operand(&mut self, target: LifetimeSlot, operand: &Operand<'tcx>) {
-        if let Some(source) = self.operand_slot(operand) {
-            self.flow.add_flow(source, target);
-        } else {
+    fn assign_known_return_from_operand(
+        &mut self,
+        target: LifetimeSlot,
+        operand: &Operand<'tcx>,
+        location: Location,
+    ) {
+        let sources = self.operand_slots(operand, location);
+        if sources.is_empty() {
             self.flow.mark_unknown(target);
+        } else {
+            for source in sources {
+                self.flow.add_flow(source, target);
+            }
         }
     }
 
@@ -644,7 +960,7 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
         &mut self,
         place: &Place<'tcx>,
         rvalue: &Rvalue<'tcx>,
-        _location: rustc_middle::mir::Location,
+        location: rustc_middle::mir::Location,
     ) {
         let rvalue_ty = rvalue.ty(self.body, self.tcx);
         if pointer_slot_count(rvalue_ty) == 0 {
@@ -659,9 +975,11 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
             Rvalue::Use(operand)
             | Rvalue::Cast(_, operand, _)
             | Rvalue::ShallowInitBox(operand, _)
-            | Rvalue::WrapUnsafeBinder(operand, _) => self.assign_from_operand(target, operand),
+            | Rvalue::WrapUnsafeBinder(operand, _) => {
+                self.assign_from_operand(target, operand, location)
+            }
             Rvalue::CopyForDeref(place) => {
-                if let Some(source) = self.place_slot_or_derived(*place) {
+                for source in self.place_slots_or_derived(*place, location) {
                     self.flow.add_flow(source, target);
                     self.flow.add_descendant_aliases(source, target);
                 }
@@ -671,7 +989,7 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
             }
             Rvalue::ThreadLocalRef(_) => self.flow.mark_unknown(target),
             Rvalue::BinaryOp(BinOp::Offset, operands) => {
-                self.assign_from_operand(target, &operands.0);
+                self.assign_from_operand(target, &operands.0, location);
             }
             Rvalue::Repeat(..)
             | Rvalue::Len(..)
@@ -686,13 +1004,13 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
     fn visit_terminator(
         &mut self,
         terminator: &Terminator<'tcx>,
-        _location: rustc_middle::mir::Location,
+        location: rustc_middle::mir::Location,
     ) {
         let Some(call) = terminator.as_call(self.tcx) else {
             return;
         };
 
-        if self.apply_known_input_return_call(&call) {
+        if self.apply_known_input_return_call(&call, location) {
             return;
         }
 
@@ -701,7 +1019,7 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
             && let Some(arg0) = call.args.first()
         {
             if let Some(destination) = self.flow.slot_for_place(call.destination, 0) {
-                self.assign_from_operand(destination, &arg0.node);
+                self.assign_from_operand(destination, &arg0.node, location);
             }
             return;
         }

--- a/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
@@ -1,12 +1,12 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_index::{
-    bit_set::{DenseBitSet, SparseBitMatrix},
     IndexVec,
+    bit_set::{DenseBitSet, SparseBitMatrix},
 };
 use rustc_middle::{
     mir::{
-        visit::Visitor, BinOp, Body, Local, Operand, Place, PlaceElem, Rvalue, Terminator,
-        RETURN_PLACE,
+        BinOp, Body, Local, Operand, Place, PlaceElem, RETURN_PLACE, Rvalue, Terminator,
+        visit::Visitor,
     },
     ty::{Ty, TyCtxt, TyKind},
 };

--- a/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
@@ -1,0 +1,694 @@
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_index::{
+    IndexVec,
+    bit_set::{DenseBitSet, SparseBitMatrix},
+};
+use rustc_middle::{
+    mir::{
+        Body, Local, Operand, Place, PlaceElem, RETURN_PLACE, Rvalue, Terminator, visit::Visitor,
+    },
+    ty::{Ty, TyCtxt, TyKind},
+};
+use rustc_span::def_id::{DefId, LocalDefId};
+
+use super::is_borrowing_method;
+use crate::{
+    analyses::mir::{CallGraphPostOrder, CallKind, MirFunctionCall, TerminatorExt},
+    utils::rustc::RustProgram,
+};
+
+pub const MAX_SIGNATURE_SLOT_DEPTH: u8 = 3;
+
+rustc_index::newtype_index! {
+    #[orderable]
+    #[debug_format = "S_({})"]
+    pub struct LifetimeSlot {}
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SignatureRoot {
+    Return,
+    Arg(Local),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SignatureSlot {
+    pub root: SignatureRoot,
+    pub depth: u8,
+}
+
+#[derive(Clone, Debug)]
+pub struct LifetimeFlowSummary {
+    pub slots: IndexVec<LifetimeSlot, SignatureSlot>,
+    pub value_flows: SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
+    pub storage_aliases: SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
+    pub unknown_targets: DenseBitSet<LifetimeSlot>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct LocalSlot {
+    pub local: Local,
+    pub depth: u8,
+}
+
+#[derive(Clone, Debug)]
+pub struct BodyLifetimeFlow {
+    pub slots: IndexVec<LifetimeSlot, LocalSlot>,
+    slot_map: FxHashMap<(usize, u8), LifetimeSlot>,
+    pub value_flows: SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
+    pub storage_aliases: SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
+    pub unknown_targets: DenseBitSet<LifetimeSlot>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LifetimeFlowResult {
+    pub summary: LifetimeFlowSummary,
+    pub body: BodyLifetimeFlow,
+}
+
+pub type LifetimeFlowResults = FxHashMap<LocalDefId, LifetimeFlowResult>;
+
+pub fn analyze_program_lifetime_flow(program: &RustProgram<'_>) -> LifetimeFlowResults {
+    let tcx = program.tcx;
+    let program_functions: FxHashSet<_> = program.functions.iter().copied().collect();
+
+    let mut results = FxHashMap::default();
+    results.reserve(program.functions.len());
+    let mut summaries = FxHashMap::default();
+    summaries.reserve(program.functions.len());
+
+    for &did in &program.functions {
+        let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+        let result = empty_lifetime_flow_result(&body);
+        summaries.insert(did, result.summary.clone());
+        results.insert(did, result);
+    }
+
+    let call_graph = CallGraphPostOrder::new(program);
+    for scc in call_graph.sccs() {
+        loop {
+            let mut changed = false;
+
+            for &did in scc {
+                let did = did.expect_local();
+                let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+                let result =
+                    analyze_body_lifetime_flow_result(tcx, &body, &summaries, &program_functions);
+
+                if results.get(&did) != Some(&result) {
+                    summaries.insert(did, result.summary.clone());
+                    results.insert(did, result);
+                    changed = true;
+                }
+            }
+
+            if !changed {
+                break;
+            }
+        }
+    }
+
+    results
+}
+
+#[allow(dead_code)]
+pub fn analyze_body_lifetime_flow<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    callee_summaries: &FxHashMap<LocalDefId, LifetimeFlowSummary>,
+    program_functions: &FxHashSet<LocalDefId>,
+) -> LifetimeFlowSummary {
+    analyze_body_lifetime_flow_result(tcx, body, callee_summaries, program_functions).summary
+}
+
+pub fn analyze_body_lifetime_flow_result<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    callee_summaries: &FxHashMap<LocalDefId, LifetimeFlowSummary>,
+    program_functions: &FxHashSet<LocalDefId>,
+) -> LifetimeFlowResult {
+    let mut body_flow = BodyLifetimeFlow::new(body);
+
+    FlowVisitor {
+        tcx,
+        body,
+        flow: &mut body_flow,
+        callee_summaries,
+        program_functions,
+    }
+    .visit_body(body);
+
+    let body_flow = body_flow.closed();
+    let summary = body_flow.to_summary(body);
+
+    LifetimeFlowResult {
+        summary,
+        body: body_flow,
+    }
+}
+
+fn empty_lifetime_flow_result(body: &Body<'_>) -> LifetimeFlowResult {
+    let body_flow = BodyLifetimeFlow::new(body).closed();
+    let summary = body_flow.to_summary(body);
+    LifetimeFlowResult {
+        summary,
+        body: body_flow,
+    }
+}
+
+impl PartialEq for LifetimeFlowSummary {
+    fn eq(&self, other: &Self) -> bool {
+        self.slots == other.slots
+            && same_matrix(&self.value_flows, &other.value_flows)
+            && same_matrix(&self.storage_aliases, &other.storage_aliases)
+            && self.unknown_targets == other.unknown_targets
+    }
+}
+
+impl Eq for LifetimeFlowSummary {}
+
+impl PartialEq for BodyLifetimeFlow {
+    fn eq(&self, other: &Self) -> bool {
+        self.slots == other.slots
+            && self.slot_map == other.slot_map
+            && same_matrix(&self.value_flows, &other.value_flows)
+            && same_matrix(&self.storage_aliases, &other.storage_aliases)
+            && self.unknown_targets == other.unknown_targets
+    }
+}
+
+impl Eq for BodyLifetimeFlow {}
+
+impl PartialEq for LifetimeFlowResult {
+    fn eq(&self, other: &Self) -> bool {
+        self.summary == other.summary && self.body == other.body
+    }
+}
+
+impl Eq for LifetimeFlowResult {}
+
+impl BodyLifetimeFlow {
+    fn new(body: &Body<'_>) -> Self {
+        let mut slots = IndexVec::new();
+        let mut slot_map = FxHashMap::default();
+
+        for (local, local_decl) in body.local_decls.iter_enumerated() {
+            for depth in 0..pointer_slot_count(local_decl.ty) {
+                let slot = slots.push(LocalSlot { local, depth });
+                slot_map.insert((local.index(), depth), slot);
+            }
+        }
+
+        let domain_size = slots.len();
+        BodyLifetimeFlow {
+            slots,
+            slot_map,
+            value_flows: SparseBitMatrix::new(domain_size),
+            storage_aliases: SparseBitMatrix::new(domain_size),
+            unknown_targets: DenseBitSet::new_empty(domain_size),
+        }
+    }
+
+    pub fn slot_for_local(&self, local: Local, depth: u8) -> Option<LifetimeSlot> {
+        self.slot_map.get(&(local.index(), depth)).copied()
+    }
+
+    pub fn depth0_value_flows(&self) -> Vec<(Local, Local)> {
+        let mut flows = vec![];
+
+        for source in self.value_flows.rows() {
+            let source_slot = self.slots[source];
+            if source_slot.depth != 0 {
+                continue;
+            }
+
+            let Some(targets) = self.value_flows.row(source) else {
+                continue;
+            };
+
+            for target in targets.iter() {
+                let target_slot = self.slots[target];
+                if target_slot.depth == 0 {
+                    flows.push((source_slot.local, target_slot.local));
+                }
+            }
+        }
+
+        flows
+    }
+
+    fn slot_for_place(&self, place: Place<'_>, extra_depth: u8) -> Option<LifetimeSlot> {
+        let base_depth = place_deref_depth(place)?;
+        let depth = base_depth.checked_add(extra_depth)?;
+        self.slot_for_local(place.local, depth)
+    }
+
+    fn slot_after(&self, slot: LifetimeSlot, offset: u8) -> Option<LifetimeSlot> {
+        let local_slot = self.slots[slot];
+        self.slot_for_local(local_slot.local, local_slot.depth.checked_add(offset)?)
+    }
+
+    fn add_flow(&mut self, source: LifetimeSlot, target: LifetimeSlot) {
+        if source != target {
+            self.value_flows.insert(source, target);
+        }
+    }
+
+    fn add_alias(&mut self, a: LifetimeSlot, b: LifetimeSlot) {
+        if a == b {
+            return;
+        }
+        self.storage_aliases.insert(a, b);
+        self.storage_aliases.insert(b, a);
+    }
+
+    fn add_descendant_aliases(&mut self, a: LifetimeSlot, b: LifetimeSlot) {
+        for offset in 1..=MAX_SIGNATURE_SLOT_DEPTH {
+            let Some(a_descendant) = self.slot_after(a, offset) else {
+                break;
+            };
+            let Some(b_descendant) = self.slot_after(b, offset) else {
+                break;
+            };
+            self.add_alias(a_descendant, b_descendant);
+        }
+    }
+
+    fn mark_unknown(&mut self, target: LifetimeSlot) {
+        self.unknown_targets.insert(target);
+    }
+
+    fn mark_unknown_place_slots(&mut self, place: Place<'_>, start_depth: u8) {
+        for depth in start_depth..MAX_SIGNATURE_SLOT_DEPTH {
+            let Some(slot) = self.slot_for_place(place, depth) else {
+                break;
+            };
+            self.mark_unknown(slot);
+        }
+    }
+
+    fn closed(mut self) -> Self {
+        self.storage_aliases = transitive_closure(&self.storage_aliases, self.slots.len());
+
+        let mut combined = SparseBitMatrix::new(self.slots.len());
+        union_matrix_into(&mut combined, &self.value_flows);
+        union_matrix_into(&mut combined, &self.storage_aliases);
+        self.value_flows = transitive_closure(&combined, self.slots.len());
+
+        let mut unknown = self.unknown_targets.clone();
+        for source in self.unknown_targets.iter() {
+            if let Some(targets) = self.value_flows.row(source) {
+                unknown.union(targets);
+            }
+        }
+        self.unknown_targets = unknown;
+
+        self
+    }
+
+    fn to_summary(&self, body: &Body<'_>) -> LifetimeFlowSummary {
+        let mut slots = IndexVec::new();
+        let mut internal_to_summary = FxHashMap::default();
+
+        for local in std::iter::once(RETURN_PLACE).chain(body.args_iter()) {
+            let root = if local == RETURN_PLACE {
+                SignatureRoot::Return
+            } else {
+                SignatureRoot::Arg(local)
+            };
+
+            for depth in 0..pointer_slot_count(body.local_decls[local].ty) {
+                let Some(internal) = self.slot_for_local(local, depth) else {
+                    continue;
+                };
+                let summary = slots.push(SignatureSlot { root, depth });
+                internal_to_summary.insert(internal, summary);
+            }
+        }
+
+        let mut value_flows = SparseBitMatrix::new(slots.len());
+        let mut storage_aliases = SparseBitMatrix::new(slots.len());
+        let mut unknown_targets = DenseBitSet::new_empty(slots.len());
+
+        for source in self.value_flows.rows() {
+            let Some(&summary_source) = internal_to_summary.get(&source) else {
+                continue;
+            };
+            let Some(targets) = self.value_flows.row(source) else {
+                continue;
+            };
+            for target in targets.iter() {
+                let Some(&summary_target) = internal_to_summary.get(&target) else {
+                    continue;
+                };
+                if observable_value_target(slots[summary_target]) {
+                    value_flows.insert(summary_source, summary_target);
+                }
+            }
+        }
+
+        for source in self.storage_aliases.rows() {
+            let Some(&summary_source) = internal_to_summary.get(&source) else {
+                continue;
+            };
+            let Some(targets) = self.storage_aliases.row(source) else {
+                continue;
+            };
+            for target in targets.iter() {
+                let Some(&summary_target) = internal_to_summary.get(&target) else {
+                    continue;
+                };
+                storage_aliases.insert(summary_source, summary_target);
+            }
+        }
+
+        for target in self.unknown_targets.iter() {
+            let Some(&summary_target) = internal_to_summary.get(&target) else {
+                continue;
+            };
+            if observable_value_target(slots[summary_target]) {
+                unknown_targets.insert(summary_target);
+            }
+        }
+
+        LifetimeFlowSummary {
+            slots,
+            value_flows,
+            storage_aliases,
+            unknown_targets,
+        }
+    }
+}
+
+struct FlowVisitor<'flow, 'summary, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    body: &'flow Body<'tcx>,
+    flow: &'flow mut BodyLifetimeFlow,
+    callee_summaries: &'summary FxHashMap<LocalDefId, LifetimeFlowSummary>,
+    program_functions: &'summary FxHashSet<LocalDefId>,
+}
+
+impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
+    fn assign_from_operand(&mut self, target: LifetimeSlot, operand: &Operand<'tcx>) {
+        let Some(source) = self.operand_slot(operand) else {
+            return;
+        };
+        self.flow.add_flow(source, target);
+        self.flow.add_descendant_aliases(source, target);
+    }
+
+    fn operand_slot(&self, operand: &Operand<'tcx>) -> Option<LifetimeSlot> {
+        match operand {
+            Operand::Copy(place) | Operand::Move(place) => self.flow.slot_for_place(*place, 0),
+            Operand::Constant(_) => None,
+        }
+    }
+
+    fn assign_from_place_address(&mut self, target: LifetimeSlot, place: Place<'tcx>) {
+        match place_deref_depth(place) {
+            Some(0) => {
+                if let Some(place_slot) = self.flow.slot_for_place(place, 0)
+                    && let Some(target_pointee) = self.flow.slot_after(target, 1)
+                {
+                    self.flow.add_alias(target_pointee, place_slot);
+                }
+            }
+            Some(deref_depth) => {
+                if let Some(source) = self
+                    .flow
+                    .slot_for_local(place.local, deref_depth.saturating_sub(1))
+                {
+                    self.flow.add_flow(source, target);
+                    self.flow.add_descendant_aliases(source, target);
+                }
+            }
+            None => {
+                self.flow.mark_unknown(target);
+            }
+        }
+    }
+
+    fn apply_call_summary(
+        &mut self,
+        call: &MirFunctionCall<'_, 'tcx>,
+        summary: &LifetimeFlowSummary,
+    ) {
+        for source in summary.value_flows.rows() {
+            let Some(source_slot) = self.instantiate_signature_slot(call, summary.slots[source])
+            else {
+                continue;
+            };
+            let Some(targets) = summary.value_flows.row(source) else {
+                continue;
+            };
+            for target in targets.iter() {
+                let Some(target_slot) =
+                    self.instantiate_signature_slot(call, summary.slots[target])
+                else {
+                    continue;
+                };
+                self.flow.add_flow(source_slot, target_slot);
+            }
+        }
+
+        for source in summary.storage_aliases.rows() {
+            let Some(source_slot) = self.instantiate_signature_slot(call, summary.slots[source])
+            else {
+                continue;
+            };
+            let Some(targets) = summary.storage_aliases.row(source) else {
+                continue;
+            };
+            for target in targets.iter() {
+                let Some(target_slot) =
+                    self.instantiate_signature_slot(call, summary.slots[target])
+                else {
+                    continue;
+                };
+                self.flow.add_alias(source_slot, target_slot);
+            }
+        }
+
+        for target in summary.unknown_targets.iter() {
+            if let Some(target_slot) = self.instantiate_signature_slot(call, summary.slots[target])
+            {
+                self.flow.mark_unknown(target_slot);
+            }
+        }
+    }
+
+    fn instantiate_signature_slot(
+        &self,
+        call: &MirFunctionCall<'_, 'tcx>,
+        slot: SignatureSlot,
+    ) -> Option<LifetimeSlot> {
+        match slot.root {
+            SignatureRoot::Return => self.flow.slot_for_place(call.destination, slot.depth),
+            SignatureRoot::Arg(local) => {
+                let arg_index = local.index().checked_sub(1)?;
+                let arg = call.args.get(arg_index)?;
+                let place = arg.node.place()?;
+                self.flow.slot_for_place(place, slot.depth)
+            }
+        }
+    }
+
+    fn mark_unknown_call_effects(&mut self, call: &MirFunctionCall<'_, 'tcx>) {
+        self.flow.mark_unknown_place_slots(call.destination, 0);
+
+        for arg in call.args {
+            let Some(place) = arg.node.place() else {
+                continue;
+            };
+            self.flow.mark_unknown_place_slots(place, 1);
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
+    fn visit_assign(
+        &mut self,
+        place: &Place<'tcx>,
+        rvalue: &Rvalue<'tcx>,
+        _location: rustc_middle::mir::Location,
+    ) {
+        let rvalue_ty = rvalue.ty(self.body, self.tcx);
+        if pointer_slot_count(rvalue_ty) == 0 {
+            return;
+        }
+
+        let Some(target) = self.flow.slot_for_place(*place, 0) else {
+            return;
+        };
+
+        match rvalue {
+            Rvalue::Use(operand)
+            | Rvalue::Cast(_, operand, _)
+            | Rvalue::ShallowInitBox(operand, _)
+            | Rvalue::WrapUnsafeBinder(operand, _) => self.assign_from_operand(target, operand),
+            Rvalue::CopyForDeref(place) => {
+                if let Some(source) = self.flow.slot_for_place(*place, 0) {
+                    self.flow.add_flow(source, target);
+                    self.flow.add_descendant_aliases(source, target);
+                }
+            }
+            Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) => {
+                self.assign_from_place_address(target, *place);
+            }
+            Rvalue::ThreadLocalRef(_) => self.flow.mark_unknown(target),
+            Rvalue::Repeat(..)
+            | Rvalue::Len(..)
+            | Rvalue::BinaryOp(..)
+            | Rvalue::NullaryOp(..)
+            | Rvalue::UnaryOp(..)
+            | Rvalue::Discriminant(..)
+            | Rvalue::Aggregate(..) => self.flow.mark_unknown(target),
+        }
+    }
+
+    fn visit_terminator(
+        &mut self,
+        terminator: &Terminator<'tcx>,
+        _location: rustc_middle::mir::Location,
+    ) {
+        let Some(call) = terminator.as_call(self.tcx) else {
+            return;
+        };
+
+        if let CallKind::RustLib(def_id) = &call.func
+            && is_borrowing_method(*def_id, self.tcx)
+            && let Some(arg0) = call.args.first()
+        {
+            if let Some(destination) = self.flow.slot_for_place(call.destination, 0) {
+                self.assign_from_operand(destination, &arg0.node);
+            }
+            return;
+        }
+
+        if let CallKind::RustLib(def_id) = &call.func
+            && is_null_pointer_constructor(*def_id, self.tcx)
+        {
+            return;
+        }
+
+        match &call.func {
+            CallKind::FreeStanding(callee) if self.program_functions.contains(callee) => {
+                if let Some(summary) = self.callee_summaries.get(callee) {
+                    self.apply_call_summary(&call, summary);
+                } else {
+                    self.mark_unknown_call_effects(&call);
+                }
+            }
+            _ => self.mark_unknown_call_effects(&call),
+        }
+    }
+}
+
+fn observable_value_target(slot: SignatureSlot) -> bool {
+    match slot.root {
+        SignatureRoot::Return => true,
+        SignatureRoot::Arg(_) => slot.depth > 0,
+    }
+}
+
+fn pointer_slot_count(mut ty: Ty<'_>) -> u8 {
+    let mut depth = 0;
+    while depth < MAX_SIGNATURE_SLOT_DEPTH {
+        let Some(pointee) = pointer_pointee_ty(ty) else {
+            break;
+        };
+        depth += 1;
+        ty = pointee;
+    }
+    depth
+}
+
+fn pointer_pointee_ty(ty: Ty<'_>) -> Option<Ty<'_>> {
+    match ty.kind() {
+        TyKind::RawPtr(inner, _) => Some(*inner),
+        TyKind::Ref(_, inner, _) => Some(*inner),
+        _ => None,
+    }
+}
+
+fn is_null_pointer_constructor(def_id: DefId, tcx: TyCtxt<'_>) -> bool {
+    !def_id.is_local() && {
+        let name = tcx.item_name(def_id);
+        let name = name.as_str();
+        name == "null" || name == "null_mut"
+    }
+}
+
+fn place_deref_depth(place: Place<'_>) -> Option<u8> {
+    let mut depth = 0u8;
+    for projection in place.projection {
+        match projection {
+            PlaceElem::Deref => {
+                depth = depth.checked_add(1)?;
+            }
+            PlaceElem::OpaqueCast(_) => {}
+            _ => return None,
+        }
+    }
+    Some(depth)
+}
+
+fn transitive_closure(
+    edges: &SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
+    domain_size: usize,
+) -> SparseBitMatrix<LifetimeSlot, LifetimeSlot> {
+    let mut closure = SparseBitMatrix::new(domain_size);
+    let mut stack = vec![];
+    let mut visited = DenseBitSet::new_empty(domain_size);
+
+    for source in (0..domain_size).map(LifetimeSlot::from_usize) {
+        stack.clear();
+        visited.clear();
+
+        if let Some(targets) = edges.row(source) {
+            stack.extend(targets.iter());
+        }
+
+        while let Some(target) = stack.pop() {
+            if !visited.insert(target) {
+                continue;
+            }
+            if source != target {
+                closure.insert(source, target);
+            }
+            if let Some(next_targets) = edges.row(target) {
+                stack.extend(next_targets.iter());
+            }
+        }
+    }
+
+    closure
+}
+
+fn union_matrix_into(
+    target: &mut SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
+    source: &SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
+) {
+    for row in source.rows() {
+        if let Some(bits) = source.row(row) {
+            target.union_row(row, bits);
+        }
+    }
+}
+
+fn same_matrix(
+    lhs: &SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
+    rhs: &SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
+) -> bool {
+    for row in lhs.rows() {
+        if lhs.row(row) != rhs.row(row) {
+            return false;
+        }
+    }
+    for row in rhs.rows() {
+        if lhs.row(row) != rhs.row(row) {
+            return false;
+        }
+    }
+    true
+}

--- a/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
@@ -5,8 +5,8 @@ use rustc_index::{
 };
 use rustc_middle::{
     mir::{
-        BinOp, Body, Local, Location, Operand, Place, PlaceElem, RETURN_PLACE, Rvalue, Statement,
-        StatementKind, Terminator, visit::Visitor,
+        BinOp, Body, Const, ConstOperand, ConstValue, Local, Location, Operand, Place, PlaceElem,
+        RETURN_PLACE, Rvalue, Statement, StatementKind, Terminator, visit::Visitor,
     },
     ty::{Ty, TyCtxt, TyKind},
 };
@@ -718,7 +718,15 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
         operand: &Operand<'tcx>,
         location: Location,
     ) {
-        for source in self.operand_slots(operand, location) {
+        let sources = self.operand_slots(operand, location);
+        if sources.is_empty() {
+            if self.operand_without_modeled_sources_is_unknown(operand) {
+                self.flow.mark_unknown(target);
+            }
+            return;
+        }
+
+        for source in sources {
             self.flow.add_flow(source, target);
             self.flow.add_descendant_aliases(source, target);
         }
@@ -757,6 +765,48 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
                 is_slice_like_ref_ty(place.ty(self.body, self.tcx).ty)
             }
             Operand::Constant(_) => false,
+        }
+    }
+
+    fn operand_without_modeled_sources_is_unknown(&self, operand: &Operand<'tcx>) -> bool {
+        match operand {
+            Operand::Copy(_) | Operand::Move(_) => true,
+            Operand::Constant(constant) => {
+                self.constant_without_modeled_sources_is_unknown(constant)
+            }
+        }
+    }
+
+    fn constant_without_modeled_sources_is_unknown(&self, constant: &ConstOperand<'tcx>) -> bool {
+        match &constant.const_ {
+            Const::Unevaluated(unevaluated, ty) => {
+                if unevaluated.promoted.is_some() {
+                    return false;
+                }
+                self.tcx
+                    .const_eval_poly(unevaluated.def)
+                    .map(|value| self.const_value_without_modeled_sources_is_unknown(&value, *ty))
+                    .unwrap_or(true)
+            }
+            Const::Val(value, ty) => {
+                self.const_value_without_modeled_sources_is_unknown(value, *ty)
+            }
+            Const::Ty(_, _) => true,
+        }
+    }
+
+    fn const_value_without_modeled_sources_is_unknown(
+        &self,
+        value: &ConstValue<'tcx>,
+        ty: Ty<'tcx>,
+    ) -> bool {
+        match value {
+            ConstValue::Scalar(scalar) => match scalar.try_to_scalar_int() {
+                Ok(int) => int.to_bits(int.size()) != 0,
+                Err(_) => true,
+            },
+            ConstValue::Indirect { .. } => pointer_slot_count(ty) > 0,
+            ConstValue::ZeroSized | ConstValue::Slice { .. } => false,
         }
     }
 

--- a/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
@@ -1,11 +1,12 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_index::{
-    IndexVec,
     bit_set::{DenseBitSet, SparseBitMatrix},
+    IndexVec,
 };
 use rustc_middle::{
     mir::{
-        Body, Local, Operand, Place, PlaceElem, RETURN_PLACE, Rvalue, Terminator, visit::Visitor,
+        visit::Visitor, BinOp, Body, Local, Operand, Place, PlaceElem, Rvalue, Terminator,
+        RETURN_PLACE,
     },
     ty::{Ty, TyCtxt, TyKind},
 };
@@ -49,6 +50,17 @@ pub struct LifetimeFlowSummary {
 pub struct LocalSlot {
     pub local: Local,
     pub depth: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct DerivedPlaceKey {
+    local: Local,
+    projection: Vec<DerivedPlaceElem>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum DerivedPlaceElem {
+    Field(usize),
 }
 
 #[derive(Clone, Debug)]
@@ -135,6 +147,7 @@ pub fn analyze_body_lifetime_flow_result<'tcx>(
         flow: &mut body_flow,
         callee_summaries,
         program_functions,
+        derived_place_sources: FxHashMap::default(),
     }
     .visit_body(body);
 
@@ -386,6 +399,7 @@ struct FlowVisitor<'flow, 'summary, 'tcx> {
     flow: &'flow mut BodyLifetimeFlow,
     callee_summaries: &'summary FxHashMap<LocalDefId, LifetimeFlowSummary>,
     program_functions: &'summary FxHashSet<LocalDefId>,
+    derived_place_sources: FxHashMap<DerivedPlaceKey, LifetimeSlot>,
 }
 
 impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
@@ -399,9 +413,46 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
 
     fn operand_slot(&self, operand: &Operand<'tcx>) -> Option<LifetimeSlot> {
         match operand {
-            Operand::Copy(place) | Operand::Move(place) => self.flow.slot_for_place(*place, 0),
+            Operand::Copy(place) | Operand::Move(place) => self.place_slot_or_derived(*place),
             Operand::Constant(_) => None,
         }
+    }
+
+    fn place_slot_or_derived(&self, place: Place<'tcx>) -> Option<LifetimeSlot> {
+        self.flow
+            .slot_for_place(place, 0)
+            .or_else(|| self.derived_place_source(place))
+    }
+
+    fn derived_place_source(&self, place: Place<'tcx>) -> Option<LifetimeSlot> {
+        let key = derived_place_key(place)?;
+        self.derived_place_sources.get(&key).copied()
+    }
+
+    fn record_derived_field_source(
+        &mut self,
+        place: Place<'tcx>,
+        field_index: usize,
+        source: LifetimeSlot,
+    ) -> bool {
+        let Some(key) = derived_field_key(place, field_index) else {
+            return false;
+        };
+        self.derived_place_sources.insert(key, source);
+        true
+    }
+
+    fn operand_is_slice_like_ref(&self, operand: &Operand<'tcx>) -> bool {
+        match operand {
+            Operand::Copy(place) | Operand::Move(place) => {
+                is_slice_like_ref_ty(place.ty(self.body, self.tcx).ty)
+            }
+            Operand::Constant(_) => false,
+        }
+    }
+
+    fn place_is_slice_like_ref(&self, place: Place<'tcx>) -> bool {
+        is_slice_like_ref_ty(place.ty(self.body, self.tcx).ty)
     }
 
     fn assign_from_place_address(&mut self, target: LifetimeSlot, place: Place<'tcx>) {
@@ -423,8 +474,91 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
                 }
             }
             None => {
-                self.flow.mark_unknown(target);
+                if let Some(deref_depth) = place_deref_interior_depth(place) {
+                    if let Some(source) = self.flow.slot_for_local(place.local, deref_depth - 1) {
+                        self.flow.add_flow(source, target);
+                    } else {
+                        self.flow.mark_unknown(target);
+                    }
+                } else {
+                    self.flow.mark_unknown(target);
+                }
             }
+        }
+    }
+
+    fn apply_known_input_return_call(&mut self, call: &MirFunctionCall<'_, 'tcx>) -> bool {
+        let Some(arg0) = call.args.first() else {
+            return false;
+        };
+
+        if self.apply_known_aggregate_input_return_call(call, &arg0.node) {
+            return true;
+        }
+
+        let Some(destination) = self.flow.slot_for_place(call.destination, 0) else {
+            return false;
+        };
+
+        if is_provenance_preserving_pointer_method(&call.func, self.tcx) {
+            self.assign_known_return_from_operand(destination, &arg0.node);
+            return true;
+        }
+
+        if is_known_slice_view_return_call(&call.func, self.tcx)
+            && self.place_is_slice_like_ref(call.destination)
+        {
+            self.assign_known_return_from_operand(destination, &arg0.node);
+            return true;
+        }
+
+        if is_known_slice_index_return_call(&call.func, self.tcx)
+            && self.operand_is_slice_like_ref(&arg0.node)
+        {
+            self.assign_known_return_from_operand(destination, &arg0.node);
+            return true;
+        }
+
+        if is_known_c_string_search_return_call(&call.func, self.tcx) {
+            self.assign_known_return_from_operand(destination, &arg0.node);
+            return true;
+        }
+
+        if is_known_memchr_return_call(&call.func, self.tcx)
+            && self.operand_is_slice_like_ref(&arg0.node)
+        {
+            self.assign_known_return_from_operand(destination, &arg0.node);
+            return true;
+        }
+
+        false
+    }
+
+    fn apply_known_aggregate_input_return_call(
+        &mut self,
+        call: &MirFunctionCall<'_, 'tcx>,
+        arg0: &Operand<'tcx>,
+    ) -> bool {
+        if !is_known_slice_split_return_call(&call.func, self.tcx)
+            || !self.operand_is_slice_like_ref(arg0)
+            || !place_is_slice_pair_ref(self.body, self.tcx, call.destination)
+        {
+            return false;
+        }
+
+        let Some(source) = self.operand_slot(arg0) else {
+            return false;
+        };
+
+        self.record_derived_field_source(call.destination, 0, source)
+            | self.record_derived_field_source(call.destination, 1, source)
+    }
+
+    fn assign_known_return_from_operand(&mut self, target: LifetimeSlot, operand: &Operand<'tcx>) {
+        if let Some(source) = self.operand_slot(operand) {
+            self.flow.add_flow(source, target);
+        } else {
+            self.flow.mark_unknown(target);
         }
     }
 
@@ -527,7 +661,7 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
             | Rvalue::ShallowInitBox(operand, _)
             | Rvalue::WrapUnsafeBinder(operand, _) => self.assign_from_operand(target, operand),
             Rvalue::CopyForDeref(place) => {
-                if let Some(source) = self.flow.slot_for_place(*place, 0) {
+                if let Some(source) = self.place_slot_or_derived(*place) {
                     self.flow.add_flow(source, target);
                     self.flow.add_descendant_aliases(source, target);
                 }
@@ -536,6 +670,9 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
                 self.assign_from_place_address(target, *place);
             }
             Rvalue::ThreadLocalRef(_) => self.flow.mark_unknown(target),
+            Rvalue::BinaryOp(BinOp::Offset, operands) => {
+                self.assign_from_operand(target, &operands.0);
+            }
             Rvalue::Repeat(..)
             | Rvalue::Len(..)
             | Rvalue::BinaryOp(..)
@@ -554,6 +691,10 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
         let Some(call) = terminator.as_call(self.tcx) else {
             return;
         };
+
+        if self.apply_known_input_return_call(&call) {
+            return;
+        }
 
         if let CallKind::RustLib(def_id) = &call.func
             && is_borrowing_method(*def_id, self.tcx)
@@ -611,12 +752,128 @@ fn pointer_pointee_ty(ty: Ty<'_>) -> Option<Ty<'_>> {
     }
 }
 
+fn is_slice_like_ref_ty(ty: Ty<'_>) -> bool {
+    match ty.kind() {
+        TyKind::Ref(_, inner, _) => matches!(inner.kind(), TyKind::Slice(_) | TyKind::Array(..)),
+        _ => false,
+    }
+}
+
+fn place_is_slice_pair_ref<'tcx>(body: &Body<'tcx>, tcx: TyCtxt<'tcx>, place: Place<'tcx>) -> bool {
+    is_slice_pair_ref_ty(place.ty(body, tcx).ty)
+}
+
+fn is_slice_pair_ref_ty(ty: Ty<'_>) -> bool {
+    match ty.kind() {
+        TyKind::Tuple(fields) if fields.len() == 2 => {
+            fields.iter().all(|field| is_slice_like_ref_ty(field))
+        }
+        _ => false,
+    }
+}
+
 fn is_null_pointer_constructor(def_id: DefId, tcx: TyCtxt<'_>) -> bool {
     !def_id.is_local() && {
         let name = tcx.item_name(def_id);
         let name = name.as_str();
         name == "null" || name == "null_mut"
     }
+}
+
+fn is_provenance_preserving_pointer_method(func: &CallKind, tcx: TyCtxt<'_>) -> bool {
+    let CallKind::RustLib(def_id) = func else {
+        return false;
+    };
+    if def_id.is_local() || tcx.def_kind(*def_id) != rustc_hir::def::DefKind::AssocFn {
+        return false;
+    }
+
+    let name = tcx.item_name(*def_id);
+    let name = name.as_str();
+    matches!(
+        name,
+        "wrapping_offset"
+            | "byte_offset"
+            | "wrapping_byte_offset"
+            | "add"
+            | "wrapping_add"
+            | "sub"
+            | "wrapping_sub"
+    )
+}
+
+fn is_known_slice_view_return_call(func: &CallKind, tcx: TyCtxt<'_>) -> bool {
+    let CallKind::RustLib(def_id) = func else {
+        return false;
+    };
+    if def_id.is_local() {
+        return false;
+    }
+
+    let name = tcx.item_name(*def_id);
+    let name = name.as_str();
+    name == "cast_slice"
+        || name == "cast_slice_mut"
+        || name == "from_raw_parts"
+        || name == "from_raw_parts_mut"
+}
+
+fn is_known_slice_index_return_call(func: &CallKind, tcx: TyCtxt<'_>) -> bool {
+    let CallKind::RustLib(def_id) = func else {
+        return false;
+    };
+    if def_id.is_local() || tcx.def_kind(*def_id) != rustc_hir::def::DefKind::AssocFn {
+        return false;
+    }
+
+    let name = tcx.item_name(*def_id);
+    let name = name.as_str();
+    matches!(
+        name,
+        "index" | "index_mut" | "get_unchecked" | "get_unchecked_mut"
+    )
+}
+
+fn is_known_slice_split_return_call(func: &CallKind, tcx: TyCtxt<'_>) -> bool {
+    let CallKind::RustLib(def_id) = func else {
+        return false;
+    };
+    if def_id.is_local() || tcx.def_kind(*def_id) != rustc_hir::def::DefKind::AssocFn {
+        return false;
+    }
+
+    let name = tcx.item_name(*def_id);
+    let name = name.as_str();
+    matches!(
+        name,
+        "split_at" | "split_at_mut" | "split_at_unchecked" | "split_at_mut_unchecked"
+    )
+}
+
+fn is_known_c_string_search_return_call(func: &CallKind, tcx: TyCtxt<'_>) -> bool {
+    match func {
+        CallKind::FreeStanding(def_id) | CallKind::Impl(def_id) => {
+            is_known_c_string_search_name(tcx.item_name(def_id.to_def_id()).as_str())
+        }
+        CallKind::RustLib(def_id) => is_known_c_string_search_name(tcx.item_name(*def_id).as_str()),
+        CallKind::LibC(name) => is_known_c_string_search_name(name.as_str()),
+        CallKind::Closure | CallKind::Dynamic => false,
+    }
+}
+
+fn is_known_memchr_return_call(func: &CallKind, tcx: TyCtxt<'_>) -> bool {
+    match func {
+        CallKind::FreeStanding(def_id) | CallKind::Impl(def_id) => {
+            tcx.item_name(def_id.to_def_id()).as_str() == "memchr"
+        }
+        CallKind::RustLib(def_id) => tcx.item_name(*def_id).as_str() == "memchr",
+        CallKind::LibC(name) => name.as_str() == "memchr",
+        CallKind::Closure | CallKind::Dynamic => false,
+    }
+}
+
+fn is_known_c_string_search_name(name: impl PartialEq<&'static str>) -> bool {
+    name == "strchr" || name == "strrchr" || name == "strstr"
 }
 
 fn place_deref_depth(place: Place<'_>) -> Option<u8> {
@@ -631,6 +888,61 @@ fn place_deref_depth(place: Place<'_>) -> Option<u8> {
         }
     }
     Some(depth)
+}
+
+fn derived_place_key(place: Place<'_>) -> Option<DerivedPlaceKey> {
+    let key = derived_place_key_prefix(place)?;
+    if key.projection.is_empty() {
+        return None;
+    }
+    Some(key)
+}
+
+fn derived_field_key(place: Place<'_>, field_index: usize) -> Option<DerivedPlaceKey> {
+    let mut key = derived_place_key_prefix(place)?;
+    key.projection.push(DerivedPlaceElem::Field(field_index));
+    Some(key)
+}
+
+fn derived_place_key_prefix(place: Place<'_>) -> Option<DerivedPlaceKey> {
+    let mut projection = vec![];
+    for elem in place.projection {
+        match elem {
+            PlaceElem::Field(field, _) => {
+                projection.push(DerivedPlaceElem::Field(field.as_usize()));
+            }
+            PlaceElem::OpaqueCast(_) => {}
+            _ => return None,
+        }
+    }
+    Some(DerivedPlaceKey {
+        local: place.local,
+        projection,
+    })
+}
+
+fn place_deref_interior_depth(place: Place<'_>) -> Option<u8> {
+    let mut depth = 0u8;
+    let mut saw_interior = false;
+    for projection in place.projection {
+        match projection {
+            PlaceElem::Deref if !saw_interior => {
+                depth = depth.checked_add(1)?;
+            }
+            PlaceElem::Field(..)
+            | PlaceElem::Index(_)
+            | PlaceElem::ConstantIndex { .. }
+            | PlaceElem::Subslice { .. }
+            | PlaceElem::Downcast(..)
+                if depth > 0 =>
+            {
+                saw_interior = true;
+            }
+            PlaceElem::OpaqueCast(_) => {}
+            _ => return None,
+        }
+    }
+    saw_interior.then_some(depth)
 }
 
 fn transitive_closure(

--- a/crates/pointer_replacer/src/analyses/borrow/mod.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/mod.rs
@@ -38,6 +38,7 @@ macro_rules! disallow_interprocedural {
 mod errors;
 mod invalidates;
 mod killed;
+pub mod lifetime_flow;
 mod loan_liveness;
 mod places_conflict;
 mod provenance_liveness;

--- a/crates/pointer_replacer/src/analyses/borrow/mod.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/mod.rs
@@ -6,6 +6,7 @@ use errors::{Errors, compute_errors};
 use invalidates::{Invalidates, compute_invalidates};
 use itertools::Itertools as _;
 use killed::{Killed, compute_killed};
+use lifetime_flow::{LifetimeFlowResults, analyze_program_lifetime_flow};
 use loan_liveness::{LoanLiveness, compute_loan_liveness};
 use provenance_liveness::{ProvenanceLiveness, compute_provenance_liveness};
 use requires::{ProvenanceRequiresLoan, compute_requires};
@@ -131,6 +132,7 @@ impl HasProvenanceSet for Body<'_> {
 
 pub struct GBorrowInferCtxt {
     pub provenances: FxHashMap<LocalDefId, ProvenanceSet>,
+    pub lifetime_flows: LifetimeFlowResults,
 }
 
 impl GBorrowInferCtxt {
@@ -141,6 +143,7 @@ impl GBorrowInferCtxt {
         K: Fn(LocalDefId) -> L,
         L: Fn(Local) -> bool,
     {
+        let lifetime_flows = analyze_program_lifetime_flow(program);
         let mut provenances = FxHashMap::default();
         for f in program.functions.iter().copied() {
             let body = program
@@ -152,7 +155,10 @@ impl GBorrowInferCtxt {
             provenances.insert(f, body.provenance_set(is_candidate, is_mutable));
         }
 
-        GBorrowInferCtxt { provenances }
+        GBorrowInferCtxt {
+            provenances,
+            lifetime_flows,
+        }
     }
 
     pub fn _all_pointers(program: &RustProgram) -> Self {
@@ -547,6 +553,25 @@ impl ProvenanceConstraintGraph {
         }
         .visit_body(body);
 
+        if let Some(lifetime_flow) = global_borrow_ctxt
+            .lifetime_flows
+            .get(&body.source.def_id().expect_local())
+        {
+            for (source, target) in lifetime_flow.body.depth0_value_flows() {
+                let Some(source_provenance) = provenance_set.local_data[source] else {
+                    continue;
+                };
+                let Some(target_provenance) = provenance_set.local_data[target] else {
+                    continue;
+                };
+                graph.subset.push(SubsetConstraint {
+                    sup: target_provenance,
+                    sub: source_provenance,
+                    _location: Location::START,
+                });
+            }
+        }
+
         graph
     }
 }
@@ -774,7 +799,11 @@ pub fn demote_pointers_iterative(
 
         let inference = borrow_inference(tcx, f, global_borrow_ctxt);
         let BorrowInferenceResults {
-            borrow_set, errors, ..
+            borrow_set,
+            errors,
+            provenance_liveness,
+            requires,
+            ..
         } = inference;
 
         let mut invalid_loans = DenseBitSet::new_empty(borrow_set.loans.len());
@@ -794,15 +823,38 @@ pub fn demote_pointers_iterative(
 
         for loan in invalid_loans.iter() {
             let borrow_data = &borrow_set.loans[loan];
-            match borrow_data.assigned {
-                Borrower::AssignStmt(assigned) => {
-                    demoted_locals.insert(assigned.local);
+            for row in errors.rows() {
+                let Some(loans) = errors.row(row) else {
+                    continue;
+                };
+                if !loans.contains(loan) {
+                    continue;
+                }
+                let Some(live_provenances) = provenance_liveness.row(row) else {
+                    continue;
+                };
+                for provenance in live_provenances.iter() {
+                    if !requires.contains(provenance, loan) {
+                        continue;
+                    }
+                    let local = provenance_set.provenance_data[provenance].local();
+                    demoted_locals.insert(local);
                     provenance_set
                         .tree_borrow_local
                         .get_mut()
-                        .union(assigned.local, borrow_data.borrowed.local);
+                        .union(local, borrow_data.borrowed.local);
                 }
-                Borrower::CallArg(..) => unimplemented!(),
+            }
+        }
+
+        for loan in invalid_loans.iter() {
+            let borrow_data = &borrow_set.loans[loan];
+            if let Borrower::AssignStmt(assigned) = borrow_data.assigned {
+                demoted_locals.insert(assigned.local);
+                provenance_set
+                    .tree_borrow_local
+                    .get_mut()
+                    .union(assigned.local, borrow_data.borrowed.local);
             }
         }
 

--- a/crates/pointer_replacer/src/analyses/borrow/mod.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/mod.rs
@@ -821,6 +821,9 @@ pub fn demote_pointers_iterative(
 
         let provenance_set = global_borrow_ctxt.provenances.get_mut(&f).unwrap();
 
+        // Demote every live provenance that depends on the invalid loan, not just
+        // the local where the borrow was originally assigned.
+        // (for inter-procedural borrow inference, e.g., p = id(q))
         for loan in invalid_loans.iter() {
             let borrow_data = &borrow_set.loans[loan];
             for row in errors.rows() {

--- a/crates/pointer_replacer/src/analyses/borrow/tests.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/tests.rs
@@ -219,6 +219,20 @@ fn assert_lifetime_unknown_target(
     );
 }
 
+fn assert_lifetime_not_unknown_target(
+    facts: &FxHashMap<String, LifetimeFlowFacts>,
+    function: &str,
+    target: &str,
+) {
+    assert!(
+        !facts[function]
+            .unknown_targets
+            .contains(&target.to_string()),
+        "{function} should not mark {target} unknown; got {:?}",
+        facts[function].unknown_targets
+    );
+}
+
 #[test]
 fn test_proof_of_concept() {
     let demoted = run_demote(
@@ -332,6 +346,230 @@ fn lifetime_flow_read_output() {
         "read output should flow out arg1@1 to return@0; got {:?}",
         edges["read_out"]
     );
+}
+
+#[test]
+fn lifetime_flow_pointer_offset_methods_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn offset_ptr(x: *mut i32, k: isize) -> *mut i32 {
+            x.offset(k)
+        }
+
+        unsafe fn add_ptr(x: *mut i32, k: usize) -> *mut i32 {
+            x.add(k)
+        }
+
+        unsafe fn sub_ptr(x: *mut i32, k: usize) -> *mut i32 {
+            x.sub(k)
+        }
+
+        unsafe fn wrapping_add_ptr(x: *mut i32, k: usize) -> *mut i32 {
+            x.wrapping_add(k)
+        }
+
+        unsafe fn wrapping_sub_ptr(x: *mut i32, k: usize) -> *mut i32 {
+            x.wrapping_sub(k)
+        }
+
+        unsafe fn byte_offset_ptr(x: *mut u8, k: isize) -> *mut u8 {
+            x.byte_offset(k)
+        }
+        ",
+    );
+    for function in [
+        "offset_ptr",
+        "add_ptr",
+        "sub_ptr",
+        "wrapping_add_ptr",
+        "wrapping_sub_ptr",
+        "byte_offset_ptr",
+    ] {
+        assert_lifetime_flow_edge(&facts, function, "arg1@0", "return@0");
+        assert_lifetime_not_unknown_target(&facts, function, "return@0");
+    }
+}
+
+#[test]
+fn lifetime_flow_address_of_input_field_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        #[repr(C)]
+        struct State {
+            value: i32,
+        }
+
+        unsafe fn field(state: *mut State) -> *mut i32 {
+            &raw mut (*state).value
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "field", "arg1@0", "return@0");
+    assert!(
+        !facts["field"]
+            .unknown_targets
+            .contains(&"return@0".to_string()),
+        "field address provenance should be explicit, not unknown; got {:?}",
+        facts["field"].unknown_targets
+    );
+}
+
+#[test]
+fn lifetime_flow_address_of_offset_input_field_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        #[repr(C)]
+        struct State {
+            value: i32,
+        }
+
+        unsafe fn field_at(state: *mut State, index: usize) -> *mut i32 {
+            &raw mut (*state.add(index)).value
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "field_at", "arg1@0", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "field_at", "return@0");
+}
+
+#[test]
+fn lifetime_flow_slice_suffix_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn suffix(xs: &[i32]) -> *const i32 {
+            xs[1..].as_ptr()
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "suffix", "arg1@0", "return@0");
+    assert!(
+        !facts["suffix"]
+            .unknown_targets
+            .contains(&"return@0".to_string()),
+        "slice suffix provenance should be explicit, not unknown; got {:?}",
+        facts["suffix"].unknown_targets
+    );
+}
+
+#[test]
+fn lifetime_flow_slice_split_suffix_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn split_suffix(xs: &[i32], index: usize) -> *const i32 {
+            xs.split_at(index).1.as_ptr()
+        }
+
+        unsafe fn split_suffix_mut(xs: &mut [i32], index: usize) -> *mut i32 {
+            xs.split_at_mut(index).1.as_mut_ptr()
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "split_suffix", "arg1@0", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "split_suffix", "return@0");
+    assert_lifetime_flow_edge(&facts, "split_suffix_mut", "arg1@0", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "split_suffix_mut", "return@0");
+}
+
+#[test]
+fn lifetime_flow_slice_get_unchecked_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn unchecked_elem(xs: &[i32], index: usize) -> *const i32 {
+            xs.get_unchecked(index) as *const i32
+        }
+
+        unsafe fn unchecked_suffix(xs: &[i32], index: usize) -> *const i32 {
+            xs.get_unchecked(index..).as_ptr()
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "unchecked_elem", "arg1@0", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "unchecked_elem", "return@0");
+    assert_lifetime_flow_edge(&facts, "unchecked_suffix", "arg1@0", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "unchecked_suffix", "return@0");
+}
+
+#[test]
+fn lifetime_flow_known_slice_search_pipeline_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        mod c_lib {
+            unsafe extern \"C\" {
+                fn opaque_strrchr(s: *const u8, c: u8) -> *mut u8;
+            }
+
+            pub unsafe fn strrchr(s: &[u8], c: u8) -> *mut u8 {
+                unsafe { opaque_strrchr(s.as_ptr(), c) }
+            }
+        }
+
+        unsafe fn extract(path: &[u8]) -> *const u8 {
+            let found = unsafe { c_lib::strrchr(path, 0) };
+            let search = if found.is_null() {
+                &[]
+            } else {
+                unsafe { std::slice::from_raw_parts(found, 1_000_000) }
+            };
+            if search.is_empty() {
+                path.as_ptr()
+            } else {
+                search[1..].as_ptr()
+            }
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "extract", "arg1@0", "return@0");
+    assert!(
+        !facts["extract"]
+            .unknown_targets
+            .contains(&"return@0".to_string()),
+        "known slice-search/slice-view provenance should be explicit; got {:?}",
+        facts["extract"].unknown_targets
+    );
+}
+
+#[test]
+fn lifetime_flow_raw_c_string_search_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe extern \"C\" {
+            fn strrchr(s: *const i8, c: i32) -> *mut i8;
+        }
+
+        unsafe fn basename(path: *const i8) -> *const i8 {
+            let found = unsafe { strrchr(path, '/' as i32) };
+            if found.is_null() {
+                path
+            } else {
+                unsafe { found.offset(1) as *const i8 }
+            }
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "basename", "arg1@0", "return@0");
+    assert!(
+        !facts["basename"]
+            .unknown_targets
+            .contains(&"return@0".to_string()),
+        "known C string search provenance should be explicit; got {:?}",
+        facts["basename"].unknown_targets
+    );
+}
+
+#[test]
+fn lifetime_flow_raw_memchr_return_stays_unknown() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe extern \"C\" {
+            fn memchr(s: *const core::ffi::c_void, c: i32, n: usize) -> *mut core::ffi::c_void;
+        }
+
+        unsafe fn find(buffer: *const u8, len: usize) -> *const u8 {
+            unsafe { memchr(buffer as *const core::ffi::c_void, 0, len) as *const u8 }
+        }
+        ",
+    );
+    assert_lifetime_unknown_target(&facts, "find", "return@0");
 }
 
 #[test]

--- a/crates/pointer_replacer/src/analyses/borrow/tests.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/tests.rs
@@ -101,33 +101,70 @@ fn get_return_provenance_params(code: &str) -> FxHashMap<String, Vec<String>> {
 }
 
 fn get_lifetime_flow_edges(code: &str) -> FxHashMap<String, Vec<(String, String)>> {
+    get_lifetime_flow_facts(code)
+        .into_iter()
+        .map(|(name, facts)| (name, facts.value_flows))
+        .collect()
+}
+
+#[derive(Debug)]
+struct LifetimeFlowFacts {
+    value_flows: Vec<(String, String)>,
+    storage_aliases: Vec<(String, String)>,
+    unknown_targets: Vec<String>,
+}
+
+fn get_lifetime_flow_facts(code: &str) -> FxHashMap<String, LifetimeFlowFacts> {
     ::utils::compilation::run_compiler_on_str(code, |tcx| {
         let program = build_rust_program(tcx);
         let results = lifetime_flow::analyze_program_lifetime_flow(&program);
-        let mut all_edges = FxHashMap::default();
+        let mut all_facts = FxHashMap::default();
 
         for &f in &program.functions {
             let result = &results[&f];
-            let mut edges = vec![];
-            for source in result.summary.value_flows.rows() {
-                let Some(targets) = result.summary.value_flows.row(source) else {
-                    continue;
-                };
-                let source = format_signature_slot(result.summary.slots[source]);
-                for target in targets.iter() {
-                    edges.push((
-                        source.clone(),
-                        format_signature_slot(result.summary.slots[target]),
-                    ));
-                }
-            }
-            edges.sort();
-            all_edges.insert(fn_name(tcx, f), edges);
+            let mut unknown_targets: Vec<_> = result
+                .summary
+                .unknown_targets
+                .iter()
+                .map(|target| format_signature_slot(result.summary.slots[target]))
+                .collect();
+            unknown_targets.sort();
+            all_facts.insert(
+                fn_name(tcx, f),
+                LifetimeFlowFacts {
+                    value_flows: collect_lifetime_flow_edges(&result.summary, false),
+                    storage_aliases: collect_lifetime_flow_edges(&result.summary, true),
+                    unknown_targets,
+                },
+            );
         }
 
-        all_edges
+        all_facts
     })
     .unwrap()
+}
+
+fn collect_lifetime_flow_edges(
+    summary: &lifetime_flow::LifetimeFlowSummary,
+    storage_aliases: bool,
+) -> Vec<(String, String)> {
+    let matrix = if storage_aliases {
+        &summary.storage_aliases
+    } else {
+        &summary.value_flows
+    };
+    let mut edges = vec![];
+    for source in matrix.rows() {
+        let Some(targets) = matrix.row(source) else {
+            continue;
+        };
+        let source = format_signature_slot(summary.slots[source]);
+        for target in targets.iter() {
+            edges.push((source.clone(), format_signature_slot(summary.slots[target])));
+        }
+    }
+    edges.sort();
+    edges
 }
 
 fn format_signature_slot(slot: lifetime_flow::SignatureSlot) -> String {
@@ -136,6 +173,50 @@ fn format_signature_slot(slot: lifetime_flow::SignatureSlot) -> String {
         lifetime_flow::SignatureRoot::Arg(local) => format!("arg{}", local.index()),
     };
     format!("{root}@{}", slot.depth)
+}
+
+fn assert_lifetime_flow_edge(
+    facts: &FxHashMap<String, LifetimeFlowFacts>,
+    function: &str,
+    source: &str,
+    target: &str,
+) {
+    assert!(
+        facts[function]
+            .value_flows
+            .contains(&(source.to_string(), target.to_string())),
+        "{function} should contain value flow {source} -> {target}; got {:?}",
+        facts[function].value_flows
+    );
+}
+
+fn assert_lifetime_storage_alias(
+    facts: &FxHashMap<String, LifetimeFlowFacts>,
+    function: &str,
+    left: &str,
+    right: &str,
+) {
+    assert!(
+        facts[function]
+            .storage_aliases
+            .contains(&(left.to_string(), right.to_string())),
+        "{function} should contain storage alias {left} -> {right}; got {:?}",
+        facts[function].storage_aliases
+    );
+}
+
+fn assert_lifetime_unknown_target(
+    facts: &FxHashMap<String, LifetimeFlowFacts>,
+    function: &str,
+    target: &str,
+) {
+    assert!(
+        facts[function]
+            .unknown_targets
+            .contains(&target.to_string()),
+        "{function} should mark {target} unknown; got {:?}",
+        facts[function].unknown_targets
+    );
 }
 
 #[test]
@@ -251,6 +332,112 @@ fn lifetime_flow_read_output() {
         "read output should flow out arg1@1 to return@0; got {:?}",
         edges["read_out"]
     );
+}
+
+#[test]
+fn lifetime_flow_forwarded_output_reference_aliases_storage() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn forward(out: *mut *mut i32) -> *mut *mut i32 {
+            out
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "forward", "arg1@0", "return@0");
+    assert_lifetime_storage_alias(&facts, "forward", "arg1@1", "return@1");
+    assert_lifetime_storage_alias(&facts, "forward", "return@1", "arg1@1");
+}
+
+#[test]
+fn lifetime_flow_copy_between_output_slots() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn copy_out(src: *mut *mut i32, dst: *mut *mut i32) {
+            *dst = *src;
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "copy_out", "arg1@1", "arg2@1");
+    assert!(
+        !facts["copy_out"]
+            .value_flows
+            .contains(&("arg1@0".to_string(), "arg2@1".to_string())),
+        "copy_out should copy the value behind src, not src itself; got {:?}",
+        facts["copy_out"].value_flows
+    );
+}
+
+#[test]
+fn lifetime_flow_instantiates_callee_return_summary() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn id(x: *mut i32) -> *mut i32 { x }
+
+        unsafe fn wrap(y: *mut i32) -> *mut i32 {
+            id(y)
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "id", "arg1@0", "return@0");
+    assert_lifetime_flow_edge(&facts, "wrap", "arg1@0", "return@0");
+}
+
+#[test]
+fn lifetime_flow_instantiates_callee_output_store_summary() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn write_out(out: *mut *mut i32, value: *mut i32) {
+            *out = value;
+        }
+
+        unsafe fn wrap(out: *mut *mut i32, value: *mut i32) {
+            write_out(out, value);
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "write_out", "arg2@0", "arg1@1");
+    assert_lifetime_flow_edge(&facts, "wrap", "arg2@0", "arg1@1");
+}
+
+#[test]
+fn lifetime_flow_external_call_marks_unknown_return_and_nested_arg() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe extern \"C\" {
+            fn external(out: *mut *mut i32) -> *mut i32;
+        }
+
+        unsafe fn call_external(out: *mut *mut i32) -> *mut i32 {
+            external(out)
+        }
+        ",
+    );
+    assert_lifetime_unknown_target(&facts, "call_external", "return@0");
+    assert_lifetime_unknown_target(&facts, "call_external", "arg1@1");
+    assert!(
+        !facts["call_external"]
+            .unknown_targets
+            .contains(&"arg1@0".to_string()),
+        "plain arg@0 reassignment is not caller-visible unknown output; got {:?}",
+        facts["call_external"].unknown_targets
+    );
+}
+
+#[test]
+fn lifetime_flow_mutually_recursive_scc_converges() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn a(x: *mut i32, pick_x: bool) -> *mut i32 {
+            if pick_x { x } else { b(x, pick_x) }
+        }
+
+        unsafe fn b(y: *mut i32, pick_y: bool) -> *mut i32 {
+            a(y, pick_y)
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "a", "arg1@0", "return@0");
+    assert_lifetime_flow_edge(&facts, "b", "arg1@0", "return@0");
 }
 
 #[test]
@@ -395,6 +582,56 @@ fn stored_output_lifetime() {
         demoted,
         vec!["r"],
         "r receives x's borrow through write_out and should be demoted"
+    );
+}
+
+#[test]
+fn wrapped_return_value_lifetime() {
+    let demoted = run_demote(
+        "
+        unsafe fn id(x: *mut i32) -> *mut i32 { x }
+        unsafe fn wrap(y: *mut i32) -> *mut i32 { id(y) }
+
+        unsafe fn f() {
+            let mut x = 0i32;
+            let p = wrap(&raw mut x);
+            x = 1;
+            *p = 2;
+        }
+        ",
+    );
+    assert_eq!(
+        demoted,
+        vec!["p"],
+        "p receives x's borrow through two user-defined calls and should be demoted"
+    );
+}
+
+#[test]
+fn wrapped_stored_output_lifetime() {
+    let demoted = run_demote(
+        "
+        unsafe fn write_out(out: *mut *mut i32, value: *mut i32) {
+            *out = value;
+        }
+
+        unsafe fn wrap(out: *mut *mut i32, value: *mut i32) {
+            write_out(out, value);
+        }
+
+        unsafe fn f() {
+            let mut x = 0i32;
+            let mut r: *mut i32 = core::ptr::null_mut();
+            wrap(&raw mut r, &raw mut x);
+            x = 1;
+            *r = 2;
+        }
+        ",
+    );
+    assert_eq!(
+        demoted,
+        vec!["r"],
+        "r receives x's borrow through a wrapped output store and should be demoted"
     );
 }
 

--- a/crates/pointer_replacer/src/analyses/borrow/tests.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/tests.rs
@@ -100,6 +100,44 @@ fn get_return_provenance_params(code: &str) -> FxHashMap<String, Vec<String>> {
     .unwrap()
 }
 
+fn get_lifetime_flow_edges(code: &str) -> FxHashMap<String, Vec<(String, String)>> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let program = build_rust_program(tcx);
+        let results = lifetime_flow::analyze_program_lifetime_flow(&program);
+        let mut all_edges = FxHashMap::default();
+
+        for &f in &program.functions {
+            let result = &results[&f];
+            let mut edges = vec![];
+            for source in result.summary.value_flows.rows() {
+                let Some(targets) = result.summary.value_flows.row(source) else {
+                    continue;
+                };
+                let source = format_signature_slot(result.summary.slots[source]);
+                for target in targets.iter() {
+                    edges.push((
+                        source.clone(),
+                        format_signature_slot(result.summary.slots[target]),
+                    ));
+                }
+            }
+            edges.sort();
+            all_edges.insert(fn_name(tcx, f), edges);
+        }
+
+        all_edges
+    })
+    .unwrap()
+}
+
+fn format_signature_slot(slot: lifetime_flow::SignatureSlot) -> String {
+    let root = match slot.root {
+        lifetime_flow::SignatureRoot::Return => "return".to_string(),
+        lifetime_flow::SignatureRoot::Arg(local) => format!("arg{}", local.index()),
+    };
+    format!("{root}@{}", slot.depth)
+}
+
 #[test]
 fn test_proof_of_concept() {
     let demoted = run_demote(
@@ -142,6 +180,77 @@ fn test_inferred_bounds() {
         "only q's provenance flows to f's return value"
     );
     assert!(!params.contains_key("g"), "g has no pointer return type");
+}
+
+#[test]
+fn lifetime_flow_identity_return() {
+    let edges = get_lifetime_flow_edges(
+        "
+        unsafe fn make_ref(x: *mut i32) -> *mut i32 { x }
+        ",
+    );
+    assert!(
+        edges["make_ref"].contains(&("arg1@0".to_string(), "return@0".to_string())),
+        "identity return should flow arg1@0 to return@0; got {:?}",
+        edges["make_ref"]
+    );
+}
+
+#[test]
+fn lifetime_flow_stored_output() {
+    let edges = get_lifetime_flow_edges(
+        "
+        unsafe fn write_out(out: *mut *const i32, value: *const i32) {
+            *out = value;
+        }
+        ",
+    );
+    assert!(
+        edges["write_out"].contains(&("arg2@0".to_string(), "arg1@1".to_string())),
+        "stored output should flow value arg2@0 to out arg1@1; got {:?}",
+        edges["write_out"]
+    );
+    assert!(
+        !edges["write_out"].contains(&("arg2@0".to_string(), "arg1@0".to_string())),
+        "stored output must not flow value into out arg1@0"
+    );
+}
+
+#[test]
+fn lifetime_flow_conditional_return() {
+    let edges = get_lifetime_flow_edges(
+        "
+        unsafe fn pick(x: *mut i32, y: *mut i32, pick_x: bool) -> *mut i32 {
+            if pick_x { x } else { y }
+        }
+        ",
+    );
+    assert!(
+        edges["pick"].contains(&("arg1@0".to_string(), "return@0".to_string())),
+        "x should flow to return; got {:?}",
+        edges["pick"]
+    );
+    assert!(
+        edges["pick"].contains(&("arg2@0".to_string(), "return@0".to_string())),
+        "y should flow to return; got {:?}",
+        edges["pick"]
+    );
+}
+
+#[test]
+fn lifetime_flow_read_output() {
+    let edges = get_lifetime_flow_edges(
+        "
+        unsafe fn read_out(out: *const *const i32) -> *const i32 {
+            *out
+        }
+        ",
+    );
+    assert!(
+        edges["read_out"].contains(&("arg1@1".to_string(), "return@0".to_string())),
+        "read output should flow out arg1@1 to return@0; got {:?}",
+        edges["read_out"]
+    );
 }
 
 #[test]
@@ -244,7 +353,6 @@ fn tb_union_find_over_demotion() {
 }
 
 #[test]
-#[should_panic]
 fn return_value_lifetime() {
     // make_ref returns its input — p aliases a through the call.
 
@@ -263,6 +371,30 @@ fn return_value_lifetime() {
         demoted,
         vec!["p"],
         "p aliases a through make_ref — p should be demoted due to conflict with a = 1"
+    );
+}
+
+#[test]
+fn stored_output_lifetime() {
+    let demoted = run_demote(
+        "
+        unsafe fn write_out(out: *mut *mut i32, value: *mut i32) {
+            *out = value;
+        }
+
+        unsafe fn f() {
+            let mut x = 0i32;
+            let mut r: *mut i32 = core::ptr::null_mut();
+            write_out(&raw mut r, &raw mut x);
+            x = 1;
+            *r = 2;
+        }
+        ",
+    );
+    assert_eq!(
+        demoted,
+        vec!["r"],
+        "r receives x's borrow through write_out and should be demoted"
     );
 }
 

--- a/crates/pointer_replacer/src/analyses/borrow/tests.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/tests.rs
@@ -648,6 +648,45 @@ fn lifetime_flow_raw_memchr_return_stays_unknown() {
 }
 
 #[test]
+fn lifetime_flow_int_to_pointer_cast_marks_return_unknown() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn constant_addr() -> *mut i32 {
+            0x1234usize as *mut i32
+        }
+
+        unsafe fn from_integer(n: usize) -> *mut i32 {
+            n as *mut i32
+        }
+        ",
+    );
+    assert_lifetime_unknown_target(&facts, "constant_addr", "return@0");
+    assert_lifetime_unknown_target(&facts, "from_integer", "return@0");
+}
+
+#[test]
+fn lifetime_flow_null_pointer_constructor_has_no_unknown_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn null_ptr() -> *const i32 {
+            core::ptr::null()
+        }
+
+        unsafe fn null_mut_ptr() -> *mut i32 {
+            core::ptr::null_mut()
+        }
+
+        unsafe fn zero_cast_null_ptr() -> *mut i32 {
+            0usize as *mut i32
+        }
+        ",
+    );
+    assert_lifetime_not_unknown_target(&facts, "null_ptr", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "null_mut_ptr", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "zero_cast_null_ptr", "return@0");
+}
+
+#[test]
 fn lifetime_flow_forwarded_output_reference_aliases_storage() {
     let facts = get_lifetime_flow_facts(
         "

--- a/crates/pointer_replacer/src/analyses/borrow/tests.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/tests.rs
@@ -190,6 +190,21 @@ fn assert_lifetime_flow_edge(
     );
 }
 
+fn assert_lifetime_no_flow_edge(
+    facts: &FxHashMap<String, LifetimeFlowFacts>,
+    function: &str,
+    source: &str,
+    target: &str,
+) {
+    assert!(
+        !facts[function]
+            .value_flows
+            .contains(&(source.to_string(), target.to_string())),
+        "{function} should not contain value flow {source} -> {target}; got {:?}",
+        facts[function].value_flows
+    );
+}
+
 fn assert_lifetime_storage_alias(
     facts: &FxHashMap<String, LifetimeFlowFacts>,
     function: &str,
@@ -468,6 +483,66 @@ fn lifetime_flow_slice_split_suffix_return() {
     assert_lifetime_not_unknown_target(&facts, "split_suffix", "return@0");
     assert_lifetime_flow_edge(&facts, "split_suffix_mut", "arg1@0", "return@0");
     assert_lifetime_not_unknown_target(&facts, "split_suffix_mut", "return@0");
+}
+
+#[test]
+fn lifetime_flow_slice_split_conditional_field_sources_join() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn split_suffix_conditional(
+            xs: &[i32],
+            ys: &[i32],
+            index: usize,
+            pick_x: bool,
+        ) -> *const i32 {
+            let parts: (&[i32], &[i32]);
+            if pick_x {
+                parts = xs.split_at(index);
+            } else {
+                parts = ys.split_at(index);
+            }
+            parts.1.as_ptr()
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "split_suffix_conditional", "arg1@0", "return@0");
+    assert_lifetime_flow_edge(&facts, "split_suffix_conditional", "arg2@0", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "split_suffix_conditional", "return@0");
+}
+
+#[test]
+fn lifetime_flow_slice_split_field_assignment_kills_stale_source() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn split_suffix_overwritten(
+            xs: &[i32],
+            ys: &[i32],
+            index: usize,
+        ) -> *const i32 {
+            let mut parts = xs.split_at(index);
+            parts.1 = ys;
+            parts.1.as_ptr()
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "split_suffix_overwritten", "arg2@0", "return@0");
+    assert_lifetime_no_flow_edge(&facts, "split_suffix_overwritten", "arg1@0", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "split_suffix_overwritten", "return@0");
+}
+
+#[test]
+fn lifetime_flow_slice_split_aggregate_copy_propagates_field_sources() {
+    let facts = get_lifetime_flow_facts(
+        "
+        unsafe fn split_suffix_copied(xs: &[i32], index: usize) -> *const i32 {
+            let parts = xs.split_at(index);
+            let p2 = parts;
+            p2.1.as_ptr()
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "split_suffix_copied", "arg1@0", "return@0");
+    assert_lifetime_not_unknown_target(&facts, "split_suffix_copied", "return@0");
 }
 
 #[test]


### PR DESCRIPTION
Add lifetime flow analysis for interprocedural borrow inference.

Lifetime flow analysis summarizes how pointers flow between a function's inputs and output.

For example, it can infer that a return value originates from an input:

```rust
fn foo(p: *const i32) -> *const i32 {
    p
}
```

and that writing through an output parameter transfers the lifetime/source of an
input into that output location:

```rust
fn write(out: *mut *const i32, value: *const i32) {
    *out = value;
}
```

Borrow inference consumes these summaries at call sites. For example:

```rust
fn foo(p: *const i32) -> *const i32 {
    p
}

fn main() {
    ...
    x = foo(y)  // treated like a lifetime/value flow from y to x
    ...
}
```

This lets provenance constraints account for flows across function boundaries, so invalid borrows can demote the live pointer provenances that depend on the bad loan instead of only demoting the local where the borrow was originally
assigned.

Rewriter for this interprocedural borrow inference is not implemented yet.