### PR TITLE
Pointer plugin: support struct fields and improve rewriter

### DIFF
--- a/crates/finders/src/unsafe_finder.rs
+++ b/crates/finders/src/unsafe_finder.rs
@@ -1,8 +1,17 @@
 use rustc_middle::ty::TyCtxt;
-use rustc_span::Span;
+use rustc_span::{Span, def_id::DefId};
 use utils::unsafety::{self, UnsafeOpKind};
 
 struct UnsafetyHandler(bool);
+
+fn unsafe_call_label(def_id: DefId, tcx: TyCtxt<'_>) -> String {
+    let name = utils::ir::def_id_to_symbol(def_id, tcx).unwrap();
+    if name.as_str() == "from_raw" && tcx.def_path_str(def_id).contains("boxed") {
+        "Box::from_raw".to_string()
+    } else {
+        name.to_string()
+    }
+}
 
 impl unsafety::UnsafetyHandler for UnsafetyHandler {
     fn handle_unsafety(&mut self, kind: UnsafeOpKind, span: Span, tcx: TyCtxt<'_>) {
@@ -12,12 +21,9 @@ impl unsafety::UnsafetyHandler for UnsafetyHandler {
                 && matches!(item.kind, rustc_hir::ItemKind::Fn { .. })
             {
             } else if self.0 {
-                println!(
-                    "{} {span:?}",
-                    utils::ir::def_id_to_symbol(def_id, tcx).unwrap()
-                );
+                println!("{} {span:?}", unsafe_call_label(def_id, tcx));
             } else {
-                println!("{}", utils::ir::def_id_to_symbol(def_id, tcx).unwrap());
+                println!("{}", unsafe_call_label(def_id, tcx));
             }
         } else if self.0 {
             println!("{kind:?} {span:?}");
@@ -38,5 +44,49 @@ pub fn find_unsafe(show_spans: bool, tcx: TyCtxt<'_>) {
             continue;
         }
         unsafety::check_unsafety(def_id, &mut UnsafetyHandler(show_spans), tcx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct LabelCollector(Vec<String>);
+
+    impl unsafety::UnsafetyHandler for LabelCollector {
+        fn handle_unsafety(&mut self, kind: UnsafeOpKind, _span: Span, tcx: TyCtxt<'_>) {
+            if let UnsafeOpKind::CallToUnsafeFunction(Some(def_id)) = kind {
+                self.0.push(unsafe_call_label(def_id, tcx));
+            }
+        }
+    }
+
+    #[test]
+    fn labels_box_from_raw_explicitly() {
+        let labels = utils::compilation::run_compiler_on_str(
+            r#"
+pub unsafe fn free_boxed(p: *mut i32) {
+    drop(Box::from_raw(p));
+}
+"#,
+            |tcx| {
+                let mut labels = Vec::new();
+                for item_id in tcx.hir_free_items() {
+                    let def_id = item_id.owner_id.def_id;
+                    let item = tcx.hir_item(item_id);
+                    if !matches!(item.kind, rustc_hir::ItemKind::Fn { .. }) {
+                        continue;
+                    }
+                    let mut collector = LabelCollector(Vec::new());
+                    unsafety::check_unsafety(def_id, &mut collector, tcx);
+                    labels.extend(collector.0);
+                }
+                labels
+            },
+        )
+        .unwrap();
+
+        assert!(labels.iter().any(|label| label == "Box::from_raw"));
+        assert!(!labels.iter().any(|label| label == "from_raw"));
     }
 }

--- a/crates/finders/src/unsafe_finder.rs
+++ b/crates/finders/src/unsafe_finder.rs
@@ -1,17 +1,8 @@
 use rustc_middle::ty::TyCtxt;
-use rustc_span::{Span, def_id::DefId};
+use rustc_span::Span;
 use utils::unsafety::{self, UnsafeOpKind};
 
 struct UnsafetyHandler(bool);
-
-fn unsafe_call_label(def_id: DefId, tcx: TyCtxt<'_>) -> String {
-    let name = utils::ir::def_id_to_symbol(def_id, tcx).unwrap();
-    if name.as_str() == "from_raw" && tcx.def_path_str(def_id).contains("boxed") {
-        "Box::from_raw".to_string()
-    } else {
-        name.to_string()
-    }
-}
 
 impl unsafety::UnsafetyHandler for UnsafetyHandler {
     fn handle_unsafety(&mut self, kind: UnsafeOpKind, span: Span, tcx: TyCtxt<'_>) {
@@ -21,9 +12,12 @@ impl unsafety::UnsafetyHandler for UnsafetyHandler {
                 && matches!(item.kind, rustc_hir::ItemKind::Fn { .. })
             {
             } else if self.0 {
-                println!("{} {span:?}", unsafe_call_label(def_id, tcx));
+                println!(
+                    "{} {span:?}",
+                    utils::ir::def_id_to_symbol(def_id, tcx).unwrap()
+                );
             } else {
-                println!("{}", unsafe_call_label(def_id, tcx));
+                println!("{}", utils::ir::def_id_to_symbol(def_id, tcx).unwrap());
             }
         } else if self.0 {
             println!("{kind:?} {span:?}");
@@ -44,49 +38,5 @@ pub fn find_unsafe(show_spans: bool, tcx: TyCtxt<'_>) {
             continue;
         }
         unsafety::check_unsafety(def_id, &mut UnsafetyHandler(show_spans), tcx);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    struct LabelCollector(Vec<String>);
-
-    impl unsafety::UnsafetyHandler for LabelCollector {
-        fn handle_unsafety(&mut self, kind: UnsafeOpKind, _span: Span, tcx: TyCtxt<'_>) {
-            if let UnsafeOpKind::CallToUnsafeFunction(Some(def_id)) = kind {
-                self.0.push(unsafe_call_label(def_id, tcx));
-            }
-        }
-    }
-
-    #[test]
-    fn labels_box_from_raw_explicitly() {
-        let labels = utils::compilation::run_compiler_on_str(
-            r#"
-pub unsafe fn free_boxed(p: *mut i32) {
-    drop(Box::from_raw(p));
-}
-"#,
-            |tcx| {
-                let mut labels = Vec::new();
-                for item_id in tcx.hir_free_items() {
-                    let def_id = item_id.owner_id.def_id;
-                    let item = tcx.hir_item(item_id);
-                    if !matches!(item.kind, rustc_hir::ItemKind::Fn { .. }) {
-                        continue;
-                    }
-                    let mut collector = LabelCollector(Vec::new());
-                    unsafety::check_unsafety(def_id, &mut collector, tcx);
-                    labels.extend(collector.0);
-                }
-                labels
-            },
-        )
-        .unwrap();
-
-        assert!(labels.iter().any(|label| label == "Box::from_raw"));
-        assert!(!labels.iter().any(|label| label == "from_raw"));
     }
 }

--- a/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
@@ -605,17 +605,17 @@ impl BodyLifetimeFlow {
         place: Place<'tcx>,
         extra_depth: u8,
     ) -> Option<LifetimeSlot> {
-        if let Some((field, deref_depth, _)) = direct_raw_pointer_field_slot(local_decls, place) {
-            if extra_depth == 0 {
-                return self.slot_for_owner(
-                    LifetimeOwner::Field(FieldPlace {
-                        base: place.local,
-                        deref_depth,
-                        field,
-                    }),
-                    0,
-                );
-            }
+        if let Some((field, deref_depth, _)) = direct_raw_pointer_field_slot(local_decls, place)
+            && extra_depth == 0
+        {
+            return self.slot_for_owner(
+                LifetimeOwner::Field(FieldPlace {
+                    base: place.local,
+                    deref_depth,
+                    field,
+                }),
+                0,
+            );
         }
         let base_depth = place_deref_depth(place)?;
         let depth = base_depth.checked_add(extra_depth)?;

--- a/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/lifetime_flow.rs
@@ -5,14 +5,18 @@ use rustc_index::{
 };
 use rustc_middle::{
     mir::{
-        BinOp, Body, Const, ConstOperand, ConstValue, Local, Location, Operand, Place, PlaceElem,
-        RETURN_PLACE, Rvalue, Statement, StatementKind, Terminator, visit::Visitor,
+        BinOp, Body, Const, ConstOperand, ConstValue, HasLocalDecls, Local, Location, Operand,
+        Place, PlaceElem, RETURN_PLACE, Rvalue, Statement, StatementKind, Terminator,
+        visit::Visitor,
     },
     ty::{Ty, TyCtxt, TyKind},
 };
 use rustc_span::def_id::{DefId, LocalDefId};
 
-use super::is_borrowing_method;
+use super::{
+    ProvenanceOwner, StructFieldSlot, direct_raw_pointer_field_slot, is_borrowing_method,
+    is_direct_raw_ptr_ty,
+};
 use crate::{
     analyses::mir::{CallGraphPostOrder, CallKind, MirFunctionCall, TerminatorExt},
     utils::rustc::RustProgram,
@@ -33,8 +37,15 @@ pub enum SignatureRoot {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct SignatureSlot {
+pub struct SignaturePlace {
     pub root: SignatureRoot,
+    pub deref_depth: u8,
+    pub field: Option<StructFieldSlot>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SignatureSlot {
+    pub place: SignaturePlace,
     pub depth: u8,
 }
 
@@ -47,8 +58,21 @@ pub struct LifetimeFlowSummary {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct FieldPlace {
+    base: Local,
+    deref_depth: u8,
+    field: StructFieldSlot,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum LifetimeOwner {
+    Local(Local),
+    Field(FieldPlace),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct LocalSlot {
-    pub local: Local,
+    owner: LifetimeOwner,
     pub depth: u8,
 }
 
@@ -66,7 +90,7 @@ enum DerivedPlaceElem {
 #[derive(Clone, Debug)]
 pub struct BodyLifetimeFlow {
     pub slots: IndexVec<LifetimeSlot, LocalSlot>,
-    slot_map: FxHashMap<(usize, u8), LifetimeSlot>,
+    slot_map: FxHashMap<(LifetimeOwner, u8), LifetimeSlot>,
     pub value_flows: SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
     pub storage_aliases: SparseBitMatrix<LifetimeSlot, LifetimeSlot>,
     pub unknown_targets: DenseBitSet<LifetimeSlot>,
@@ -91,7 +115,7 @@ pub fn analyze_program_lifetime_flow(program: &RustProgram<'_>) -> LifetimeFlowR
 
     for &did in &program.functions {
         let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
-        let result = empty_lifetime_flow_result(&body);
+        let result = empty_lifetime_flow_result(tcx, &body);
         summaries.insert(did, result.summary.clone());
         results.insert(did, result);
     }
@@ -139,7 +163,7 @@ pub fn analyze_body_lifetime_flow_result<'tcx>(
     callee_summaries: &FxHashMap<LocalDefId, LifetimeFlowSummary>,
     program_functions: &FxHashSet<LocalDefId>,
 ) -> LifetimeFlowResult {
-    let mut body_flow = BodyLifetimeFlow::new(body);
+    let mut body_flow = BodyLifetimeFlow::new(tcx, body);
     let derived_place_sources = compute_derived_place_sources(tcx, body, &body_flow);
 
     FlowVisitor {
@@ -161,8 +185,8 @@ pub fn analyze_body_lifetime_flow_result<'tcx>(
     }
 }
 
-fn empty_lifetime_flow_result(body: &Body<'_>) -> LifetimeFlowResult {
-    let body_flow = BodyLifetimeFlow::new(body).closed();
+fn empty_lifetime_flow_result<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) -> LifetimeFlowResult {
+    let body_flow = BodyLifetimeFlow::new(tcx, body).closed();
     let summary = body_flow.to_summary(body);
     LifetimeFlowResult {
         summary,
@@ -482,7 +506,7 @@ impl<'flow, 'tcx> DerivedPlaceDataflow<'flow, 'tcx> {
         state: &DerivedPlaceSourceState,
         place: Place<'tcx>,
     ) -> Vec<LifetimeSlot> {
-        if let Some(slot) = self.flow.slot_for_place(place, 0) {
+        if let Some(slot) = self.flow.slot_for_place(self.body, place, 0) {
             return vec![slot];
         }
         let Some(key) = derived_place_key(place) else {
@@ -510,14 +534,20 @@ fn compute_derived_place_sources<'tcx>(
 }
 
 impl BodyLifetimeFlow {
-    fn new(body: &Body<'_>) -> Self {
+    fn new<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) -> Self {
         let mut slots = IndexVec::new();
         let mut slot_map = FxHashMap::default();
 
         for (local, local_decl) in body.local_decls.iter_enumerated() {
             for depth in 0..pointer_slot_count(local_decl.ty) {
-                let slot = slots.push(LocalSlot { local, depth });
-                slot_map.insert((local.index(), depth), slot);
+                let owner = LifetimeOwner::Local(local);
+                let slot = slots.push(LocalSlot { owner, depth });
+                slot_map.insert((owner, depth), slot);
+            }
+            for field_place in field_places_for_local(tcx, local, local_decl.ty) {
+                let owner = LifetimeOwner::Field(field_place);
+                let slot = slots.push(LocalSlot { owner, depth: 0 });
+                slot_map.insert((owner, 0), slot);
             }
         }
 
@@ -532,10 +562,14 @@ impl BodyLifetimeFlow {
     }
 
     pub fn slot_for_local(&self, local: Local, depth: u8) -> Option<LifetimeSlot> {
-        self.slot_map.get(&(local.index(), depth)).copied()
+        self.slot_for_owner(LifetimeOwner::Local(local), depth)
     }
 
-    pub fn depth0_value_flows(&self) -> Vec<(Local, Local)> {
+    fn slot_for_owner(&self, owner: LifetimeOwner, depth: u8) -> Option<LifetimeSlot> {
+        self.slot_map.get(&(owner, depth)).copied()
+    }
+
+    pub fn depth0_value_flows(&self) -> Vec<(ProvenanceOwner, ProvenanceOwner)> {
         let mut flows = vec![];
 
         for source in self.value_flows.rows() {
@@ -543,6 +577,9 @@ impl BodyLifetimeFlow {
             if source_slot.depth != 0 {
                 continue;
             }
+            let Some(source_owner) = provenance_owner(source_slot.owner) else {
+                continue;
+            };
 
             let Some(targets) = self.value_flows.row(source) else {
                 continue;
@@ -551,7 +588,10 @@ impl BodyLifetimeFlow {
             for target in targets.iter() {
                 let target_slot = self.slots[target];
                 if target_slot.depth == 0 {
-                    flows.push((source_slot.local, target_slot.local));
+                    let Some(target_owner) = provenance_owner(target_slot.owner) else {
+                        continue;
+                    };
+                    flows.push((source_owner, target_owner));
                 }
             }
         }
@@ -559,7 +599,24 @@ impl BodyLifetimeFlow {
         flows
     }
 
-    fn slot_for_place(&self, place: Place<'_>, extra_depth: u8) -> Option<LifetimeSlot> {
+    fn slot_for_place<'tcx, D: HasLocalDecls<'tcx>>(
+        &self,
+        local_decls: &D,
+        place: Place<'tcx>,
+        extra_depth: u8,
+    ) -> Option<LifetimeSlot> {
+        if let Some((field, deref_depth, _)) = direct_raw_pointer_field_slot(local_decls, place) {
+            if extra_depth == 0 {
+                return self.slot_for_owner(
+                    LifetimeOwner::Field(FieldPlace {
+                        base: place.local,
+                        deref_depth,
+                        field,
+                    }),
+                    0,
+                );
+            }
+        }
         let base_depth = place_deref_depth(place)?;
         let depth = base_depth.checked_add(extra_depth)?;
         self.slot_for_local(place.local, depth)
@@ -567,7 +624,7 @@ impl BodyLifetimeFlow {
 
     fn slot_after(&self, slot: LifetimeSlot, offset: u8) -> Option<LifetimeSlot> {
         let local_slot = self.slots[slot];
-        self.slot_for_local(local_slot.local, local_slot.depth.checked_add(offset)?)
+        self.slot_for_owner(local_slot.owner, local_slot.depth.checked_add(offset)?)
     }
 
     fn add_flow(&mut self, source: LifetimeSlot, target: LifetimeSlot) {
@@ -600,9 +657,14 @@ impl BodyLifetimeFlow {
         self.unknown_targets.insert(target);
     }
 
-    fn mark_unknown_place_slots(&mut self, place: Place<'_>, start_depth: u8) {
+    fn mark_unknown_place_slots<'tcx, D: HasLocalDecls<'tcx>>(
+        &mut self,
+        local_decls: &D,
+        place: Place<'tcx>,
+        start_depth: u8,
+    ) {
         for depth in start_depth..MAX_SIGNATURE_SLOT_DEPTH {
-            let Some(slot) = self.slot_for_place(place, depth) else {
+            let Some(slot) = self.slot_for_place(local_decls, place, depth) else {
                 break;
             };
             self.mark_unknown(slot);
@@ -643,9 +705,38 @@ impl BodyLifetimeFlow {
                 let Some(internal) = self.slot_for_local(local, depth) else {
                     continue;
                 };
-                let summary = slots.push(SignatureSlot { root, depth });
+                let summary = slots.push(SignatureSlot {
+                    place: SignaturePlace {
+                        root,
+                        deref_depth: 0,
+                        field: None,
+                    },
+                    depth,
+                });
                 internal_to_summary.insert(internal, summary);
             }
+        }
+
+        for (slot, local_slot) in self.slots.iter_enumerated() {
+            let LifetimeOwner::Field(field_place) = local_slot.owner else {
+                continue;
+            };
+            let root = if field_place.base == RETURN_PLACE {
+                SignatureRoot::Return
+            } else if field_place.base.index() <= body.arg_count {
+                SignatureRoot::Arg(field_place.base)
+            } else {
+                continue;
+            };
+            let summary = slots.push(SignatureSlot {
+                place: SignaturePlace {
+                    root,
+                    deref_depth: field_place.deref_depth,
+                    field: Some(field_place.field),
+                },
+                depth: local_slot.depth,
+            });
+            internal_to_summary.insert(slot, summary);
         }
 
         let mut value_flows = SparseBitMatrix::new(slots.len());
@@ -702,6 +793,47 @@ impl BodyLifetimeFlow {
     }
 }
 
+fn provenance_owner(owner: LifetimeOwner) -> Option<ProvenanceOwner> {
+    match owner {
+        LifetimeOwner::Local(local) => Some(ProvenanceOwner::Local(local)),
+        LifetimeOwner::Field(field_place) => Some(ProvenanceOwner::Field(field_place.field)),
+    }
+}
+
+fn field_places_for_local<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    local: Local,
+    mut ty: Ty<'tcx>,
+) -> Vec<FieldPlace> {
+    let mut fields = vec![];
+    for deref_depth in 0..=MAX_SIGNATURE_SLOT_DEPTH {
+        if let TyKind::Adt(adt_def, args) = ty.kind()
+            && adt_def.did().is_local()
+            && adt_def.is_struct()
+            && !adt_def.is_union()
+        {
+            for (field_index, field_def) in adt_def.all_fields().enumerate() {
+                if is_direct_raw_ptr_ty(field_def.ty(tcx, args)) {
+                    fields.push(FieldPlace {
+                        base: local,
+                        deref_depth,
+                        field: StructFieldSlot {
+                            struct_did: adt_def.did().expect_local(),
+                            field_index,
+                        },
+                    });
+                }
+            }
+        }
+
+        let Some(pointee) = pointer_pointee_ty(ty) else {
+            break;
+        };
+        ty = pointee;
+    }
+    fields
+}
+
 struct FlowVisitor<'flow, 'summary, 'tcx> {
     tcx: TyCtxt<'tcx>,
     body: &'flow Body<'tcx>,
@@ -742,7 +874,7 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
     }
 
     fn place_slots_or_derived(&self, place: Place<'tcx>, location: Location) -> Vec<LifetimeSlot> {
-        if let Some(slot) = self.flow.slot_for_place(place, 0) {
+        if let Some(slot) = self.flow.slot_for_place(self.body, place, 0) {
             return vec![slot];
         }
         self.derived_place_sources(place, location)
@@ -817,7 +949,7 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
     fn assign_from_place_address(&mut self, target: LifetimeSlot, place: Place<'tcx>) {
         match place_deref_depth(place) {
             Some(0) => {
-                if let Some(place_slot) = self.flow.slot_for_place(place, 0)
+                if let Some(place_slot) = self.flow.slot_for_place(self.body, place, 0)
                     && let Some(target_pointee) = self.flow.slot_after(target, 1)
                 {
                     self.flow.add_alias(target_pointee, place_slot);
@@ -859,7 +991,7 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
             return true;
         }
 
-        let Some(destination) = self.flow.slot_for_place(call.destination, 0) else {
+        let Some(destination) = self.flow.slot_for_place(self.body, call.destination, 0) else {
             return false;
         };
 
@@ -982,25 +1114,56 @@ impl<'flow, 'summary, 'tcx> FlowVisitor<'flow, 'summary, 'tcx> {
         call: &MirFunctionCall<'_, 'tcx>,
         slot: SignatureSlot,
     ) -> Option<LifetimeSlot> {
-        match slot.root {
-            SignatureRoot::Return => self.flow.slot_for_place(call.destination, slot.depth),
+        match slot.place.root {
+            SignatureRoot::Return => {
+                self.instantiate_signature_place(call.destination, slot.place, slot.depth)
+            }
             SignatureRoot::Arg(local) => {
                 let arg_index = local.index().checked_sub(1)?;
                 let arg = call.args.get(arg_index)?;
                 let place = arg.node.place()?;
-                self.flow.slot_for_place(place, slot.depth)
+                self.instantiate_signature_place(place, slot.place, slot.depth)
             }
         }
     }
 
+    fn instantiate_signature_place(
+        &self,
+        root_place: Place<'tcx>,
+        signature_place: SignaturePlace,
+        depth: u8,
+    ) -> Option<LifetimeSlot> {
+        if let Some(field) = signature_place.field {
+            if depth != 0 {
+                return None;
+            }
+            let root_depth = place_deref_depth(root_place)?;
+            return self.flow.slot_for_owner(
+                LifetimeOwner::Field(FieldPlace {
+                    base: root_place.local,
+                    deref_depth: root_depth.checked_add(signature_place.deref_depth)?,
+                    field,
+                }),
+                0,
+            );
+        }
+
+        self.flow.slot_for_place(
+            self.body,
+            root_place,
+            signature_place.deref_depth.checked_add(depth)?,
+        )
+    }
+
     fn mark_unknown_call_effects(&mut self, call: &MirFunctionCall<'_, 'tcx>) {
-        self.flow.mark_unknown_place_slots(call.destination, 0);
+        self.flow
+            .mark_unknown_place_slots(self.body, call.destination, 0);
 
         for arg in call.args {
             let Some(place) = arg.node.place() else {
                 continue;
             };
-            self.flow.mark_unknown_place_slots(place, 1);
+            self.flow.mark_unknown_place_slots(self.body, place, 1);
         }
     }
 }
@@ -1017,7 +1180,7 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
             return;
         }
 
-        let Some(target) = self.flow.slot_for_place(*place, 0) else {
+        let Some(target) = self.flow.slot_for_place(self.body, *place, 0) else {
             return;
         };
 
@@ -1068,7 +1231,7 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
             && is_borrowing_method(*def_id, self.tcx)
             && let Some(arg0) = call.args.first()
         {
-            if let Some(destination) = self.flow.slot_for_place(call.destination, 0) {
+            if let Some(destination) = self.flow.slot_for_place(self.body, call.destination, 0) {
                 self.assign_from_operand(destination, &arg0.node, location);
             }
             return;
@@ -1094,9 +1257,9 @@ impl<'tcx> Visitor<'tcx> for FlowVisitor<'_, '_, 'tcx> {
 }
 
 fn observable_value_target(slot: SignatureSlot) -> bool {
-    match slot.root {
+    match slot.place.root {
         SignatureRoot::Return => true,
-        SignatureRoot::Arg(_) => slot.depth > 0,
+        SignatureRoot::Arg(_) => slot.place.field.is_some() || slot.depth > 0,
     }
 }
 

--- a/crates/pointer_replacer/src/analyses/borrow/mod.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/mod.rs
@@ -19,9 +19,11 @@ use rustc_index::{
 use rustc_middle::{
     mir::{
         Body, HasLocalDecls, Local, Location, Operand, PassWhere, Place, PlaceElem, RETURN_PLACE,
-        Rvalue, Terminator, pretty::PrettyPrintMirOptions, visit::Visitor,
+        Rvalue, Terminator,
+        pretty::PrettyPrintMirOptions,
+        visit::{PlaceContext, Visitor},
     },
-    ty::TyCtxt,
+    ty::{Ty, TyCtxt, TyKind},
 };
 use rustc_mir_dataflow::{fmt::DebugWithContext, points::DenseLocationMap};
 use rustc_span::def_id::LocalDefId;
@@ -53,17 +55,41 @@ rustc_index::newtype_index! {
 }
 
 pub type PromotedMutRefs = FxHashMap<LocalDefId, DenseBitSet<Local>>;
+pub type PromotedFieldRefs = FxHashSet<StructFieldSlot>;
+
+#[allow(dead_code)]
+pub struct BorrowPromotionResults {
+    pub mutable_locals: FxHashMap<LocalDefId, DenseBitSet<Local>>,
+    pub shared_locals: FxHashMap<LocalDefId, DenseBitSet<Local>>,
+    pub mutable_fields: PromotedFieldRefs,
+    pub shared_fields: PromotedFieldRefs,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StructFieldSlot {
+    pub struct_did: LocalDefId,
+    pub field_index: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ProvenanceOwner {
+    Local(Local),
+    Field(StructFieldSlot),
+}
 
 pub enum ProvenanceData {
     PlaceHolder(Local, bool), // (Local, is_mutable)
     Local(Local, bool),       // (Local, is_mutable)
+    Field(StructFieldSlot, bool),
 }
 
 impl ProvenanceData {
-    pub fn local(&self) -> Local {
+    pub fn owner(&self) -> ProvenanceOwner {
         match self {
-            ProvenanceData::PlaceHolder(local, _) => *local,
-            ProvenanceData::Local(local, _) => *local,
+            ProvenanceData::PlaceHolder(local, _) | ProvenanceData::Local(local, _) => {
+                ProvenanceOwner::Local(*local)
+            }
+            ProvenanceData::Field(field, _) => ProvenanceOwner::Field(*field),
         }
     }
 
@@ -71,15 +97,60 @@ impl ProvenanceData {
         match self {
             ProvenanceData::PlaceHolder(_, is_mutable) => *is_mutable,
             ProvenanceData::Local(_, is_mutable) => *is_mutable,
+            ProvenanceData::Field(_, is_mutable) => *is_mutable,
         }
     }
 }
 
+fn is_direct_raw_ptr_ty(ty: Ty<'_>) -> bool {
+    matches!(ty.kind(), TyKind::RawPtr(..))
+}
+
+fn direct_raw_pointer_field_slot<'tcx, D: HasLocalDecls<'tcx>>(
+    local_decls: &D,
+    place: Place<'tcx>,
+) -> Option<(StructFieldSlot, u8, bool)> {
+    let mut base_ty = local_decls.local_decls()[place.local].ty;
+    let mut deref_depth = 0u8;
+
+    for (index, projection_elem) in place.projection.iter().enumerate() {
+        match projection_elem {
+            PlaceElem::Deref => {
+                deref_depth = deref_depth.checked_add(1)?;
+                base_ty = base_ty.builtin_deref(true)?;
+            }
+            PlaceElem::Field(field, field_ty) if index + 1 == place.projection.len() => {
+                let TyKind::Adt(adt_def, _) = base_ty.kind() else {
+                    return None;
+                };
+                if !adt_def.did().is_local() || !adt_def.is_struct() || adt_def.is_union() {
+                    return None;
+                }
+                let TyKind::RawPtr(_, mutability) = field_ty.kind() else {
+                    return None;
+                };
+                return Some((
+                    StructFieldSlot {
+                        struct_did: adt_def.did().expect_local(),
+                        field_index: field.index(),
+                    },
+                    deref_depth,
+                    mutability.is_mut(),
+                ));
+            }
+            PlaceElem::OpaqueCast(_) => {}
+            _ => return None,
+        }
+    }
+
+    None
+}
+
 impl std::fmt::Debug for ProvenanceData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let local = self.local();
+        let owner = self.owner();
         let is_mutable = self.is_mutable();
-        f.write_fmt(format_args!("'{local:?} (mutable: {is_mutable})"))
+        f.write_fmt(format_args!("'{owner:?} (mutable: {is_mutable})"))
     }
 }
 
@@ -87,8 +158,57 @@ impl std::fmt::Debug for ProvenanceData {
 /// for nested pointers. But I guess it could be fine?
 pub struct ProvenanceSet {
     local_data: IndexVec<Local, Option<Provenance>>,
+    field_data: FxHashMap<StructFieldSlot, Option<Provenance>>,
     provenance_data: IndexVec<Provenance, ProvenanceData>,
     tree_borrow_local: RefCell<UnionFind<Local>>,
+}
+
+impl ProvenanceSet {
+    fn provenance_for_owner(&self, owner: ProvenanceOwner) -> Option<Provenance> {
+        match owner {
+            ProvenanceOwner::Local(local) => self.local_data[local],
+            ProvenanceOwner::Field(field) => self.field_data.get(&field).copied().flatten(),
+        }
+    }
+
+    fn owner_for_place<'tcx, D: HasLocalDecls<'tcx>>(
+        &self,
+        local_decls: &D,
+        place: Place<'tcx>,
+    ) -> Option<ProvenanceOwner> {
+        if let Some(local) = place.as_local()
+            && self.local_data[local].is_some()
+        {
+            return Some(ProvenanceOwner::Local(local));
+        }
+
+        let Some((field, _, _)) = direct_raw_pointer_field_slot(local_decls, place) else {
+            return None;
+        };
+        self.field_data
+            .get(&field)
+            .copied()
+            .flatten()
+            .map(|_| ProvenanceOwner::Field(field))
+    }
+
+    fn disable_owner(&mut self, owner: ProvenanceOwner) -> bool {
+        match owner {
+            ProvenanceOwner::Local(local) => {
+                let changed = self.local_data[local].is_some();
+                self.local_data[local] = None;
+                changed
+            }
+            ProvenanceOwner::Field(field) => {
+                let Some(provenance) = self.field_data.get_mut(&field) else {
+                    return false;
+                };
+                let changed = provenance.is_some();
+                *provenance = None;
+                changed
+            }
+        }
+    }
 }
 
 pub trait HasProvenanceSet {
@@ -106,6 +226,7 @@ impl HasProvenanceSet for Body<'_> {
     {
         let body = self;
         let mut local_data = IndexVec::from_elem_n(None, body.local_decls.len());
+        let mut field_data = FxHashMap::default();
         let mut provenance_data = IndexVec::new();
 
         for (provenance, (local, local_decl)) in local_data
@@ -122,17 +243,81 @@ impl HasProvenanceSet for Body<'_> {
             }
         }
 
+        for (field, is_mutable) in collect_direct_raw_pointer_field_slots(body) {
+            field_data.entry(field).or_insert_with(|| {
+                Some(provenance_data.push(ProvenanceData::Field(field, is_mutable)))
+            });
+        }
+
         ProvenanceSet {
             local_data,
+            field_data,
             provenance_data,
             tree_borrow_local: RefCell::new(UnionFind::new(body.local_decls.len())),
         }
     }
 }
 
+fn collect_direct_raw_pointer_field_slots<'tcx>(
+    body: &Body<'tcx>,
+) -> FxHashMap<StructFieldSlot, bool> {
+    struct Vis<'body, 'tcx> {
+        body: &'body Body<'tcx>,
+        fields: FxHashMap<StructFieldSlot, bool>,
+    }
+
+    impl<'tcx> Visitor<'tcx> for Vis<'_, 'tcx> {
+        fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
+            if let Some((field, _, is_mutable)) = direct_raw_pointer_field_slot(self.body, *place) {
+                self.fields
+                    .entry(field)
+                    .and_modify(|mutable| *mutable |= is_mutable)
+                    .or_insert(is_mutable);
+            }
+            self.super_place(place, context, location);
+        }
+    }
+
+    let mut vis = Vis {
+        body,
+        fields: FxHashMap::default(),
+    };
+    vis.visit_body(body);
+    vis.fields
+}
+
+fn direct_raw_pointer_field_slots_in_ty<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    mut ty: Ty<'tcx>,
+) -> Vec<StructFieldSlot> {
+    let mut fields = vec![];
+    loop {
+        if let TyKind::Adt(adt_def, args) = ty.kind()
+            && adt_def.did().is_local()
+            && adt_def.is_struct()
+            && !adt_def.is_union()
+        {
+            for (field_index, field_def) in adt_def.all_fields().enumerate() {
+                if is_direct_raw_ptr_ty(field_def.ty(tcx, args)) {
+                    fields.push(StructFieldSlot {
+                        struct_did: adt_def.did().expect_local(),
+                        field_index,
+                    });
+                }
+            }
+        }
+        let Some(pointee) = ty.builtin_deref(true) else {
+            break;
+        };
+        ty = pointee;
+    }
+    fields
+}
+
 pub struct GBorrowInferCtxt {
     pub provenances: FxHashMap<LocalDefId, ProvenanceSet>,
     pub lifetime_flows: LifetimeFlowResults,
+    pub field_users: FxHashMap<StructFieldSlot, FxHashSet<LocalDefId>>,
 }
 
 impl GBorrowInferCtxt {
@@ -145,6 +330,8 @@ impl GBorrowInferCtxt {
     {
         let lifetime_flows = analyze_program_lifetime_flow(program);
         let mut provenances = FxHashMap::default();
+        let mut field_users: FxHashMap<StructFieldSlot, FxHashSet<LocalDefId>> =
+            FxHashMap::default();
         for f in program.functions.iter().copied() {
             let body = program
                 .tcx
@@ -153,11 +340,18 @@ impl GBorrowInferCtxt {
             let is_candidate = is_candidate(f);
             let is_mutable = is_mutable(f);
             provenances.insert(f, body.provenance_set(is_candidate, is_mutable));
+            for field in collect_direct_raw_pointer_field_slots(&body)
+                .keys()
+                .copied()
+            {
+                field_users.entry(field).or_default().insert(f);
+            }
         }
 
         GBorrowInferCtxt {
             provenances,
             lifetime_flows,
+            field_users,
         }
     }
 
@@ -199,12 +393,12 @@ impl<C> DebugWithContext<C> for Loan {}
 pub struct BorrowData<'tcx> {
     location: Location,
     borrowed: Place<'tcx>,
-    assigned: Borrower<'tcx>,
+    assigned: Borrower,
 }
 
 #[derive(Clone, Copy, Debug)]
-pub enum Borrower<'tcx> {
-    AssignStmt(Place<'tcx>),
+pub enum Borrower {
+    Assign(ProvenanceOwner),
     #[allow(unused)]
     CallArg(LocalDefId, usize),
 }
@@ -252,10 +446,11 @@ impl<'tcx> HasBorrowSet<'tcx> for Body<'tcx> {
                 rvalue: &Rvalue<'tcx>,
                 location: Location,
             ) {
-                if !matches!(lhs.as_local(), Some(lhs_local) if self.provenance_set.local_data[lhs_local].is_some())
-                {
+                let Some(assigned_owner) =
+                    self.provenance_set.owner_for_place(self.local_decl, *lhs)
+                else {
                     return self.super_assign(lhs, rvalue, location);
-                }
+                };
 
                 let rvalue_ty = rvalue.ty(self.local_decl, self.tcx);
                 if !rvalue_ty.is_any_ptr() {
@@ -268,7 +463,7 @@ impl<'tcx> HasBorrowSet<'tcx> for Body<'tcx> {
                         let loan = self.loans.push(BorrowData {
                             location,
                             borrowed: *place,
-                            assigned: Borrower::AssignStmt(*lhs),
+                            assigned: Borrower::Assign(assigned_owner),
                         });
                         loans.push(loan);
 
@@ -284,7 +479,7 @@ impl<'tcx> HasBorrowSet<'tcx> for Body<'tcx> {
                             let loan = self.loans.push(BorrowData {
                                 location,
                                 borrowed: Place::from(other_local),
-                                assigned: Borrower::AssignStmt(*lhs),
+                                assigned: Borrower::Assign(assigned_owner),
                             });
                             loans.push(loan);
                         }
@@ -298,7 +493,7 @@ impl<'tcx> HasBorrowSet<'tcx> for Body<'tcx> {
                         let loan = self.loans.push(BorrowData {
                             location,
                             borrowed: place.project_deeper(&[PlaceElem::Deref], self.tcx),
-                            assigned: Borrower::AssignStmt(*lhs),
+                            assigned: Borrower::Assign(assigned_owner),
                         });
                         loans.push(loan);
 
@@ -314,7 +509,7 @@ impl<'tcx> HasBorrowSet<'tcx> for Body<'tcx> {
                             let loan = self.loans.push(BorrowData {
                                 location,
                                 borrowed: Place::from(other_local),
-                                assigned: Borrower::AssignStmt(*lhs),
+                                assigned: Borrower::Assign(assigned_owner),
                             });
                             loans.push(loan);
                         }
@@ -336,13 +531,15 @@ impl<'tcx> HasBorrowSet<'tcx> for Body<'tcx> {
                     if is_borrowing_method(*def_id, self.tcx) {
                         let arg0 = &mir_call.args[0].node;
                         if let Some(arg0_place) = arg0.place()
-                            && self.provenance_set.local_data[mir_call.destination.local].is_some()
+                            && let Some(assigned_owner) = self
+                                .provenance_set
+                                .owner_for_place(self.local_decl, mir_call.destination)
                         {
                             let mut loans = vec![];
                             let loan = self.loans.push(BorrowData {
                                 location,
                                 borrowed: arg0_place.project_deeper(&[PlaceElem::Deref], self.tcx),
-                                assigned: Borrower::AssignStmt(mir_call.destination),
+                                assigned: Borrower::Assign(assigned_owner),
                             });
                             loans.push(loan);
 
@@ -358,7 +555,7 @@ impl<'tcx> HasBorrowSet<'tcx> for Body<'tcx> {
                                 let loan = self.loans.push(BorrowData {
                                     location,
                                     borrowed: Place::from(other_local),
-                                    assigned: Borrower::AssignStmt(mir_call.destination),
+                                    assigned: Borrower::Assign(assigned_owner),
                                 });
                                 loans.push(loan);
                             }
@@ -452,6 +649,7 @@ impl ProvenanceConstraintGraph {
     ) -> Self {
         struct Vis<'this, 'tcx> {
             tcx: TyCtxt<'tcx>,
+            body: &'this Body<'tcx>,
             graph: &'this mut ProvenanceConstraintGraph,
             borrow_set: &'this BorrowSet<'tcx>,
             provenance_set: &'this ProvenanceSet,
@@ -475,10 +673,12 @@ impl ProvenanceConstraintGraph {
                         ..
                     } = &self.borrow_set.loans[loan];
 
-                    let Some(lhs) = place.as_local() else {
+                    let Some(lhs_owner) = self.provenance_set.owner_for_place(self.body, *place)
+                    else {
                         return self.super_assign(place, rvalue, location);
                     };
-                    let lhs_provenance = self.provenance_set.local_data[lhs].unwrap();
+                    let lhs_provenance =
+                        self.provenance_set.provenance_for_owner(lhs_owner).unwrap();
 
                     self.graph.membership.push(MembershipConstraint {
                         loan,
@@ -546,6 +746,7 @@ impl ProvenanceConstraintGraph {
 
         Vis {
             tcx,
+            body,
             graph: &mut graph,
             borrow_set,
             provenance_set,
@@ -558,10 +759,10 @@ impl ProvenanceConstraintGraph {
             .get(&body.source.def_id().expect_local())
         {
             for (source, target) in lifetime_flow.body.depth0_value_flows() {
-                let Some(source_provenance) = provenance_set.local_data[source] else {
+                let Some(source_provenance) = provenance_set.provenance_for_owner(source) else {
                     continue;
                 };
-                let Some(target_provenance) = provenance_set.local_data[target] else {
+                let Some(target_provenance) = provenance_set.provenance_for_owner(target) else {
                     continue;
                 };
                 graph.subset.push(SubsetConstraint {
@@ -776,11 +977,25 @@ pub fn dump_coarse_inferred_bounds(program: &RustProgram, global_borrow_ctxt: &G
     }
 }
 
+#[allow(dead_code)]
 pub fn demote_pointers_iterative(
     program: &RustProgram,
     global_borrow_ctxt: &mut GBorrowInferCtxt,
 ) -> FxHashMap<LocalDefId, DenseBitSet<Local>> {
+    demote_pointers_iterative_with_fields(program, global_borrow_ctxt).locals
+}
+
+pub struct DemotionResults {
+    pub locals: FxHashMap<LocalDefId, DenseBitSet<Local>>,
+    pub fields: FxHashSet<StructFieldSlot>,
+}
+
+pub fn demote_pointers_iterative_with_fields(
+    program: &RustProgram,
+    global_borrow_ctxt: &mut GBorrowInferCtxt,
+) -> DemotionResults {
     let mut demoted = FxHashMap::default();
+    let mut demoted_fields = FxHashSet::default();
 
     let tcx = program.tcx;
 
@@ -818,66 +1033,109 @@ pub fn demote_pointers_iterative(
         }
 
         let mut demoted_locals = DenseBitSet::new_empty(body.local_decls.len());
+        let mut demoted_field_slots = FxHashSet::default();
 
-        let provenance_set = global_borrow_ctxt.provenances.get_mut(&f).unwrap();
+        let changed = {
+            let provenance_set = global_borrow_ctxt.provenances.get_mut(&f).unwrap();
 
-        // Demote every live provenance that depends on the invalid loan, not just
-        // the local where the borrow was originally assigned.
-        // (for inter-procedural borrow inference, e.g., p = id(q))
-        for loan in invalid_loans.iter() {
-            let borrow_data = &borrow_set.loans[loan];
-            for row in errors.rows() {
-                let Some(loans) = errors.row(row) else {
-                    continue;
-                };
-                if !loans.contains(loan) {
-                    continue;
-                }
-                let Some(live_provenances) = provenance_liveness.row(row) else {
-                    continue;
-                };
-                for provenance in live_provenances.iter() {
-                    if !requires.contains(provenance, loan) {
+            // Demote every live provenance that depends on the invalid loan, not just
+            // the local where the borrow was originally assigned.
+            // (for inter-procedural borrow inference, e.g., p = id(q))
+            for loan in invalid_loans.iter() {
+                let borrow_data = &borrow_set.loans[loan];
+                for row in errors.rows() {
+                    let Some(loans) = errors.row(row) else {
+                        continue;
+                    };
+                    if !loans.contains(loan) {
                         continue;
                     }
-                    let local = provenance_set.provenance_data[provenance].local();
-                    demoted_locals.insert(local);
-                    provenance_set
-                        .tree_borrow_local
-                        .get_mut()
-                        .union(local, borrow_data.borrowed.local);
+                    let Some(live_provenances) = provenance_liveness.row(row) else {
+                        continue;
+                    };
+                    for provenance in live_provenances.iter() {
+                        if !requires.contains(provenance, loan) {
+                            continue;
+                        }
+                        match provenance_set.provenance_data[provenance].owner() {
+                            ProvenanceOwner::Local(local) => {
+                                demoted_locals.insert(local);
+                                provenance_set
+                                    .tree_borrow_local
+                                    .get_mut()
+                                    .union(local, borrow_data.borrowed.local);
+                            }
+                            ProvenanceOwner::Field(field) => {
+                                demoted_field_slots.insert(field);
+                            }
+                        }
+                    }
                 }
             }
-        }
 
-        for loan in invalid_loans.iter() {
-            let borrow_data = &borrow_set.loans[loan];
-            if let Borrower::AssignStmt(assigned) = borrow_data.assigned {
-                demoted_locals.insert(assigned.local);
-                provenance_set
-                    .tree_borrow_local
-                    .get_mut()
-                    .union(assigned.local, borrow_data.borrowed.local);
+            for loan in invalid_loans.iter() {
+                let borrow_data = &borrow_set.loans[loan];
+                if let Borrower::Assign(assigned) = borrow_data.assigned {
+                    match assigned {
+                        ProvenanceOwner::Local(local) => {
+                            demoted_locals.insert(local);
+                            provenance_set
+                                .tree_borrow_local
+                                .get_mut()
+                                .union(local, borrow_data.borrowed.local);
+                        }
+                        ProvenanceOwner::Field(field) => {
+                            demoted_field_slots.insert(field);
+                        }
+                    }
+                }
             }
-        }
 
-        let mut changed = false;
-        for (local, provenance) in provenance_set.local_data.iter_enumerated_mut() {
-            if demoted_locals.contains(local) && provenance.is_some() {
-                changed = true;
-                *provenance = None;
+            let mut changed = false;
+            for (local, provenance) in provenance_set.local_data.iter_enumerated_mut() {
+                if demoted_locals.contains(local) && provenance.is_some() {
+                    changed = true;
+                    *provenance = None;
+                }
             }
-        }
+            for field in demoted_field_slots.iter().copied() {
+                changed |= provenance_set.disable_owner(ProvenanceOwner::Field(field));
+            }
+            changed
+        };
 
         if changed && !in_worklist.contains(&f) {
             worklist.push_back(f);
             in_worklist.insert(f);
         }
 
+        for field in demoted_field_slots.iter().copied() {
+            if !demoted_fields.insert(field) {
+                continue;
+            }
+            let users = global_borrow_ctxt
+                .field_users
+                .get(&field)
+                .cloned()
+                .unwrap_or_default();
+            for user in users {
+                if let Some(provenance_set) = global_borrow_ctxt.provenances.get_mut(&user) {
+                    provenance_set.disable_owner(ProvenanceOwner::Field(field));
+                }
+                if !in_worklist.contains(&user) {
+                    worklist.push_back(user);
+                    in_worklist.insert(user);
+                }
+            }
+        }
+
         demoted.get_mut(&f).unwrap().union(&demoted_locals);
     }
 
-    demoted
+    DemotionResults {
+        locals: demoted,
+        fields: demoted_fields,
+    }
 }
 
 /// Analyse which raw pointer locals within a function can potentially be a mutable references.
@@ -891,14 +1149,47 @@ pub fn mutable_references_no_guarantee(
     FxHashMap<LocalDefId, DenseBitSet<Local>>,
     FxHashMap<LocalDefId, DenseBitSet<Local>>,
 ) {
+    let results = classified_references_with_fields_no_guarantee(program, mutables);
+    (results.mutable_locals, results.shared_locals)
+}
+
+#[allow(dead_code)]
+pub fn mutable_references_with_fields_no_guarantee(
+    program: &RustProgram,
+) -> BorrowPromotionResults {
+    let mutables = program
+        .functions
+        .iter()
+        .map(|&f| {
+            let body = program
+                .tcx
+                .mir_drops_elaborated_and_const_checked(f)
+                .borrow();
+            let facts = body
+                .local_decls
+                .iter()
+                .map(|_| true)
+                .collect::<IndexVec<Local, _>>();
+            (f, facts)
+        })
+        .collect::<FxHashMap<_, _>>();
+    classified_references_with_fields_no_guarantee(program, &mutables)
+}
+
+pub fn classified_references_with_fields_no_guarantee(
+    program: &RustProgram,
+    mutables: &FxHashMap<LocalDefId, IndexVec<Local, bool>>,
+) -> BorrowPromotionResults {
     let mut mutable_references = FxHashMap::default();
     let mut shared_references = FxHashMap::default();
+    let mut mutable_fields = FxHashSet::default();
+    let mut shared_fields = FxHashSet::default();
 
     let mut global_borrow_ctxt = GBorrowInferCtxt::classified_pointers(program, mutables);
     // let demoted = demote_pointers(program, &global_borrow_ctxt);
-    let demoted = demote_pointers_iterative(program, &mut global_borrow_ctxt);
+    let demoted = demote_pointers_iterative_with_fields(program, &mut global_borrow_ctxt);
 
-    for (&f, demoted) in demoted.iter() {
+    for (&f, demoted) in demoted.locals.iter() {
         let provenance_set = &global_borrow_ctxt.provenances[&f];
         let mut promoted_mutable = DenseBitSet::new_empty(demoted.domain_size());
         let mut promoted_shared = DenseBitSet::new_empty(demoted.domain_size());
@@ -919,7 +1210,28 @@ pub fn mutable_references_no_guarantee(
         shared_references.insert(f, promoted_shared);
     }
 
-    (mutable_references, shared_references)
+    for provenance_set in global_borrow_ctxt.provenances.values() {
+        for (&field, &provenance) in &provenance_set.field_data {
+            if demoted.fields.contains(&field) {
+                continue;
+            }
+            let Some(provenance) = provenance else {
+                continue;
+            };
+            if provenance_set.provenance_data[provenance].is_mutable() {
+                mutable_fields.insert(field);
+            } else {
+                shared_fields.insert(field);
+            }
+        }
+    }
+
+    BorrowPromotionResults {
+        mutable_locals: mutable_references,
+        shared_locals: shared_references,
+        mutable_fields,
+        shared_fields,
+    }
 }
 
 #[cfg(test)]

--- a/crates/pointer_replacer/src/analyses/borrow/mod.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/mod.rs
@@ -63,6 +63,7 @@ pub struct BorrowPromotionResults {
     pub shared_locals: FxHashMap<LocalDefId, DenseBitSet<Local>>,
     pub mutable_fields: PromotedFieldRefs,
     pub shared_fields: PromotedFieldRefs,
+    pub lifetime_flows: LifetimeFlowResults,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -1204,6 +1205,7 @@ pub fn classified_references_with_fields_no_guarantee(
         shared_locals: shared_references,
         mutable_fields,
         shared_fields,
+        lifetime_flows: global_borrow_ctxt.lifetime_flows,
     }
 }
 

--- a/crates/pointer_replacer/src/analyses/borrow/mod.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/mod.rs
@@ -183,9 +183,7 @@ impl ProvenanceSet {
             return Some(ProvenanceOwner::Local(local));
         }
 
-        let Some((field, _, _)) = direct_raw_pointer_field_slot(local_decls, place) else {
-            return None;
-        };
+        let (field, _, _) = direct_raw_pointer_field_slot(local_decls, place)?;
         self.field_data
             .get(&field)
             .copied()

--- a/crates/pointer_replacer/src/analyses/borrow/mod.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/mod.rs
@@ -1145,35 +1145,8 @@ pub fn demote_pointers_iterative_with_fields(
 pub fn mutable_references_no_guarantee(
     program: &RustProgram,
     mutables: &FxHashMap<LocalDefId, IndexVec<Local, bool>>,
-) -> (
-    FxHashMap<LocalDefId, DenseBitSet<Local>>,
-    FxHashMap<LocalDefId, DenseBitSet<Local>>,
-) {
-    let results = classified_references_with_fields_no_guarantee(program, mutables);
-    (results.mutable_locals, results.shared_locals)
-}
-
-#[allow(dead_code)]
-pub fn mutable_references_with_fields_no_guarantee(
-    program: &RustProgram,
 ) -> BorrowPromotionResults {
-    let mutables = program
-        .functions
-        .iter()
-        .map(|&f| {
-            let body = program
-                .tcx
-                .mir_drops_elaborated_and_const_checked(f)
-                .borrow();
-            let facts = body
-                .local_decls
-                .iter()
-                .map(|_| true)
-                .collect::<IndexVec<Local, _>>();
-            (f, facts)
-        })
-        .collect::<FxHashMap<_, _>>();
-    classified_references_with_fields_no_guarantee(program, &mutables)
+    classified_references_with_fields_no_guarantee(program, mutables)
 }
 
 pub fn classified_references_with_fields_no_guarantee(

--- a/crates/pointer_replacer/src/analyses/borrow/provenance_liveness.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/provenance_liveness.rs
@@ -8,7 +8,7 @@ use rustc_mir_dataflow::{
     points::{DenseLocationMap, PointIndex},
 };
 
-use super::{Provenance, ProvenanceSet};
+use super::{Provenance, ProvenanceSet, direct_raw_pointer_field_slots_in_ty};
 use crate::analyses::{liveness::MaybeLiveLocals, mir::TerminatorExt};
 
 /// The set of program points that a [`Provenance`] is live on exit
@@ -40,11 +40,17 @@ pub fn compute_provenance_liveness<'tcx>(
 
             local_liveness.seek_before_primary_effect(location);
             let liveness = local_liveness.get();
-            for provenance in liveness
-                .iter()
-                .flat_map(|local| provenance_set.local_data[local])
-            {
-                provenance_liveness.insert(point_index, provenance);
+            for local in liveness.iter() {
+                if let Some(provenance) = provenance_set.local_data[local] {
+                    provenance_liveness.insert(point_index, provenance);
+                }
+                for field in direct_raw_pointer_field_slots_in_ty(tcx, body.local_decls[local].ty) {
+                    if let Some(provenance) =
+                        provenance_set.field_data.get(&field).copied().flatten()
+                    {
+                        provenance_liveness.insert(point_index, provenance);
+                    }
+                }
             }
 
             if position == bb_len - 1 {

--- a/crates/pointer_replacer/src/analyses/borrow/tests.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/tests.rs
@@ -5,6 +5,7 @@ use super::*;
 
 fn build_rust_program(tcx: TyCtxt<'_>) -> RustProgram<'_> {
     let mut functions = vec![];
+    let mut structs = vec![];
     for maybe_owner in tcx.hir_crate(()).owners.iter() {
         let Some(owner) = maybe_owner.as_owner() else {
             continue;
@@ -12,14 +13,16 @@ fn build_rust_program(tcx: TyCtxt<'_>) -> RustProgram<'_> {
         let OwnerNode::Item(item) = owner.node() else {
             continue;
         };
-        if matches!(item.kind, ItemKind::Fn { .. }) {
-            functions.push(item.owner_id.def_id);
+        match item.kind {
+            ItemKind::Fn { .. } => functions.push(item.owner_id.def_id),
+            ItemKind::Struct(..) => structs.push(item.owner_id.def_id),
+            _ => {}
         }
     }
     RustProgram {
         tcx,
         functions,
-        structs: vec![],
+        structs,
     }
 }
 
@@ -58,6 +61,61 @@ fn run_demote(code: &str) -> Vec<String> {
         }
         all_demoted.sort();
         all_demoted
+    })
+    .unwrap()
+}
+
+fn run_demote_fields(code: &str) -> Vec<String> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let program = build_rust_program(tcx);
+        let mut ctxt = all_mutable_ctxt(&program);
+        let demoted = demote_pointers_iterative_with_fields(&program, &mut ctxt);
+        let mut fields = demoted
+            .fields
+            .iter()
+            .map(|field| {
+                let struct_name = tcx.item_name(field.struct_did.to_def_id());
+                format!("{}::field{}", struct_name, field.field_index)
+            })
+            .collect::<Vec<_>>();
+        fields.sort();
+        fields
+    })
+    .unwrap()
+}
+
+fn run_promoted_mut_fields(code: &str) -> Vec<String> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let program = build_rust_program(tcx);
+        let results = mutable_references_with_fields_no_guarantee(&program);
+        let mut fields = results
+            .mutable_fields
+            .iter()
+            .map(|field| {
+                let struct_name = tcx.item_name(field.struct_did.to_def_id());
+                format!("{}::field{}", struct_name, field.field_index)
+            })
+            .collect::<Vec<_>>();
+        fields.sort();
+        fields
+    })
+    .unwrap()
+}
+
+fn run_promoted_shared_fields(code: &str) -> Vec<String> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let program = build_rust_program(tcx);
+        let results = mutable_references_with_fields_no_guarantee(&program);
+        let mut fields = results
+            .shared_fields
+            .iter()
+            .map(|field| {
+                let struct_name = tcx.item_name(field.struct_did.to_def_id());
+                format!("{}::field{}", struct_name, field.field_index)
+            })
+            .collect::<Vec<_>>();
+        fields.sort();
+        fields
     })
     .unwrap()
 }
@@ -168,11 +226,17 @@ fn collect_lifetime_flow_edges(
 }
 
 fn format_signature_slot(slot: lifetime_flow::SignatureSlot) -> String {
-    let root = match slot.root {
+    let root = match slot.place.root {
         lifetime_flow::SignatureRoot::Return => "return".to_string(),
         lifetime_flow::SignatureRoot::Arg(local) => format!("arg{}", local.index()),
     };
-    format!("{root}@{}", slot.depth)
+    let derefs = "*".repeat(slot.place.deref_depth as usize);
+    let field = slot
+        .place
+        .field
+        .map(|field| format!(".field{}", field.field_index))
+        .unwrap_or_default();
+    format!("{root}{derefs}{field}@{}", slot.depth)
 }
 
 fn assert_lifetime_flow_edge(
@@ -361,6 +425,43 @@ fn lifetime_flow_read_output() {
         "read output should flow out arg1@1 to return@0; got {:?}",
         edges["read_out"]
     );
+}
+
+#[test]
+fn lifetime_flow_arg_deref_field_return() {
+    let facts = get_lifetime_flow_facts(
+        "
+        #[repr(C)]
+        struct Holder {
+            p: *mut i32,
+        }
+
+        unsafe fn get(h: *mut Holder) -> *mut i32 {
+            (*h).p
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "get", "arg1*.field0@0", "return@0");
+}
+
+#[test]
+fn lifetime_flow_store_then_load_arg_deref_field() {
+    let facts = get_lifetime_flow_facts(
+        "
+        #[repr(C)]
+        struct Holder {
+            p: *mut i32,
+        }
+
+        unsafe fn store_then_get(h: *mut Holder, p: *mut i32) -> *mut i32 {
+            (*h).p = p;
+            (*h).p
+        }
+        ",
+    );
+    assert_lifetime_flow_edge(&facts, "store_then_get", "arg2@0", "return@0");
+    assert_lifetime_flow_edge(&facts, "store_then_get", "arg2@0", "arg1*.field0@0");
+    assert_lifetime_flow_edge(&facts, "store_then_get", "arg1*.field0@0", "return@0");
 }
 
 #[test]
@@ -806,6 +907,75 @@ fn test_demote_strategy_no_ub() {
         ",
     );
     assert_eq!(demoted, vec!["x", "y"], "both x and y should be demoted");
+}
+
+#[test]
+fn demote_struct_field_assignment_on_conflict() {
+    let demoted_fields = run_demote_fields(
+        "
+        struct Holder {
+            p: *mut i32,
+        }
+
+        unsafe fn f() {
+            let mut x = 0i32;
+            let mut h = Holder { p: core::ptr::null_mut() };
+            h.p = &raw mut x;
+            x = 1;
+            *h.p = 2;
+        }
+        ",
+    );
+    assert_eq!(
+        demoted_fields,
+        vec!["Holder::field0"],
+        "conflicting use of h.p should demote the global Holder::p field slot"
+    );
+}
+
+#[test]
+fn promote_direct_struct_field_without_conflict() {
+    let promoted_fields = run_promoted_mut_fields(
+        "
+        struct Holder {
+            p: *mut i32,
+        }
+
+        unsafe fn f() {
+            let mut x = 0i32;
+            let mut h = Holder { p: core::ptr::null_mut() };
+            h.p = &raw mut x;
+            *h.p = 1;
+        }
+        ",
+    );
+    assert_eq!(
+        promoted_fields,
+        vec!["Holder::field0"],
+        "Holder::p should be promoted when its field borrow has no conflict"
+    );
+}
+
+#[test]
+fn promote_direct_const_struct_field_without_conflict() {
+    let promoted_fields = run_promoted_shared_fields(
+        "
+        struct Holder {
+            p: *const i32,
+        }
+
+        unsafe fn f() -> i32 {
+            let x = 0i32;
+            let h = Holder { p: &raw const x };
+            *h.p
+        }
+        ",
+    );
+    assert_eq!(
+        promoted_fields,
+        vec!["Holder::field0"],
+        "Holder::p should be promoted as shared when it is a const raw pointer field"
+    );
 }
 
 #[test]

--- a/crates/pointer_replacer/src/analyses/borrow/tests.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/tests.rs
@@ -30,6 +30,25 @@ fn all_mutable_ctxt(program: &RustProgram) -> GBorrowInferCtxt {
     GBorrowInferCtxt::new(program, |_| |_| true, |_| |_| true)
 }
 
+fn all_mutable_facts(program: &RustProgram) -> FxHashMap<LocalDefId, IndexVec<Local, bool>> {
+    program
+        .functions
+        .iter()
+        .map(|&f| {
+            let body = program
+                .tcx
+                .mir_drops_elaborated_and_const_checked(f)
+                .borrow();
+            let facts = body
+                .local_decls
+                .iter()
+                .map(|_| true)
+                .collect::<IndexVec<Local, _>>();
+            (f, facts)
+        })
+        .collect()
+}
+
 fn user_var_names(tcx: TyCtxt, def_id: LocalDefId, locals: &DenseBitSet<Local>) -> Vec<String> {
     let body = &*tcx.mir_drops_elaborated_and_const_checked(def_id).borrow();
     let mut names = vec![];
@@ -87,7 +106,8 @@ fn run_demote_fields(code: &str) -> Vec<String> {
 fn run_promoted_mut_fields(code: &str) -> Vec<String> {
     ::utils::compilation::run_compiler_on_str(code, |tcx| {
         let program = build_rust_program(tcx);
-        let results = mutable_references_with_fields_no_guarantee(&program);
+        let mutables = all_mutable_facts(&program);
+        let results = mutable_references_no_guarantee(&program, &mutables);
         let mut fields = results
             .mutable_fields
             .iter()
@@ -105,7 +125,8 @@ fn run_promoted_mut_fields(code: &str) -> Vec<String> {
 fn run_promoted_shared_fields(code: &str) -> Vec<String> {
     ::utils::compilation::run_compiler_on_str(code, |tcx| {
         let program = build_rust_program(tcx);
-        let results = mutable_references_with_fields_no_guarantee(&program);
+        let mutables = all_mutable_facts(&program);
+        let results = mutable_references_no_guarantee(&program, &mutables);
         let mut fields = results
             .shared_fields
             .iter()

--- a/crates/pointer_replacer/src/analyses/mod.rs
+++ b/crates/pointer_replacer/src/analyses/mod.rs
@@ -9,4 +9,5 @@ pub mod offset_sign;
 pub(crate) mod output_params;
 pub mod ownership;
 pub mod struct_array_field;
+pub mod struct_copy;
 pub mod type_qualifier;

--- a/crates/pointer_replacer/src/analyses/offset_sign/sign.rs
+++ b/crates/pointer_replacer/src/analyses/offset_sign/sign.rs
@@ -24,12 +24,13 @@ use rustc_mir_dataflow::{
 use rustc_span::def_id::LocalDefId;
 use utils::graph;
 
-use crate::utils::rustc::RustProgram;
+use crate::{analyses::borrow::StructFieldSlot, utils::rustc::RustProgram};
 
 // Analysis output
 #[derive(Debug, Default)]
 pub struct OffsetSignResult {
     pub access_signs: FxHashMap<LocalDefId, DenseBitSet<Local>>,
+    pub field_access_signs: FxHashSet<StructFieldSlot>,
 }
 
 /// abstract-value lattice combining concrete constants with sign
@@ -1078,14 +1079,30 @@ fn eval_integer_terminator_call<'tcx>(
 type Node = (LocalDefId, Local);
 type SignGraph = FxHashMap<Node, FxHashSet<Node>>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum FieldNode {
+    Local(LocalDefId, Local),
+    Field(StructFieldSlot),
+}
+
+type FieldSignGraph = FxHashMap<FieldNode, FxHashSet<FieldNode>>;
+
+fn add_field_edge(graph: &mut FieldSignGraph, lhs: FieldNode, rhs: FieldNode) {
+    graph.entry(lhs).or_default().insert(rhs);
+    graph.entry(rhs).or_default();
+}
+
 // collect flow-edges of offset inforamtion in program
 #[allow(dead_code)]
 struct Collector<'mir, 'tcx, 'a> {
     tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
+    body: &'mir Body<'tcx>,
     cursor: &'a mut ResultsCursor<'mir, 'tcx, Signedness<'a, 'tcx>>,
     graph: &'a mut FxHashMap<Node, FxHashSet<Node>>,
     tainted: &'a mut FxHashSet<Node>,
+    field_graph: &'a mut FieldSignGraph,
+    field_tainted: &'a mut FxHashSet<FieldNode>,
     addr_takens: &'a FxHashSet<Local>,
 }
 
@@ -1094,6 +1111,45 @@ fn contains_deref(place: &Place<'_>) -> bool {
         .projection
         .iter()
         .any(|elem| matches!(elem, mir::ProjectionElem::Deref))
+}
+
+fn raw_pointer_field_slot<'tcx>(body: &Body<'tcx>, place: Place<'tcx>) -> Option<StructFieldSlot> {
+    let mut base_ty = body.local_decls[place.local].ty;
+
+    for (index, projection_elem) in place.projection.iter().enumerate() {
+        match projection_elem {
+            mir::ProjectionElem::Deref => {
+                base_ty = base_ty.builtin_deref(true)?;
+            }
+            mir::ProjectionElem::Field(field, field_ty) if index + 1 == place.projection.len() => {
+                let ty::TyKind::Adt(adt_def, _) = base_ty.kind() else {
+                    return None;
+                };
+                if !adt_def.did().is_local() || !adt_def.is_struct() || adt_def.is_union() {
+                    return None;
+                }
+                let ty::TyKind::RawPtr(..) = field_ty.kind() else {
+                    return None;
+                };
+                return Some(StructFieldSlot {
+                    struct_did: adt_def.did().expect_local(),
+                    field_index: field.index(),
+                });
+            }
+            mir::ProjectionElem::OpaqueCast(_) => {}
+            _ => return None,
+        }
+    }
+
+    None
+}
+
+fn copied_place_from_rvalue<'tcx>(rvalue: &Rvalue<'tcx>) -> Option<Place<'tcx>> {
+    match rvalue {
+        Rvalue::Use(Operand::Copy(place) | Operand::Move(place))
+        | Rvalue::Cast(_, Operand::Copy(place) | Operand::Move(place), _) => Some(*place),
+        _ => None,
+    }
 }
 
 fn is_pointer_offset_like_call(name: &str) -> bool {
@@ -1109,6 +1165,23 @@ fn is_pointer_offset_like_call(name: &str) -> bool {
 impl<'mir, 'tcx, 'a> MVisitor<'tcx> for Collector<'mir, 'tcx, 'a> {
     fn visit_statement(&mut self, stmt: &mir::Statement<'tcx>, _location: Location) {
         if let StatementKind::Assign(box (place, rvalue)) = &stmt.kind {
+            if let Some(dst) = copied_place_from_rvalue(rvalue) {
+                let lhs = raw_pointer_field_slot(self.body, *place)
+                    .map(FieldNode::Field)
+                    .or_else(|| {
+                        (!contains_deref(place))
+                            .then_some(FieldNode::Local(self.def_id, place.local))
+                    });
+                let rhs = raw_pointer_field_slot(self.body, dst)
+                    .map(FieldNode::Field)
+                    .or_else(|| {
+                        (!contains_deref(&dst)).then_some(FieldNode::Local(self.def_id, dst.local))
+                    });
+                if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
+                    add_field_edge(self.field_graph, lhs, rhs);
+                }
+            }
+
             if contains_deref(place) {
                 match rvalue {
                     Rvalue::Use(Operand::Copy(dst) | Operand::Move(dst))
@@ -1160,6 +1233,11 @@ impl<'mir, 'tcx, 'a> MVisitor<'tcx> for Collector<'mir, 'tcx, 'a> {
                         let offset_val = eval_operand(&offset_arg.node, &state.0, self.tcx);
                         if offset_val.needs_cursor() {
                             self.tainted.insert((self.def_id, place.local));
+                            let field_node = raw_pointer_field_slot(self.body, *place)
+                                .map(FieldNode::Field)
+                                .unwrap_or(FieldNode::Local(self.def_id, place.local));
+                            self.field_graph.entry(field_node).or_default();
+                            self.field_tainted.insert(field_node);
                         }
                     }
                 }
@@ -1178,6 +1256,12 @@ impl<'mir, 'tcx, 'a> MVisitor<'tcx> for Collector<'mir, 'tcx, 'a> {
                             .entry(callee_param)
                             .or_default()
                             .insert(caller_arg);
+
+                        let lhs = FieldNode::Local(local_def_id, param);
+                        let rhs = raw_pointer_field_slot(self.body, *place)
+                            .map(FieldNode::Field)
+                            .unwrap_or(FieldNode::Local(self.def_id, place.local));
+                        add_field_edge(self.field_graph, lhs, rhs);
                     }
                 }
             };
@@ -1273,6 +1357,8 @@ pub fn offset_sign_analysis(rust_program: &RustProgram<'_>) -> OffsetSignResult 
 
     let mut graph: SignGraph = FxHashMap::default();
     let mut tainted: FxHashSet<Node> = FxHashSet::default();
+    let mut field_graph: FieldSignGraph = FxHashMap::default();
+    let mut field_tainted: FxHashSet<FieldNode> = FxHashSet::default();
     let mut access_signs: FxHashMap<LocalDefId, DenseBitSet<Local>> = FxHashMap::default();
 
     // phase 1: re-run analysis with caller-refined parameter initializations
@@ -1281,6 +1367,7 @@ pub fn offset_sign_analysis(rust_program: &RustProgram<'_>) -> OffsetSignResult 
 
         for (local, _) in body.local_decls.iter_enumerated() {
             graph.insert((def_id, local), FxHashSet::default());
+            field_graph.insert(FieldNode::Local(def_id, local), FxHashSet::default());
         }
 
         // extract per-function caller param vals; empty = no known callers = type-based fallback
@@ -1305,9 +1392,12 @@ pub fn offset_sign_analysis(rust_program: &RustProgram<'_>) -> OffsetSignResult 
         let mut collector = Collector {
             tcx,
             def_id,
+            body: &body,
             cursor: &mut cursor,
             graph: &mut graph,
             tainted: &mut tainted,
+            field_graph: &mut field_graph,
+            field_tainted: &mut field_tainted,
             addr_takens: &addr_takens,
         };
         collector.visit_body(&body);
@@ -1350,5 +1440,30 @@ pub fn offset_sign_analysis(rust_program: &RustProgram<'_>) -> OffsetSignResult 
         access_signs.insert(def_id, access_sign);
     }
 
-    OffsetSignResult { access_signs }
+    let field_sccs = graph::sccs_copied::<_, false>(&field_graph);
+    let mut field_worklist: VecDeque<graph::SccId> = field_tainted
+        .iter()
+        .filter_map(|node| field_sccs.indices.get(node).copied())
+        .collect();
+    let mut field_tainted_sccs: FxHashSet<graph::SccId> = FxHashSet::default();
+    while let Some(scc_id) = field_worklist.pop_front() {
+        if !field_tainted_sccs.insert(scc_id) {
+            continue;
+        }
+        field_worklist.extend(field_sccs.successors(scc_id));
+    }
+
+    let field_access_signs = field_tainted_sccs
+        .iter()
+        .flat_map(|&scc_id| &field_sccs.scc_elems[scc_id])
+        .filter_map(|node| match node {
+            FieldNode::Field(field) => Some(*field),
+            FieldNode::Local(..) => None,
+        })
+        .collect();
+
+    OffsetSignResult {
+        access_signs,
+        field_access_signs,
+    }
 }

--- a/crates/pointer_replacer/src/analyses/offset_sign/tests.rs
+++ b/crates/pointer_replacer/src/analyses/offset_sign/tests.rs
@@ -70,6 +70,35 @@ fn needs_cursor(map: &FxHashMap<(String, String), bool>, fn_name: &str, var: &st
     map.get(&(fn_name.to_string(), var.to_string())).copied()
 }
 
+fn run_field_analysis(code: &str) -> FxHashMap<(String, String), bool> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let rust_program = build_rust_program(tcx);
+        let result = offset_sign_analysis(&rust_program);
+        let mut map = FxHashMap::default();
+        for field in &result.field_access_signs {
+            let struct_name = tcx.item_name(field.struct_did.to_def_id()).to_string();
+            let field_name = tcx
+                .adt_def(field.struct_did)
+                .all_fields()
+                .nth(field.field_index)
+                .map(|field| field.name.to_string())
+                .unwrap_or_else(|| field.field_index.to_string());
+            map.insert((struct_name, field_name), true);
+        }
+        map
+    })
+    .unwrap()
+}
+
+fn field_needs_cursor(
+    map: &FxHashMap<(String, String), bool>,
+    struct_name: &str,
+    field_name: &str,
+) -> Option<bool> {
+    map.get(&(struct_name.to_string(), field_name.to_string()))
+        .copied()
+}
+
 #[test]
 fn lit_neg_needs_cursor() {
     let map = run_analysis(
@@ -866,6 +895,51 @@ fn struct_field_deref_not_flagged() {
         needs_cursor(&map, "use_field", "s"),
         Some(true),
         "s: struct pointer — (*s).buf.offset should not be attributed to s"
+    );
+}
+
+#[test]
+fn struct_field_copy_to_local_negative_offset_marks_field() {
+    let map = run_field_analysis(
+        "
+        pub struct Buf {
+            pub buf: *const i32,
+        }
+
+        pub unsafe fn use_field(s: *const Buf) -> i32 {
+            let p = (*s).buf;
+            *p.offset(-1)
+        }
+        ",
+    );
+    assert_eq!(
+        field_needs_cursor(&map, "Buf", "buf"),
+        Some(true),
+        "Buf::buf copied to p and offset(-1) should need a cursor"
+    );
+}
+
+#[test]
+fn struct_field_passed_to_callee_negative_offset_marks_field() {
+    let map = run_field_analysis(
+        "
+        pub struct Buf {
+            pub buf: *const i32,
+        }
+
+        pub unsafe fn read_prev(p: *const i32) -> i32 {
+            *p.offset(-1)
+        }
+
+        pub unsafe fn use_field(s: *const Buf) -> i32 {
+            read_prev((*s).buf)
+        }
+        ",
+    );
+    assert_eq!(
+        field_needs_cursor(&map, "Buf", "buf"),
+        Some(true),
+        "Buf::buf passed to a callee whose param needs a cursor should need a cursor"
     );
 }
 

--- a/crates/pointer_replacer/src/analyses/struct_copy/mod.rs
+++ b/crates/pointer_replacer/src/analyses/struct_copy/mod.rs
@@ -83,12 +83,10 @@ fn collect_copy_impls(tcx: TyCtxt<'_>) -> CopyImpls {
         let Some(of_trait) = impl_.of_trait else {
             continue;
         };
-        if !of_trait
-            .path
-            .segments
-            .last()
-            .is_some_and(|seg| seg.ident.name.as_str() == "Copy")
-        {
+        if !matches!(
+            of_trait.path.segments.last(),
+            Some(seg) if seg.ident.name.as_str() == "Copy"
+        ) {
             continue;
         }
         let Some(struct_did) = hir_local_struct_did_from_ty(impl_.self_ty) else {

--- a/crates/pointer_replacer/src/analyses/struct_copy/mod.rs
+++ b/crates/pointer_replacer/src/analyses/struct_copy/mod.rs
@@ -1,0 +1,383 @@
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{
+    self as hir,
+    def::{DefKind, Res},
+};
+use rustc_middle::{
+    mir::{Body, Local, Operand, Place, PlaceElem, Rvalue, StatementKind, TerminatorKind},
+    ty::{self, TyCtxt},
+};
+use rustc_span::def_id::LocalDefId;
+
+use crate::{analyses::borrow::StructFieldSlot, utils::rustc::RustProgram};
+
+#[derive(Debug, Default)]
+pub struct StructCopyAnalysisResult {
+    copy_impl_structs: FxHashSet<LocalDefId>,
+    copy_removable_structs: FxHashSet<LocalDefId>,
+}
+
+impl StructCopyAnalysisResult {
+    pub fn must_preserve_copy(&self, struct_did: LocalDefId) -> bool {
+        self.copy_impl_structs.contains(&struct_did)
+            && !self.copy_removable_structs.contains(&struct_did)
+    }
+
+    pub fn should_remove_generated_impl(&self, struct_did: LocalDefId) -> bool {
+        self.copy_removable_structs.contains(&struct_did)
+    }
+}
+
+pub fn analyze(
+    input: &RustProgram<'_>,
+    mutable_fields: &FxHashSet<StructFieldSlot>,
+) -> StructCopyAnalysisResult {
+    let copy_impls = collect_copy_impls(input.tcx);
+    let candidate_structs = mutable_fields
+        .iter()
+        .map(|field| field.struct_did)
+        .collect::<FxHashSet<_>>();
+    let candidate_generated_copy_structs = candidate_structs
+        .iter()
+        .copied()
+        .filter(|struct_did| copy_impls.generated.contains(struct_did))
+        .collect::<FxHashSet<_>>();
+
+    let mut required = collect_hard_copy_requirements(input);
+    propagate_copy_field_requirements(
+        input.tcx,
+        &copy_impls.all,
+        &candidate_generated_copy_structs,
+        &mut required,
+    );
+
+    let copy_removable_structs = candidate_generated_copy_structs
+        .difference(&required)
+        .copied()
+        .collect();
+
+    StructCopyAnalysisResult {
+        copy_impl_structs: copy_impls.all,
+        copy_removable_structs,
+    }
+}
+
+#[derive(Default)]
+struct CopyImpls {
+    all: FxHashSet<LocalDefId>,
+    generated: FxHashSet<LocalDefId>,
+}
+
+fn collect_copy_impls(tcx: TyCtxt<'_>) -> CopyImpls {
+    let mut impls = CopyImpls::default();
+    for owner in tcx.hir_crate(()).owners.iter() {
+        let Some(owner) = owner.as_owner() else {
+            continue;
+        };
+        let hir::OwnerNode::Item(item) = owner.node() else {
+            continue;
+        };
+        let hir::ItemKind::Impl(impl_) = item.kind else {
+            continue;
+        };
+        let Some(of_trait) = impl_.of_trait else {
+            continue;
+        };
+        if !of_trait
+            .path
+            .segments
+            .last()
+            .is_some_and(|seg| seg.ident.name.as_str() == "Copy")
+        {
+            continue;
+        }
+        let Some(struct_did) = hir_local_struct_did_from_ty(impl_.self_ty) else {
+            continue;
+        };
+        impls.all.insert(struct_did);
+        if tcx.is_automatically_derived(item.owner_id.def_id.to_def_id()) {
+            impls.generated.insert(struct_did);
+        }
+    }
+    impls
+}
+
+fn collect_hard_copy_requirements(input: &RustProgram<'_>) -> FxHashSet<LocalDefId> {
+    let mut required = FxHashSet::default();
+    for &did in &input.functions {
+        let body = input
+            .tcx
+            .mir_drops_elaborated_and_const_checked(did)
+            .borrow();
+        collect_body_hard_copy_requirements(input.tcx, &body, &mut required);
+    }
+    required
+}
+
+fn collect_body_hard_copy_requirements<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    required: &mut FxHashSet<LocalDefId>,
+) {
+    let mut moved_into_raw_storage: FxHashSet<(Local, LocalDefId)> = FxHashSet::default();
+    let mut copy_aliases: FxHashMap<Local, (Local, LocalDefId)> = FxHashMap::default();
+
+    for block in body.basic_blocks.iter() {
+        for stmt in &block.statements {
+            if let StatementKind::Assign(box (lhs, rvalue)) = &stmt.kind {
+                inspect_rvalue_operands(tcx, body, rvalue, &moved_into_raw_storage, required);
+
+                if let Some(local) = lhs.as_local() {
+                    moved_into_raw_storage.retain(|(moved_local, _)| *moved_local != local);
+                    copy_aliases.remove(&local);
+                }
+                if place_has_raw_deref(body, *lhs)
+                    && let Some((local, struct_did)) = rvalue_local_struct_source(tcx, body, rvalue)
+                {
+                    moved_into_raw_storage.insert(resolve_copy_alias(
+                        local,
+                        struct_did,
+                        &copy_aliases,
+                    ));
+                }
+                if let Some(lhs_local) = lhs.as_local()
+                    && let Some((rhs_local, rhs_struct)) =
+                        rvalue_local_struct_source(tcx, body, rvalue)
+                {
+                    copy_aliases.insert(
+                        lhs_local,
+                        resolve_copy_alias(rhs_local, rhs_struct, &copy_aliases),
+                    );
+                }
+            }
+        }
+
+        let terminator = block.terminator();
+        match &terminator.kind {
+            TerminatorKind::Call { func, args, .. }
+            | TerminatorKind::TailCall { func, args, .. } => {
+                inspect_operand(tcx, body, func, &moved_into_raw_storage, required);
+                for arg in args {
+                    inspect_operand(tcx, body, &arg.node, &moved_into_raw_storage, required);
+                }
+            }
+            TerminatorKind::SwitchInt { discr, .. }
+            | TerminatorKind::Assert { cond: discr, .. } => {
+                inspect_operand(tcx, body, discr, &moved_into_raw_storage, required);
+            }
+            TerminatorKind::Yield { value, .. } => {
+                inspect_operand(tcx, body, value, &moved_into_raw_storage, required);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn resolve_copy_alias(
+    mut local: Local,
+    mut struct_did: LocalDefId,
+    copy_aliases: &FxHashMap<Local, (Local, LocalDefId)>,
+) -> (Local, LocalDefId) {
+    let mut seen = FxHashSet::default();
+    while seen.insert(local) {
+        let Some(&(next_local, next_struct)) = copy_aliases.get(&local) else {
+            break;
+        };
+        local = next_local;
+        struct_did = next_struct;
+    }
+    (local, struct_did)
+}
+
+fn inspect_rvalue_operands<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    rvalue: &Rvalue<'tcx>,
+    moved_into_raw_storage: &FxHashSet<(Local, LocalDefId)>,
+    required: &mut FxHashSet<LocalDefId>,
+) {
+    match rvalue {
+        Rvalue::Use(operand)
+        | Rvalue::Repeat(operand, _)
+        | Rvalue::UnaryOp(_, operand)
+        | Rvalue::Cast(_, operand, _)
+        | Rvalue::ShallowInitBox(operand, _)
+        | Rvalue::WrapUnsafeBinder(operand, _) => {
+            inspect_operand(tcx, body, operand, moved_into_raw_storage, required);
+            if matches!(rvalue, Rvalue::Repeat(..))
+                && let Some(struct_did) = operand_local_struct(tcx, body, operand)
+            {
+                required.insert(struct_did);
+            }
+        }
+        Rvalue::BinaryOp(_, box (lhs, rhs)) => {
+            inspect_operand(tcx, body, lhs, moved_into_raw_storage, required);
+            inspect_operand(tcx, body, rhs, moved_into_raw_storage, required);
+        }
+        Rvalue::Aggregate(_, operands) => {
+            for operand in operands {
+                inspect_operand(tcx, body, operand, moved_into_raw_storage, required);
+            }
+        }
+        Rvalue::CopyForDeref(place) => {
+            inspect_place(tcx, body, *place, moved_into_raw_storage, required);
+        }
+        _ => {}
+    }
+}
+
+fn inspect_operand<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    operand: &Operand<'tcx>,
+    moved_into_raw_storage: &FxHashSet<(Local, LocalDefId)>,
+    required: &mut FxHashSet<LocalDefId>,
+) {
+    let (Operand::Copy(place) | Operand::Move(place)) = operand else {
+        return;
+    };
+    inspect_place(tcx, body, *place, moved_into_raw_storage, required);
+}
+
+fn inspect_place<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    place: Place<'tcx>,
+    moved_into_raw_storage: &FxHashSet<(Local, LocalDefId)>,
+    required: &mut FxHashSet<LocalDefId>,
+) {
+    for &(local, struct_did) in moved_into_raw_storage {
+        if place.local == local {
+            required.insert(struct_did);
+        }
+    }
+
+    if place_has_raw_deref(body, place)
+        && let Some(struct_did) = local_struct_ty(place.ty(body, tcx).ty)
+    {
+        required.insert(struct_did);
+    }
+}
+
+fn rvalue_local_struct_source<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    rvalue: &Rvalue<'tcx>,
+) -> Option<(Local, LocalDefId)> {
+    let Rvalue::Use(Operand::Copy(place) | Operand::Move(place)) = rvalue else {
+        return None;
+    };
+    let local = place.as_local()?;
+    let struct_did = local_struct_ty(place.ty(body, tcx).ty)?;
+    Some((local, struct_did))
+}
+
+fn operand_local_struct<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    operand: &Operand<'tcx>,
+) -> Option<LocalDefId> {
+    let (Operand::Copy(place) | Operand::Move(place)) = operand else {
+        return None;
+    };
+    local_struct_ty(place.ty(body, tcx).ty)
+}
+
+fn place_has_raw_deref(body: &Body<'_>, place: Place<'_>) -> bool {
+    body.local_decls[place.local].ty.is_raw_ptr()
+        && place
+            .projection
+            .iter()
+            .any(|elem| matches!(elem, PlaceElem::Deref))
+}
+
+fn propagate_copy_field_requirements(
+    tcx: TyCtxt<'_>,
+    copy_impl_structs: &FxHashSet<LocalDefId>,
+    candidate_removable_structs: &FxHashSet<LocalDefId>,
+    required: &mut FxHashSet<LocalDefId>,
+) {
+    loop {
+        let mut changed = false;
+        for &container in copy_impl_structs {
+            let container_copy_will_be_removed =
+                candidate_removable_structs.contains(&container) && !required.contains(&container);
+            if container_copy_will_be_removed {
+                continue;
+            }
+
+            for field_struct in copied_field_structs(tcx, container) {
+                if copy_impl_structs.contains(&field_struct) {
+                    changed |= required.insert(field_struct);
+                }
+            }
+        }
+
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn copied_field_structs(tcx: TyCtxt<'_>, struct_did: LocalDefId) -> FxHashSet<LocalDefId> {
+    let mut copied = FxHashSet::default();
+    let struct_ty = tcx.type_of(struct_did).skip_binder();
+    let ty::TyKind::Adt(adt_def, args) = struct_ty.kind() else {
+        return copied;
+    };
+    for field in adt_def.all_fields() {
+        collect_local_structs_requiring_copy(field.ty(tcx, args), &mut copied);
+    }
+    copied.remove(&struct_did);
+    copied
+}
+
+fn collect_local_structs_requiring_copy(ty: ty::Ty<'_>, out: &mut FxHashSet<LocalDefId>) {
+    match ty.kind() {
+        ty::TyKind::Adt(adt_def, args) => {
+            if adt_def.did().is_local() && adt_def.is_struct() && !adt_def.is_union() {
+                out.insert(adt_def.did().expect_local());
+            }
+            for arg in args.iter() {
+                if let ty::GenericArgKind::Type(ty) = arg.kind() {
+                    collect_local_structs_requiring_copy(ty, out);
+                }
+            }
+        }
+        ty::TyKind::Array(inner, _) | ty::TyKind::Slice(inner) => {
+            collect_local_structs_requiring_copy(*inner, out);
+        }
+        ty::TyKind::Tuple(fields) => {
+            for field in fields.iter() {
+                collect_local_structs_requiring_copy(field, out);
+            }
+        }
+        ty::TyKind::RawPtr(..) | ty::TyKind::Ref(..) => {}
+        _ => {}
+    }
+}
+
+fn local_struct_ty(ty: ty::Ty<'_>) -> Option<LocalDefId> {
+    let ty::TyKind::Adt(adt_def, _) = ty.kind() else {
+        return None;
+    };
+    (adt_def.did().is_local() && adt_def.is_struct() && !adt_def.is_union())
+        .then(|| adt_def.did().expect_local())
+}
+
+fn hir_local_struct_did_from_ty(ty: &hir::Ty<'_>) -> Option<LocalDefId> {
+    let hir::TyKind::Path(qpath) = ty.kind else {
+        return None;
+    };
+    hir_local_struct_did_from_qpath(&qpath)
+}
+
+fn hir_local_struct_did_from_qpath(qpath: &hir::QPath<'_>) -> Option<LocalDefId> {
+    let hir::QPath::Resolved(_, path) = qpath else {
+        return None;
+    };
+    match path.res {
+        Res::Def(DefKind::Struct, def_id) if def_id.is_local() => Some(def_id.expect_local()),
+        _ => None,
+    }
+}

--- a/crates/pointer_replacer/src/rewriter/collector.rs
+++ b/crates/pointer_replacer/src/rewriter/collector.rs
@@ -4,15 +4,19 @@ use rustc_hir::{
     def::{DefKind, Res},
     intravisit::{Visitor, walk_expr},
 };
-use rustc_middle::mir::Local;
+use rustc_middle::mir::{Local, Operand, Rvalue, StatementKind};
 use rustc_span::def_id::LocalDefId;
 
-use super::{Analysis, decision::PtrKind};
+use super::{
+    Analysis,
+    decision::{PtrKind, SigDecisions},
+};
 use crate::{rewriter::decision::DecisionMaker, utils::rustc::RustProgram};
 
 pub fn collect_diffs<'tcx>(
     rust_program: &RustProgram<'tcx>,
     analysis: &Analysis,
+    sig_decs: &SigDecisions,
 ) -> FxHashMap<HirId, PtrKind> {
     let mut ptr_kinds = FxHashMap::default();
     let non_outermost_owning_locals = collect_non_outermost_owning_hir_locals(rust_program);
@@ -46,6 +50,13 @@ pub fn collect_diffs<'tcx>(
             .len();
 
         let aliases = analysis.aliases.get(did);
+        let returned_output_locals = sig_decs
+            .data
+            .get(did)
+            .and_then(|sig_dec| sig_dec.output_dec)
+            .filter(|kind| matches!(kind, PtrKind::Ref(_) | PtrKind::OptRef(_)))
+            .map(|kind| collect_returned_output_locals(body, kind))
+            .unwrap_or_default();
 
         for (local, decl) in body
             .local_decls
@@ -53,8 +64,23 @@ pub fn collect_diffs<'tcx>(
             .skip(1 + input_skip_len * (used_as_fn_ptr as usize))
         // skip inputs if used as fn ptr
         {
+            let sig_input_dec = local
+                .index()
+                .checked_sub(1)
+                .filter(|idx| *idx < input_skip_len)
+                .and_then(|idx| {
+                    sig_decs
+                        .data
+                        .get(did)?
+                        .input_decs
+                        .get(idx)
+                        .copied()
+                        .flatten()
+                });
             let aliases = aliases.and_then(|aliases| aliases.get(&local));
-            if let Some(mut ptr_kind) = decision_maker.decide(local, decl, aliases)
+            if let Some(mut ptr_kind) = sig_input_dec
+                .or_else(|| returned_output_locals.get(&local).copied())
+                .or_else(|| decision_maker.decide(local, decl, aliases))
                 && let Some(hir_id) = local_to_binding.get(&local)
             {
                 if non_outermost_owning_locals.contains(hir_id) && ptr_kind.is_owning_box_like() {
@@ -66,6 +92,44 @@ pub fn collect_diffs<'tcx>(
     }
 
     ptr_kinds
+}
+
+fn collect_returned_output_locals(
+    body: &rustc_middle::mir::Body<'_>,
+    output_kind: PtrKind,
+) -> FxHashMap<Local, PtrKind> {
+    let mut locals = FxHashMap::default();
+    locals.insert(Local::from_u32(0), output_kind);
+
+    loop {
+        let mut changed = false;
+        for bb in body.basic_blocks.iter() {
+            for stmt in &bb.statements {
+                let StatementKind::Assign(box (place, rvalue)) = &stmt.kind else {
+                    continue;
+                };
+                let Some(destination) = place.as_local() else {
+                    continue;
+                };
+                if !locals.contains_key(&destination) {
+                    continue;
+                }
+                let Rvalue::Use(Operand::Copy(source) | Operand::Move(source)) = rvalue else {
+                    continue;
+                };
+                let Some(source) = source.as_local() else {
+                    continue;
+                };
+                changed |= locals.insert(source, output_kind).is_none();
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    locals.remove(&Local::from_u32(0));
+    locals
 }
 
 fn collect_non_outermost_owning_hir_locals(rust_program: &RustProgram) -> FxHashSet<HirId> {

--- a/crates/pointer_replacer/src/rewriter/decision.rs
+++ b/crates/pointer_replacer/src/rewriter/decision.rs
@@ -1,10 +1,15 @@
 use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{
+    self as hir, HirId,
+    def::Res,
+    intravisit::{self, Visitor},
+};
 use rustc_index::{IndexVec, bit_set::DenseBitSet};
 use rustc_middle::{
     mir::{Local, LocalDecl, Operand, Rvalue, StatementKind, TerminatorKind},
     ty::{self, TyCtxt},
 };
-use rustc_span::def_id::LocalDefId;
+use rustc_span::{Symbol, def_id::LocalDefId};
 
 use super::{Analysis, collector::collect_fn_ptrs};
 use crate::{analyses::ownership::Ownership, utils::rustc::RustProgram};
@@ -246,8 +251,45 @@ impl<'tcx> DecisionMaker<'tcx> {
 pub struct SigDecision {
     /// None means no change
     pub input_decs: Vec<Option<PtrKind>>,
+    pub input_lifetimes: Vec<Option<Symbol>>,
     pub output_dec: Option<PtrKind>,
+    pub output_lifetime: Option<Symbol>,
     pub signature_locked: bool,
+}
+
+impl SigDecision {
+    pub(crate) fn set_input_dec(&mut self, idx: usize, decision: Option<PtrKind>) {
+        self.input_decs[idx] = decision;
+        if !decision_carries_lifetime(decision)
+            && let Some(lifetime) = self.input_lifetimes.get_mut(idx)
+        {
+            *lifetime = None;
+        }
+    }
+
+    pub(crate) fn set_output_dec(&mut self, decision: Option<PtrKind>) {
+        self.output_dec = decision;
+        if !decision_carries_lifetime(decision) {
+            self.output_lifetime = None;
+        }
+    }
+
+    fn normalize_lifetimes(&mut self) {
+        for idx in 0..self.input_decs.len() {
+            if !decision_carries_lifetime(self.input_decs[idx])
+                && let Some(lifetime) = self.input_lifetimes.get_mut(idx)
+            {
+                *lifetime = None;
+            }
+        }
+        if !decision_carries_lifetime(self.output_dec) {
+            self.output_lifetime = None;
+        }
+    }
+}
+
+fn decision_carries_lifetime(decision: Option<PtrKind>) -> bool {
+    matches!(decision, Some(PtrKind::Ref(_) | PtrKind::OptRef(_)))
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -256,7 +298,11 @@ pub struct SigDecisions {
 }
 
 impl SigDecisions {
-    pub fn new(rust_program: &RustProgram, analysis: &Analysis) -> Self {
+    pub fn new(
+        rust_program: &RustProgram,
+        analysis: &Analysis,
+        lifetime_plans: &super::lifetimes::LifetimePlans,
+    ) -> Self {
         let mut data = FxHashMap::default();
         data.reserve(rust_program.functions.len());
 
@@ -264,21 +310,21 @@ impl SigDecisions {
         let fn_ptrs = collect_fn_ptrs(rust_program);
 
         for did in rust_program.functions.iter() {
+            let input_len = rust_program
+                .tcx
+                .fn_sig(*did)
+                .skip_binder()
+                .inputs()
+                .skip_binder()
+                .len();
             if fn_ptrs.contains(did) {
                 data.insert(
                     *did,
                     SigDecision {
-                        input_decs: vec![
-                            None;
-                            rust_program
-                                .tcx
-                                .fn_sig(*did)
-                                .skip_binder()
-                                .inputs()
-                                .skip_binder()
-                                .len()
-                        ],
+                        input_decs: vec![None; input_len],
+                        input_lifetimes: vec![None; input_len],
                         output_dec: None,
+                        output_lifetime: None,
                         signature_locked: true,
                     },
                 );
@@ -292,7 +338,18 @@ impl SigDecisions {
                 .borrow();
 
             let sig = rust_program.tcx.fn_sig(*did).skip_binder();
-            let input_len = sig.inputs().skip_binder().len();
+            debug_assert_eq!(input_len, sig.inputs().skip_binder().len());
+            let lifetime_plan = lifetime_plans
+                .functions
+                .get(did)
+                .cloned()
+                .unwrap_or_default();
+            let output_lifetime = lifetime_plan.output_lifetime;
+            let input_lifetimes = if lifetime_plan.input_lifetimes.len() == input_len {
+                lifetime_plan.input_lifetimes.clone()
+            } else {
+                vec![None; input_len]
+            };
 
             let aliases = analysis.aliases.get(did);
 
@@ -312,6 +369,11 @@ impl SigDecisions {
             let return_aliases = aliases.and_then(|a| a.get(&return_local));
             let direct_output_dec =
                 match decision_maker.decide(return_local, return_decl, return_aliases) {
+                    Some(kind @ (PtrKind::Ref(_) | PtrKind::OptRef(_)))
+                        if output_lifetime.is_some() =>
+                    {
+                        Some(kind)
+                    }
                     Some(
                         kind @ (PtrKind::Raw(_)
                         | PtrKind::OptBox
@@ -343,17 +405,236 @@ impl SigDecisions {
                 (None, None) => None,
             };
 
-            data.insert(
-                *did,
-                SigDecision {
+            data.insert(*did, {
+                let mut sig_dec = SigDecision {
                     input_decs,
+                    input_lifetimes,
                     output_dec,
+                    output_lifetime,
                     signature_locked: false,
-                },
-            );
+                };
+                apply_return_borrow_lifetime_plan(
+                    *did,
+                    body,
+                    &lifetime_plan,
+                    &decision_maker,
+                    &mut sig_dec,
+                );
+                sig_dec.normalize_lifetimes();
+                sig_dec
+            });
         }
         SigDecisions { data }
     }
+}
+
+fn apply_return_borrow_lifetime_plan<'tcx>(
+    did: LocalDefId,
+    body: &rustc_middle::mir::Body<'tcx>,
+    lifetime_plan: &super::lifetimes::FnLifetimePlan,
+    decision_maker: &DecisionMaker<'tcx>,
+    sig_dec: &mut SigDecision,
+) {
+    let Some(output_lifetime) = lifetime_plan.output_lifetime else {
+        return;
+    };
+    let return_local = Local::from_u32(0);
+    let Some((_, output_mutability)) =
+        super::transform::unwrap_ptr_from_mir_ty(body.local_decls[return_local].ty)
+    else {
+        return;
+    };
+
+    let mut returned_inputs = Vec::new();
+    for (idx, lifetime) in lifetime_plan.input_lifetimes.iter().enumerate() {
+        if *lifetime != Some(output_lifetime) {
+            continue;
+        }
+        if !matches!(
+            sig_dec.input_decs.get(idx).copied().flatten(),
+            Some(PtrKind::Ref(_) | PtrKind::OptRef(_))
+        ) {
+            return;
+        }
+        let local = Local::from_usize(idx + 1);
+        let Some((_, input_mutability)) =
+            super::transform::unwrap_ptr_from_mir_ty(body.local_decls[local].ty)
+        else {
+            return;
+        };
+        returned_inputs.push((idx, input_mutability.is_mut()));
+    }
+    if returned_inputs.is_empty() {
+        return;
+    }
+
+    let return_kind =
+        if return_place_may_receive_null_constructor(body, decision_maker.tcx, return_local) {
+            PtrKind::OptRef(output_mutability.is_mut())
+        } else {
+            PtrKind::Ref(output_mutability.is_mut())
+        };
+    for (idx, is_mut) in returned_inputs {
+        let input_kind = if return_kind.is_optional()
+            || returned_input_is_observed_nullable(decision_maker.tcx, did, idx)
+        {
+            PtrKind::OptRef
+        } else {
+            PtrKind::Ref
+        };
+        sig_dec.set_input_dec(idx, Some(input_kind(is_mut)));
+        sig_dec.input_lifetimes[idx] = Some(output_lifetime);
+    }
+    sig_dec.set_output_dec(Some(return_kind));
+    sig_dec.output_lifetime = Some(output_lifetime);
+}
+
+fn returned_input_is_observed_nullable(tcx: TyCtxt<'_>, did: LocalDefId, idx: usize) -> bool {
+    fn hir_unwrapped_local_id(expr: &hir::Expr<'_>) -> Option<HirId> {
+        let expr = match expr.kind {
+            hir::ExprKind::Cast(inner, _) | hir::ExprKind::DropTemps(inner) => inner,
+            _ => expr,
+        };
+        let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = expr.kind else {
+            return None;
+        };
+        let Res::Local(hir_id) = path.res else {
+            return None;
+        };
+        Some(hir_id)
+    }
+
+    struct NullableUseVisitor {
+        param: HirId,
+        found: bool,
+    }
+
+    impl<'tcx> Visitor<'tcx> for NullableUseVisitor {
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            if self.found {
+                return;
+            }
+            if let hir::ExprKind::MethodCall(seg, receiver, _, _) = expr.kind
+                && seg.ident.name.as_str() == "is_null"
+                && hir_unwrapped_local_id(receiver) == Some(self.param)
+            {
+                self.found = true;
+                return;
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let hir::Node::Item(item) = tcx.hir_node_by_def_id(did) else {
+        return false;
+    };
+    let hir::ItemKind::Fn { body, .. } = item.kind else {
+        return false;
+    };
+    let body = tcx.hir_body(body);
+    let Some(param) = body.params.get(idx) else {
+        return false;
+    };
+    let hir::PatKind::Binding(_, param_hir_id, _, _) = param.pat.kind else {
+        return false;
+    };
+    let mut visitor = NullableUseVisitor {
+        param: param_hir_id,
+        found: false,
+    };
+    visitor.visit_body(body);
+    visitor.found
+}
+
+fn return_place_may_receive_null_constructor<'tcx>(
+    body: &rustc_middle::mir::Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    return_local: Local,
+) -> bool {
+    fn is_null_like_call<'tcx>(tcx: TyCtxt<'tcx>, func: &Operand<'tcx>) -> bool {
+        let Some(func_const) = func.constant() else {
+            return false;
+        };
+        let ty::TyKind::FnDef(def_id, _) = func_const.ty().kind() else {
+            return false;
+        };
+        matches!(tcx.item_name(*def_id).as_str(), "null" | "null_mut")
+    }
+
+    fn const_is_zero(value: &rustc_middle::mir::Const<'_>, tcx: TyCtxt<'_>) -> bool {
+        if let Some(scalar) = value.try_to_scalar()
+            && let Ok(int) = scalar.try_to_scalar_int()
+        {
+            return int.to_bits(int.size()) == 0;
+        }
+        if let rustc_middle::mir::Const::Unevaluated(unevaluated, _) = value
+            && unevaluated.promoted.is_none()
+            && let Ok(rustc_middle::mir::ConstValue::Scalar(scalar)) =
+                tcx.const_eval_poly(unevaluated.def)
+            && let Ok(int) = scalar.try_to_scalar_int()
+        {
+            return int.to_bits(int.size()) == 0;
+        }
+        false
+    }
+
+    fn operand_is_zero(operand: &Operand<'_>, tcx: TyCtxt<'_>) -> bool {
+        let Operand::Constant(constant) = operand else {
+            return false;
+        };
+        const_is_zero(&constant.const_, tcx)
+    }
+
+    let mut nullable = DenseBitSet::new_empty(body.local_decls.len());
+    loop {
+        let mut changed = false;
+        for bb in body.basic_blocks.iter() {
+            for stmt in &bb.statements {
+                let StatementKind::Assign(box (place, rvalue)) = &stmt.kind else {
+                    continue;
+                };
+                let Some(destination) = place.as_local() else {
+                    continue;
+                };
+                let source_nullable = match rvalue {
+                    Rvalue::Use(Operand::Copy(src) | Operand::Move(src)) => src
+                        .as_local()
+                        .is_some_and(|source| nullable.contains(source)),
+                    Rvalue::Use(operand) if body.local_decls[destination].ty.is_raw_ptr() => {
+                        operand_is_zero(operand, tcx)
+                    }
+                    Rvalue::Cast(_, operand, ty) if ty.is_raw_ptr() => {
+                        operand_is_zero(operand, tcx)
+                    }
+                    _ => false,
+                };
+                if source_nullable {
+                    changed |= nullable.insert(destination);
+                }
+            }
+
+            let Some(terminator) = &bb.terminator else {
+                continue;
+            };
+            let TerminatorKind::Call {
+                func, destination, ..
+            } = &terminator.kind
+            else {
+                continue;
+            };
+            if is_null_like_call(tcx, func)
+                && let Some(destination) = destination.as_local()
+            {
+                changed |= nullable.insert(destination);
+            }
+        }
+
+        if !changed {
+            break;
+        }
+    }
+
+    nullable.contains(return_local)
 }
 
 fn infer_returned_local_box_kind<'tcx>(
@@ -758,5 +1039,39 @@ pub unsafe fn foo(p: *mut i32, q: *mut i32) {
             );
         });
         assert_eq!(decision, Some(PtrKind::Raw(true)));
+    }
+
+    #[test]
+    fn sig_decision_clears_input_lifetime_when_downgraded_to_raw() {
+        let lifetime = Symbol::new(1);
+        let mut sig_dec = SigDecision {
+            input_decs: vec![Some(PtrKind::OptRef(true))],
+            input_lifetimes: vec![Some(lifetime)],
+            output_dec: Some(PtrKind::OptRef(true)),
+            output_lifetime: Some(lifetime),
+            signature_locked: false,
+        };
+
+        sig_dec.set_input_dec(0, Some(PtrKind::Raw(true)));
+
+        assert_eq!(sig_dec.input_lifetimes, vec![None]);
+        assert_eq!(sig_dec.output_lifetime, Some(lifetime));
+    }
+
+    #[test]
+    fn sig_decision_clears_output_lifetime_when_downgraded_to_raw() {
+        let lifetime = Symbol::new(1);
+        let mut sig_dec = SigDecision {
+            input_decs: vec![Some(PtrKind::OptRef(true))],
+            input_lifetimes: vec![Some(lifetime)],
+            output_dec: Some(PtrKind::OptRef(true)),
+            output_lifetime: Some(lifetime),
+            signature_locked: false,
+        };
+
+        sig_dec.set_output_dec(Some(PtrKind::Raw(true)));
+
+        assert_eq!(sig_dec.input_lifetimes, vec![Some(lifetime)]);
+        assert_eq!(sig_dec.output_lifetime, None);
     }
 }

--- a/crates/pointer_replacer/src/rewriter/lifetimes.rs
+++ b/crates/pointer_replacer/src/rewriter/lifetimes.rs
@@ -136,9 +136,6 @@ fn function_lifetime_plans(
     let mut plans = FxHashMap::default();
 
     for did in input.functions.iter().copied() {
-        if !is_rust_abi_fn(input.tcx, did) {
-            continue;
-        }
         let body = input
             .tcx
             .mir_drops_elaborated_and_const_checked(did)
@@ -174,16 +171,6 @@ fn function_lifetime_plans(
     }
 
     plans
-}
-
-fn is_rust_abi_fn(tcx: TyCtxt<'_>, did: LocalDefId) -> bool {
-    let hir::Node::Item(item) = tcx.hir_node_by_def_id(did) else {
-        return false;
-    };
-    let hir::ItemKind::Fn { sig, .. } = item.kind else {
-        return false;
-    };
-    sig.header.abi.is_rustic_abi()
 }
 
 fn returned_input_indexes(summary: &LifetimeFlowSummary, input_len: usize) -> Option<Vec<usize>> {

--- a/crates/pointer_replacer/src/rewriter/lifetimes.rs
+++ b/crates/pointer_replacer/src/rewriter/lifetimes.rs
@@ -1,0 +1,350 @@
+use rustc_ast::{GenericParam, GenericParamKind, Generics};
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir as hir;
+use rustc_middle::{
+    mir::{Local, RETURN_PLACE},
+    ty::TyCtxt,
+};
+use rustc_span::{DUMMY_SP, Ident, Symbol, def_id::LocalDefId};
+
+use super::Analysis;
+use crate::{
+    analyses::borrow::{
+        StructFieldSlot,
+        lifetime_flow::{LifetimeFlowSummary, SignatureRoot, SignatureSlot},
+    },
+    utils::rustc::RustProgram,
+};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FnLifetimePlan {
+    pub input_lifetimes: Vec<Option<Symbol>>,
+    pub output_lifetime: Option<Symbol>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StructLifetimePlan {
+    pub field_lifetimes: FxHashMap<usize, Symbol>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LifetimePlans {
+    pub functions: FxHashMap<LocalDefId, FnLifetimePlan>,
+    pub structs: FxHashMap<LocalDefId, StructLifetimePlan>,
+}
+
+impl LifetimePlans {
+    pub fn new(input: &RustProgram<'_>, analysis: &Analysis) -> Self {
+        Self {
+            functions: function_lifetime_plans(input, analysis),
+            structs: struct_lifetime_plans(input.tcx, analysis),
+        }
+    }
+}
+
+fn generated_lifetime_param(name: Symbol) -> GenericParam {
+    let name = Symbol::intern(&format!("'{}", name.as_str().trim_start_matches('\'')));
+    GenericParam {
+        id: rustc_ast::DUMMY_NODE_ID,
+        ident: Ident::new(name, DUMMY_SP),
+        attrs: Default::default(),
+        bounds: vec![],
+        is_placeholder: false,
+        kind: GenericParamKind::Lifetime,
+        colon_span: None,
+    }
+}
+
+fn existing_lifetime_params(generics: &Generics) -> FxHashSet<Symbol> {
+    generics
+        .params
+        .iter()
+        .filter(|param| matches!(param.kind, GenericParamKind::Lifetime))
+        .map(|param| Symbol::intern(param.ident.name.as_str().trim_start_matches('\'')))
+        .collect()
+}
+
+pub(super) fn ensure_lifetime_params(generics: &mut Generics, lifetimes: &[Symbol]) {
+    let mut existing = existing_lifetime_params(generics);
+    let mut insert_at = generics
+        .params
+        .iter()
+        .position(|param| !matches!(param.kind, GenericParamKind::Lifetime))
+        .unwrap_or(generics.params.len());
+
+    for lifetime in lifetimes {
+        if !existing.insert(*lifetime) {
+            continue;
+        }
+        generics
+            .params
+            .insert(insert_at, generated_lifetime_param(*lifetime));
+        insert_at += 1;
+    }
+}
+
+#[derive(Default)]
+struct LifetimeNameAllocator {
+    used: FxHashSet<Symbol>,
+}
+
+impl LifetimeNameAllocator {
+    fn with_existing<I>(existing: I) -> Self
+    where I: IntoIterator<Item = Symbol> {
+        Self {
+            used: existing.into_iter().collect(),
+        }
+    }
+
+    fn next(&mut self) -> Symbol {
+        for ch in b'a'..=b'z' {
+            let name = Symbol::intern(std::str::from_utf8(&[ch]).unwrap());
+            if self.used.insert(name) {
+                return name;
+            }
+        }
+        let mut index = 0usize;
+        loop {
+            let name = Symbol::intern(&format!("lt{index}"));
+            if self.used.insert(name) {
+                return name;
+            }
+            index += 1;
+        }
+    }
+}
+
+fn existing_hir_lifetime_params(tcx: TyCtxt<'_>, did: LocalDefId) -> Vec<Symbol> {
+    let hir::Node::Item(item) = tcx.hir_node_by_def_id(did) else {
+        return vec![];
+    };
+    let Some(generics) = item.kind.generics() else {
+        return vec![];
+    };
+    generics
+        .params
+        .iter()
+        .filter(|param| matches!(param.kind, hir::GenericParamKind::Lifetime { .. }))
+        .map(|param| Symbol::intern(param.name.ident().name.as_str().trim_start_matches('\'')))
+        .collect()
+}
+
+fn function_lifetime_plans(
+    input: &RustProgram<'_>,
+    analysis: &Analysis,
+) -> FxHashMap<LocalDefId, FnLifetimePlan> {
+    let mut plans = FxHashMap::default();
+
+    for did in input.functions.iter().copied() {
+        if !is_rust_abi_fn(input.tcx, did) {
+            continue;
+        }
+        let body = input
+            .tcx
+            .mir_drops_elaborated_and_const_checked(did)
+            .borrow();
+        let return_decl = &body.local_decls[RETURN_PLACE];
+        if !return_decl.ty.is_raw_ptr() {
+            continue;
+        }
+
+        let Some(flow) = analysis.borrow_lifetime_flows.get(&did) else {
+            continue;
+        };
+        let input_len = body.arg_count;
+        let Some(returned_inputs) = returned_input_indexes(&flow.summary, input_len) else {
+            continue;
+        };
+
+        let mut allocator =
+            LifetimeNameAllocator::with_existing(existing_hir_lifetime_params(input.tcx, did));
+        let lifetime = allocator.next();
+        let mut input_lifetimes = vec![None; input_len];
+        for input_index in returned_inputs {
+            input_lifetimes[input_index] = Some(lifetime);
+        }
+
+        plans.insert(
+            did,
+            FnLifetimePlan {
+                input_lifetimes,
+                output_lifetime: Some(lifetime),
+            },
+        );
+    }
+
+    plans
+}
+
+fn is_rust_abi_fn(tcx: TyCtxt<'_>, did: LocalDefId) -> bool {
+    let hir::Node::Item(item) = tcx.hir_node_by_def_id(did) else {
+        return false;
+    };
+    let hir::ItemKind::Fn { sig, .. } = item.kind else {
+        return false;
+    };
+    sig.header.abi.is_rustic_abi()
+}
+
+fn returned_input_indexes(summary: &LifetimeFlowSummary, input_len: usize) -> Option<Vec<usize>> {
+    let return_slot = summary
+        .slots
+        .iter_enumerated()
+        .find_map(|(slot, sig_slot)| is_depth0_return_slot(*sig_slot).then_some(slot))?;
+    let mut input_indexes = vec![];
+
+    for (source, source_slot) in summary.slots.iter_enumerated() {
+        if !summary.value_flows.contains(source, return_slot) {
+            continue;
+        }
+        let Some(input_index) = depth0_arg_input_index(*source_slot, input_len) else {
+            continue;
+        };
+        if !input_indexes.contains(&input_index) {
+            input_indexes.push(input_index);
+        }
+    }
+
+    if input_indexes.is_empty() {
+        None
+    } else {
+        input_indexes.sort_unstable();
+        Some(input_indexes)
+    }
+}
+
+fn is_depth0_return_slot(slot: SignatureSlot) -> bool {
+    slot.place.root == SignatureRoot::Return
+        && slot.place.deref_depth == 0
+        && slot.place.field.is_none()
+        && slot.depth == 0
+}
+
+fn depth0_arg_input_index(slot: SignatureSlot, input_len: usize) -> Option<usize> {
+    let SignatureRoot::Arg(local) = slot.place.root else {
+        return None;
+    };
+    if slot.place.deref_depth != 0 || slot.place.field.is_some() || slot.depth != 0 {
+        return None;
+    }
+    mir_arg_local_to_input_index(local).filter(|input_index| *input_index < input_len)
+}
+
+fn mir_arg_local_to_input_index(local: Local) -> Option<usize> {
+    local.index().checked_sub(1)
+}
+
+fn struct_lifetime_plans(
+    tcx: TyCtxt<'_>,
+    analysis: &Analysis,
+) -> FxHashMap<LocalDefId, StructLifetimePlan> {
+    let mut fields_by_struct: FxHashMap<LocalDefId, Vec<StructFieldSlot>> = FxHashMap::default();
+    for field in analysis
+        .borrow_promotion_result
+        .mutable_fields
+        .iter()
+        .chain(analysis.borrow_promotion_result.shared_fields.iter())
+        .copied()
+    {
+        let fields = fields_by_struct.entry(field.struct_did).or_default();
+        if !fields.contains(&field) {
+            fields.push(field);
+        }
+    }
+
+    let mut plans = FxHashMap::default();
+    for (struct_did, mut fields) in fields_by_struct {
+        fields.sort_by_key(|field| field.field_index);
+        let mut allocator =
+            LifetimeNameAllocator::with_existing(existing_hir_lifetime_params(tcx, struct_did));
+        let mut plan = StructLifetimePlan::default();
+        for field in fields {
+            plan.field_lifetimes
+                .insert(field.field_index, allocator.next());
+        }
+        plans.insert(struct_did, plan);
+    }
+
+    plans
+}
+
+#[cfg(test)]
+mod tests {
+    use rustc_index::{
+        IndexVec,
+        bit_set::{DenseBitSet, SparseBitMatrix},
+    };
+
+    use super::*;
+    use crate::analyses::borrow::lifetime_flow::{LifetimeSlot, SignaturePlace};
+
+    #[test]
+    fn returned_input_indexes_keep_only_depth0_direct_arg_flows_to_return() {
+        let mut slots: IndexVec<LifetimeSlot, SignatureSlot> = IndexVec::new();
+        let direct_arg = slots.push(SignatureSlot {
+            place: SignaturePlace {
+                root: SignatureRoot::Arg(Local::from_u32(1)),
+                deref_depth: 0,
+                field: None,
+            },
+            depth: 0,
+        });
+        let deeper_arg = slots.push(SignatureSlot {
+            place: SignaturePlace {
+                root: SignatureRoot::Arg(Local::from_u32(2)),
+                deref_depth: 0,
+                field: None,
+            },
+            depth: 1,
+        });
+        let derefed_arg = slots.push(SignatureSlot {
+            place: SignaturePlace {
+                root: SignatureRoot::Arg(Local::from_u32(2)),
+                deref_depth: 1,
+                field: None,
+            },
+            depth: 0,
+        });
+        let out_of_range_arg = slots.push(SignatureSlot {
+            place: SignaturePlace {
+                root: SignatureRoot::Arg(Local::from_u32(4)),
+                deref_depth: 0,
+                field: None,
+            },
+            depth: 0,
+        });
+        let return_slot = slots.push(SignatureSlot {
+            place: SignaturePlace {
+                root: SignatureRoot::Return,
+                deref_depth: 0,
+                field: None,
+            },
+            depth: 0,
+        });
+        let mut value_flows = SparseBitMatrix::new(slots.len());
+        value_flows.insert(direct_arg, return_slot);
+        value_flows.insert(deeper_arg, return_slot);
+        value_flows.insert(derefed_arg, return_slot);
+        value_flows.insert(out_of_range_arg, return_slot);
+        let slot_count = slots.len();
+        let summary = LifetimeFlowSummary {
+            slots,
+            value_flows,
+            storage_aliases: SparseBitMatrix::new(slot_count),
+            unknown_targets: DenseBitSet::new_empty(slot_count),
+        };
+
+        assert_eq!(returned_input_indexes(&summary, 2), Some(vec![0]));
+    }
+
+    #[test]
+    fn lifetime_name_allocator_skips_existing_lifetime_names() {
+        ::utils::compilation::run_compiler_on_str("", |_tcx| {
+            let mut allocator =
+                LifetimeNameAllocator::with_existing([Symbol::intern("a"), Symbol::intern("b")]);
+
+            assert_eq!(allocator.next(), Symbol::intern("c"));
+        })
+        .unwrap();
+    }
+}

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -15,7 +15,10 @@ use transform::TransformVisitor;
 use crate::{
     analyses::{
         self,
-        borrow::PromotedMutRefs as PromotedMutRefResult,
+        borrow::{
+            BorrowPromotionResults, PromotedMutRefs as PromotedMutRefResult,
+            lifetime_flow::LifetimeFlowResults,
+        },
         offset_sign::sign::OffsetSignResult,
         output_params::OutputParams,
         ownership::{
@@ -29,10 +32,15 @@ use crate::{
 
 mod collector;
 mod decision;
+mod lifetimes;
 mod struct_array_field_pre;
 mod transform;
 
 pub struct Analysis {
+    #[allow(dead_code)]
+    borrow_promotion_result: BorrowPromotionResults,
+    #[allow(dead_code)]
+    borrow_lifetime_flows: LifetimeFlowResults,
     promoted_mut_ref_result: PromotedMutRefResult,
     promoted_shared_ref_result: PromotedMutRefResult,
     mutability_result: MutabilityResult,
@@ -85,10 +93,11 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     let mutables = source_var_groups.postprocess_mut_res(&input, &mutability_result);
     let borrow_promotion_result =
         analyses::borrow::mutable_references_no_guarantee(&input, &mutables);
-    let promoted_mut_ref_result =
-        source_var_groups.postprocess_promoted_mut_refs(borrow_promotion_result.mutable_locals);
-    let promoted_shared_ref_result =
-        source_var_groups.postprocess_promoted_mut_refs(borrow_promotion_result.shared_locals);
+    let borrow_lifetime_flows = borrow_promotion_result.lifetime_flows.clone();
+    let promoted_mut_ref_result = source_var_groups
+        .postprocess_promoted_mut_refs(borrow_promotion_result.mutable_locals.clone());
+    let promoted_shared_ref_result = source_var_groups
+        .postprocess_promoted_mut_refs(borrow_promotion_result.shared_locals.clone());
     let fatness_result = analyses::type_qualifier::foster::fatness::fatness_analysis(&input);
     let mut offset_sign_result = analyses::offset_sign::sign::offset_sign_analysis(&input);
     offset_sign_result.access_signs =
@@ -97,6 +106,8 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     nullity_result.non_null_locals =
         source_var_groups.postprocess_non_null_locals(nullity_result.non_null_locals);
     let analysis_results = Analysis {
+        borrow_promotion_result,
+        borrow_lifetime_flows,
         promoted_mut_ref_result,
         promoted_shared_ref_result,
         mutability_result,

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -124,7 +124,7 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
         struct_copy_result,
     };
 
-    let mut visitor = TransformVisitor::new(&input, &analysis_results, ast_to_hir);
+    let mut visitor = TransformVisitor::new(config, &input, &analysis_results, ast_to_hir);
     visitor.visit_crate(&mut krate);
 
     // add SliceCursor module to the crate if it was used

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -25,6 +25,7 @@ use crate::{
             AnalysisKind as OwnershipAnalysisKind, CrateCtxt, solidify::SolidifiedOwnershipSchemes,
             whole_program::WholeProgramAnalysis,
         },
+        struct_copy::StructCopyAnalysisResult,
         type_qualifier::foster::{fatness::FatnessResult, mutability::MutabilityResult},
     },
     utils::rustc::RustProgram,
@@ -50,6 +51,7 @@ pub struct Analysis {
     ownership_schemes: Option<SolidifiedOwnershipSchemes>,
     offset_sign_result: OffsetSignResult,
     nullity_result: analyses::nullity::NullityResult,
+    struct_copy_result: StructCopyAnalysisResult,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -94,6 +96,8 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     let borrow_promotion_result =
         analyses::borrow::mutable_references_no_guarantee(&input, &mutables);
     let borrow_lifetime_flows = borrow_promotion_result.lifetime_flows.clone();
+    let struct_copy_result =
+        analyses::struct_copy::analyze(&input, &borrow_promotion_result.mutable_fields);
     let promoted_mut_ref_result = source_var_groups
         .postprocess_promoted_mut_refs(borrow_promotion_result.mutable_locals.clone());
     let promoted_shared_ref_result = source_var_groups
@@ -117,6 +121,7 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
         ownership_schemes,
         offset_sign_result,
         nullity_result,
+        struct_copy_result,
     };
 
     let mut visitor = TransformVisitor::new(&input, &analysis_results, ast_to_hir);

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -124,7 +124,7 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
         struct_copy_result,
     };
 
-    let mut visitor = TransformVisitor::new(config, &input, &analysis_results, ast_to_hir);
+    let mut visitor = TransformVisitor::new(&input, &analysis_results, ast_to_hir);
     visitor.visit_crate(&mut krate);
 
     // add SliceCursor module to the crate if it was used

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -83,12 +83,12 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     let ownership_schemes = maybe_solidified_ownership(config, &input, &output_params);
     let source_var_groups = analyses::mir_variable_grouping::SourceVarGroups::new(&input);
     let mutables = source_var_groups.postprocess_mut_res(&input, &mutability_result);
-    let (mutable_references, shared_references) =
+    let borrow_promotion_result =
         analyses::borrow::mutable_references_no_guarantee(&input, &mutables);
     let promoted_mut_ref_result =
-        source_var_groups.postprocess_promoted_mut_refs(mutable_references);
+        source_var_groups.postprocess_promoted_mut_refs(borrow_promotion_result.mutable_locals);
     let promoted_shared_ref_result =
-        source_var_groups.postprocess_promoted_mut_refs(shared_references);
+        source_var_groups.postprocess_promoted_mut_refs(borrow_promotion_result.shared_locals);
     let fatness_result = analyses::type_qualifier::foster::fatness::fatness_analysis(&input);
     let mut offset_sign_result = analyses::offset_sign::sign::offset_sign_analysis(&input);
     offset_sign_result.access_signs =

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -44,6 +44,7 @@ pub(crate) struct TransformVisitor<'a, 'tcx> {
     alloc_wrappers: FxHashMap<LocalDefId, AllocWrapperInfo>,
     free_like_wrappers: FxHashSet<LocalDefId>,
     demoted_fields: FxHashSet<StructFieldSlot>,
+    field_cursor_fields: FxHashSet<StructFieldSlot>,
     impl_self_lifetimes: Vec<(LocalDefId, Vec<Symbol>)>,
     ast_to_hir: AstToHir,
     pub bytemuck: Cell<bool>,
@@ -234,7 +235,8 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = self.mk_slice_ty(inner_ty, *m);
+                            *param.ty =
+                                self.mk_slice_ty_with_lifetime(inner_ty, *m, input_lifetime);
                         }
                         Some(PtrKind::Raw(m)) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -254,7 +256,8 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = self.mk_cursor_ty(inner_ty, *m);
+                            *param.ty =
+                                self.mk_cursor_ty_with_lifetime(inner_ty, *m, input_lifetime);
                             self.slice_cursor.set(true);
                         }
                         Some(PtrKind::BoxedSlice) => {
@@ -715,11 +718,22 @@ impl MutVisitor for TransformVisitor<'_, '_> {
             {
                 let receiver = unwrap_paren(receiver);
                 let hir_receiver = self.ast_to_hir.get_expr(receiver.id, self.tcx);
-                if hir_receiver.is_some_and(|hir_receiver| {
-                    self.promoted_field_slot_for_hir_field(hir_receiver)
-                        .is_some()
-                }) {
-                    seg.ident.name = Symbol::intern("is_none");
+                if let Some(field_kind) = hir_receiver
+                    .and_then(|hir_receiver| self.promoted_field_slot_for_hir_field(hir_receiver))
+                    .and_then(|field| self.field_ptr_kind(field))
+                {
+                    match field_kind {
+                        PtrKind::OptRef(_) | PtrKind::OptBox | PtrKind::OptBoxedSlice => {
+                            seg.ident.name = Symbol::intern("is_none");
+                        }
+                        PtrKind::Slice(_) | PtrKind::SliceCursor(_) => {
+                            seg.ident.name = Symbol::intern("is_empty");
+                        }
+                        PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice => {
+                            *expr = utils::expr!("false");
+                        }
+                        PtrKind::Raw(_) => {}
+                    }
                 } else if let Some(hir_receiver) = hir_receiver
                     && let Some(pe) = self.ptr_expr(receiver, hir_receiver)
                     && matches!(self.ptr_source_kind(&pe), Some(PtrKind::OptRef(_)))
@@ -848,6 +862,12 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                             }
                             PtrKind::OptBox => {
                                 utils::expr!("*({field_str}).as_deref().unwrap()")
+                            }
+                            PtrKind::Slice(_) => {
+                                utils::expr!("({field_str})[0]")
+                            }
+                            PtrKind::SliceCursor(_) => {
+                                utils::expr!("({field_str})[0 as usize]")
                             }
                             _ => unreachable!(),
                         };
@@ -1066,6 +1086,15 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         }
         normalize_forced_raw_bindings(rust_program.tcx, &mut ptr_kinds, &forced_raw_bindings);
         emit_ownership_field_diagnostics(rust_program.tcx, analysis, &sig_decs, &ptr_kinds);
+        let field_cursor_fields = analysis.offset_sign_result.field_access_signs.clone();
+        apply_field_storage_input_lifetimes(
+            rust_program.tcx,
+            analysis,
+            &lifetime_plans,
+            &demoted_fields,
+            &field_cursor_fields,
+            &mut sig_decs,
+        );
         let raw_bridge_bindings = collect_raw_bridge_bindings(
             rust_program.tcx,
             &ptr_kinds,
@@ -1085,6 +1114,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             alloc_wrappers,
             free_like_wrappers,
             demoted_fields,
+            field_cursor_fields,
             impl_self_lifetimes: Vec::new(),
             ast_to_hir,
             bytemuck: Cell::new(false),
@@ -1093,7 +1123,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn field_ptr_kind(&self, field: StructFieldSlot) -> Option<PtrKind> {
-        if scalar_owning_raw_field_inner_ty(self.tcx, self.analysis, field).is_some() {
+        if struct_field_is_exactly_owning(self.analysis, field) {
             self.ownership_field_kind(field)
         } else {
             self.promoted_field_kind(field)
@@ -1114,23 +1144,36 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         if self.demoted_fields.contains(&field) {
             return None;
         }
-        if self
+        let mutability = if self
             .analysis
             .borrow_promotion_result
             .mutable_fields
             .contains(&field)
         {
-            Some(PtrKind::OptRef(true))
+            true
         } else if self
             .analysis
             .borrow_promotion_result
             .shared_fields
             .contains(&field)
         {
-            Some(PtrKind::OptRef(false))
+            false
         } else {
-            None
+            return None;
+        };
+        if self.field_is_array_like(field) {
+            if self.field_cursor_fields.contains(&field) {
+                Some(PtrKind::SliceCursor(mutability))
+            } else {
+                Some(PtrKind::Slice(mutability))
+            }
+        } else {
+            Some(PtrKind::OptRef(mutability))
         }
+    }
+
+    fn field_is_array_like(&self, field: StructFieldSlot) -> bool {
+        analysis_field_is_array_like(self.analysis, field)
     }
 
     fn mark_param_mut_if_needed(&self, param: &mut Param) {
@@ -1260,6 +1303,23 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 }
                 PtrKind::OptBox => {
                     field_def.ty = P(utils::ty!("Option<Box<{inner_ty}>>"));
+                }
+                PtrKind::Slice(mutability) => {
+                    let Some(lifetime) = self.field_lifetime(field) else {
+                        continue;
+                    };
+                    field_def.ty = P(mk_slice_ast_ty_with_lifetime(
+                        inner_ty, mutability, lifetime,
+                    ));
+                }
+                PtrKind::SliceCursor(mutability) => {
+                    let Some(lifetime) = self.field_lifetime(field) else {
+                        continue;
+                    };
+                    field_def.ty = P(mk_cursor_ast_ty_with_lifetime(
+                        inner_ty, mutability, lifetime,
+                    ));
+                    self.slice_cursor.set(true);
                 }
                 _ => {}
             }
@@ -1728,6 +1788,24 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         }
     }
 
+    fn mk_cursor_ty_with_lifetime(
+        &self,
+        ty: ty::Ty<'tcx>,
+        mutability: bool,
+        lifetime: Option<Symbol>,
+    ) -> Ty {
+        let ty = self.ty_name(ty);
+        let cursor = if mutability {
+            "SliceCursorMut"
+        } else {
+            "SliceCursor"
+        };
+        let lifetime = lifetime
+            .map(|lifetime| format!("'{}", lifetime.as_str()))
+            .unwrap_or_else(|| "'_".to_owned());
+        utils::ty!("crate::slice_cursor::{cursor}<{lifetime}, {ty}>")
+    }
+
     fn mk_slice_ty(&self, ty: ty::Ty<'tcx>, mutability: bool) -> Ty {
         let ty = self.ty_name(ty);
         if mutability {
@@ -1735,6 +1813,20 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         } else {
             utils::ty!("&[{ty}]")
         }
+    }
+
+    fn mk_slice_ty_with_lifetime(
+        &self,
+        ty: ty::Ty<'tcx>,
+        mutability: bool,
+        lifetime: Option<Symbol>,
+    ) -> Ty {
+        let ty = self.ty_name(ty);
+        let m = if mutability { "mut " } else { "" };
+        let lifetime = lifetime
+            .map(|lifetime| format!("'{} ", lifetime.as_str()))
+            .unwrap_or_default();
+        utils::ty!("&{lifetime}{m}[{ty}]")
     }
 
     fn mk_raw_ptr_ty(&self, ty: ty::Ty<'tcx>, mutability: bool) -> Ty {
@@ -1748,17 +1840,30 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         field_expr: &Expr,
         mutability: bool,
         inner_ty: ty::Ty<'tcx>,
+        field_kind: PtrKind,
     ) -> Expr {
         let field_expr = pprust::expr_to_string(field_expr);
         let inner_ty = self.ty_name(inner_ty);
-        if mutability {
-            utils::expr!(
-                "({field_expr}).as_deref_mut().map_or(std::ptr::null_mut(), |r| r as *mut {inner_ty})"
-            )
-        } else {
-            utils::expr!(
-                "({field_expr}).as_deref().map_or(std::ptr::null(), |r| r as *const {inner_ty})"
-            )
+        match field_kind {
+            PtrKind::OptRef(_) | PtrKind::OptBox => {
+                if mutability {
+                    utils::expr!(
+                        "({field_expr}).as_deref_mut().map_or(std::ptr::null_mut(), |r| r as *mut {inner_ty})"
+                    )
+                } else {
+                    utils::expr!(
+                        "({field_expr}).as_deref().map_or(std::ptr::null(), |r| r as *const {inner_ty})"
+                    )
+                }
+            }
+            PtrKind::Slice(_) | PtrKind::SliceCursor(_) => {
+                if mutability {
+                    utils::expr!("({field_expr}).as_mut_ptr() as *mut {inner_ty}")
+                } else {
+                    utils::expr!("({field_expr}).as_ptr() as *const {inner_ty}")
+                }
+            }
+            _ => unreachable!(),
         }
     }
 
@@ -2414,7 +2519,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         let typeck = self.tcx.typeck(hir_ptr.hir_id.owner);
         let lhs_ty = typeck.expr_ty_adjusted(hir_ptr);
         let rhs_ty = typeck.expr_ty(hir_unwrap_cast(hir_ptr));
-        if let PtrCtx::Rhs(kind @ PtrKind::OptRef(_)) = ctx
+        if let PtrCtx::Rhs(
+            kind @ (PtrKind::OptRef(_) | PtrKind::Slice(_) | PtrKind::SliceCursor(_)),
+        ) = ctx
             && let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
             && self.field_ptr_kind(field) == Some(kind)
         {
@@ -2422,10 +2529,14 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         }
         if let PtrCtx::Rhs(PtrKind::Raw(m)) = ctx
             && let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
-            && matches!(self.field_ptr_kind(field), Some(PtrKind::OptRef(_)))
+            && let Some(field_kind) = self.field_ptr_kind(field)
+            && matches!(
+                field_kind,
+                PtrKind::OptRef(_) | PtrKind::OptBox | PtrKind::Slice(_) | PtrKind::SliceCursor(_)
+            )
             && let Some((lhs_inner_ty, _)) = unwrap_ptr_from_mir_ty(lhs_ty)
         {
-            *ptr = self.raw_from_promoted_field_expr(e, m, lhs_inner_ty);
+            *ptr = self.raw_from_promoted_field_expr(e, m, lhs_inner_ty, field_kind);
             return PtrKind::Raw(m);
         }
         let mut pe = if let Some(pe) = self.ptr_expr(e, hir_e) {
@@ -3438,7 +3549,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     let base = self.projected_expr(&pe, m, false);
                     let mut result =
                         self.cursor_from_slice_or_cursor(&base, &pe, m, lhs_inner_ty, rhs_inner_ty);
-                    if !m && m1 {
+                    if !m && m1 && pe.projs.is_empty() && lhs_inner_ty == rhs_inner_ty {
                         result = utils::expr!("({}).as_deref()", pprust::expr_to_string(&result),);
                     }
                     // need fork only for identity copy (no projections, no cast)
@@ -3770,10 +3881,18 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                             struct_did,
                             field_index,
                         };
-                        let field_expr = if self.field_ptr_kind(field_slot).is_some() {
-                            utils::expr!("None")
-                        } else {
-                            self.default_value_expr(field.ty(self.tcx, args))
+                        let field_expr = match self.field_ptr_kind(field_slot) {
+                            Some(PtrKind::OptRef(_) | PtrKind::OptBox) => utils::expr!("None"),
+                            Some(PtrKind::Slice(m)) => self.empty_slice_expr(m),
+                            Some(PtrKind::SliceCursor(m)) => {
+                                self.slice_cursor.set(true);
+                                if m {
+                                    utils::expr!("crate::slice_cursor::SliceCursorMut::empty()")
+                                } else {
+                                    utils::expr!("crate::slice_cursor::SliceCursor::empty()")
+                                }
+                            }
+                            _ => self.default_value_expr(field.ty(self.tcx, args)),
                         };
                         format!("{field_name}: {}", pprust::expr_to_string(&field_expr))
                     })
@@ -5327,6 +5446,10 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         lhs_inner_ty: ty::Ty<'tcx>,
         rhs_inner_ty: ty::Ty<'tcx>,
     ) -> Expr {
+        if !m && let Some(receiver) = slice_cursor_mut_temp_as_slice_receiver(e) {
+            let shared_cursor = utils::expr!("({}).as_deref()", pprust::expr_to_string(receiver));
+            return self.cursor_from_cursor(&shared_cursor, m, lhs_inner_ty, rhs_inner_ty);
+        }
         let need_cast = lhs_inner_ty != rhs_inner_ty;
         let is_rewritten_slice_like_local =
             matches!(pe.base_kind, PtrExprBaseKind::Path(Res::Local(_)))
@@ -5437,14 +5560,13 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         if !need_cast {
             e.clone()
         } else if lhs_inner_ty.is_numeric() && rhs_inner_ty.is_numeric() {
-            self.bytemuck.set(true);
             utils::expr!(
-                "{}::new(bytemuck::cast_slice{}::<_, {}>(({}).as_slice{}()))",
+                "{}::from_raw_parts{}(({}).as_ptr() as *{} {}, 1_000_000)",
                 cursor_ty,
                 if m { "_mut" } else { "" },
-                mir_ty_to_string(lhs_inner_ty, self.tcx),
                 pprust::expr_to_string(e),
-                if m { "_mut" } else { "" },
+                if m { "mut" } else { "const" },
+                mir_ty_to_string(lhs_inner_ty, self.tcx),
             )
         } else {
             utils::expr!(
@@ -5747,11 +5869,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             },
             |kind| kind.is_mut(),
         );
-        let mut is_plain_slice = if let PtrExprBaseKind::Path(Res::Local(hir_id)) = pe.base_kind {
-            matches!(self.effective_ptr_kind(hir_id), Some(PtrKind::Slice(_)))
-        } else {
-            false
-        };
+        let mut is_plain_slice = matches!(self.ptr_source_kind(pe), Some(PtrKind::Slice(_)));
         // A "data container" is a Vec/array accessed via as_ptr that is NOT a cursor.
         // For these, offsets should produce re-sliced expressions, not cursor operations.
         let is_data_container = pe.as_ptr
@@ -5759,14 +5877,8 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 pe.base_kind,
                 PtrExprBaseKind::Array | PtrExprBaseKind::Alloca
             );
-        let is_mut_cursor_base = if let PtrExprBaseKind::Path(Res::Local(hir_id)) = pe.base_kind {
-            matches!(
-                self.ptr_kinds.get(&hir_id),
-                Some(PtrKind::SliceCursor(true))
-            )
-        } else {
-            false
-        };
+        let is_mut_cursor_base =
+            matches!(self.ptr_source_kind(pe), Some(PtrKind::SliceCursor(true)));
         let mut e = pe.base.clone();
         if pe.projs.is_empty() {
             return e;
@@ -5800,12 +5912,28 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                                 pprust::expr_to_string(offset),
                             );
                         }
-                    } else if m && is_mut_cursor_base {
-                        e = utils::expr!(
-                            "{{ let mut _c = ({}).as_deref_mut(); _c.seek(({}) as isize); _c }}",
-                            pprust::expr_to_string(&e),
-                            pprust::expr_to_string(offset),
-                        );
+                    } else if is_mut_cursor_base {
+                        if m {
+                            e = utils::expr!(
+                                "{{ let mut _c = ({}).as_deref_mut(); _c.seek(({}) as isize); _c }}",
+                                pprust::expr_to_string(&e),
+                                pprust::expr_to_string(offset),
+                            );
+                        } else {
+                            if is_slice_cursor_mut_constructor_call(&e) {
+                                e = utils::expr!(
+                                    "{{ let mut _c = ({}).as_deref(); _c.seek(({}) as isize); _c }}",
+                                    pprust::expr_to_string(&e),
+                                    pprust::expr_to_string(offset),
+                                );
+                            } else {
+                                e = utils::expr!(
+                                    "{{ let mut _c = crate::slice_cursor::SliceCursor::new(({}).as_slice()); _c.seek(({}) as isize); _c }}",
+                                    pprust::expr_to_string(&e),
+                                    pprust::expr_to_string(offset),
+                                );
+                            }
+                        }
                     } else {
                         e = utils::expr!(
                             "{{ let mut _c = ({}); _c.seek(({}) as isize); _c }}",
@@ -5939,6 +6067,24 @@ fn mk_opt_ref_ast_ty_with_lifetime(inner_ty: String, mutability: bool, lifetime:
     let m = if mutability { "mut " } else { "" };
     let lifetime = lifetime.as_str();
     utils::ty!("Option<&'{lifetime} {m}{inner_ty}>")
+}
+
+#[inline]
+fn mk_slice_ast_ty_with_lifetime(inner_ty: String, mutability: bool, lifetime: Symbol) -> Ty {
+    let m = if mutability { "mut " } else { "" };
+    let lifetime = lifetime.as_str();
+    utils::ty!("&'{lifetime} {m}[{inner_ty}]")
+}
+
+#[inline]
+fn mk_cursor_ast_ty_with_lifetime(inner_ty: String, mutability: bool, lifetime: Symbol) -> Ty {
+    let cursor = if mutability {
+        "SliceCursorMut"
+    } else {
+        "SliceCursor"
+    };
+    let lifetime = lifetime.as_str();
+    utils::ty!("crate::slice_cursor::{cursor}<'{lifetime}, {inner_ty}>")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -12416,6 +12562,148 @@ fn hir_struct_field_slot(tcx: TyCtxt<'_>, hir_expr: &hir::Expr<'_>) -> Option<St
     })
 }
 
+fn apply_field_storage_input_lifetimes(
+    tcx: TyCtxt<'_>,
+    analysis: &Analysis,
+    lifetime_plans: &super::lifetimes::LifetimePlans,
+    demoted_fields: &FxHashSet<StructFieldSlot>,
+    field_cursor_fields: &FxHashSet<StructFieldSlot>,
+    sig_decs: &mut SigDecisions,
+) {
+    struct FieldStorageLifetimeVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        analysis: &'a Analysis,
+        lifetime_plans: &'a super::lifetimes::LifetimePlans,
+        demoted_fields: &'a FxHashSet<StructFieldSlot>,
+        field_cursor_fields: &'a FxHashSet<StructFieldSlot>,
+        sig_decs: &'a mut SigDecisions,
+    }
+
+    impl FieldStorageLifetimeVisitor<'_, '_> {
+        fn record_storage(&mut self, field: StructFieldSlot, rhs: &hir::Expr<'_>) {
+            if !matches!(
+                borrow_promoted_array_field_kind(
+                    self.analysis,
+                    self.demoted_fields,
+                    self.field_cursor_fields,
+                    field,
+                ),
+                Some(PtrKind::Slice(_) | PtrKind::SliceCursor(_))
+            ) {
+                return;
+            }
+            let Some(lifetime) = self
+                .lifetime_plans
+                .structs
+                .get(&field.struct_did)
+                .and_then(|plan| plan.field_lifetimes.get(&field.field_index))
+                .copied()
+            else {
+                return;
+            };
+            let Some(rhs_hir_id) = hir_unwrapped_local_id(hir_unwrap_addr_of_deref(rhs)) else {
+                return;
+            };
+            let Some((did, input_index)) = param_index_for_binding(self.tcx, rhs_hir_id) else {
+                return;
+            };
+            let Some(sig_dec) = self.sig_decs.data.get_mut(&did) else {
+                return;
+            };
+            if let Some(input_lifetime) = sig_dec.input_lifetimes.get_mut(input_index)
+                && (input_lifetime.is_none() || *input_lifetime == Some(lifetime))
+            {
+                *input_lifetime = Some(lifetime);
+            }
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for FieldStorageLifetimeVisitor<'_, 'tcx> {
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            match expr.kind {
+                hir::ExprKind::Assign(lhs, rhs, _) => {
+                    if let Some(field) = hir_struct_field_slot(self.tcx, lhs) {
+                        self.record_storage(field, rhs);
+                    }
+                }
+                hir::ExprKind::Struct(qpath, fields, _) => {
+                    if let Some(struct_did) = hir_local_struct_did_from_qpath(qpath) {
+                        for field_expr in fields {
+                            if let Some(field_index) =
+                                hir_field_index_by_name(self.tcx, struct_did, field_expr.ident.name)
+                            {
+                                self.record_storage(
+                                    StructFieldSlot {
+                                        struct_did,
+                                        field_index,
+                                    },
+                                    field_expr.expr,
+                                );
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut visitor = FieldStorageLifetimeVisitor {
+        tcx,
+        analysis,
+        lifetime_plans,
+        demoted_fields,
+        field_cursor_fields,
+        sig_decs,
+    };
+    for def_id in tcx.hir_body_owners() {
+        visitor.visit_body(tcx.hir_body_owned_by(def_id));
+    }
+}
+
+fn borrow_promoted_array_field_kind(
+    analysis: &Analysis,
+    demoted_fields: &FxHashSet<StructFieldSlot>,
+    field_cursor_fields: &FxHashSet<StructFieldSlot>,
+    field: StructFieldSlot,
+) -> Option<PtrKind> {
+    if demoted_fields.contains(&field) || struct_field_is_exactly_owning(analysis, field) {
+        return None;
+    }
+    let mutability = if analysis
+        .borrow_promotion_result
+        .mutable_fields
+        .contains(&field)
+    {
+        true
+    } else if analysis
+        .borrow_promotion_result
+        .shared_fields
+        .contains(&field)
+    {
+        false
+    } else {
+        return None;
+    };
+    if !analysis_field_is_array_like(analysis, field) {
+        return None;
+    }
+    if field_cursor_fields.contains(&field) {
+        Some(PtrKind::SliceCursor(mutability))
+    } else {
+        Some(PtrKind::Slice(mutability))
+    }
+}
+
+fn analysis_field_is_array_like(analysis: &Analysis, field: StructFieldSlot) -> bool {
+    analysis
+        .fatness_result
+        .struct_facts(field.struct_did)
+        .nth(field.field_index)
+        .is_some_and(|fatnesses| fatnesses.iter().any(|fatness| fatness.is_arr()))
+}
+
 fn hir_field_base_local_id(hir_expr: &hir::Expr<'_>) -> Option<HirId> {
     let hir::ExprKind::Field(base, _) = hir_expr.kind else {
         return None;
@@ -12604,6 +12892,36 @@ fn is_std_slice_constructor_call(expr: &Expr) -> bool {
                 && matches!(
                     ctor,
                     "from_mut" | "from_ref" | "from_raw_parts" | "from_raw_parts_mut"
+                );
+        }
+    }
+    false
+}
+
+fn slice_cursor_mut_temp_as_slice_receiver(expr: &Expr) -> Option<&Expr> {
+    let expr = unwrap_paren(expr);
+    let ExprKind::MethodCall(call) = &expr.kind else {
+        return None;
+    };
+    if !matches!(call.seg.ident.name.as_str(), "as_slice" | "as_slice_mut") {
+        return None;
+    }
+    let receiver = unwrap_paren(&call.receiver);
+    is_slice_cursor_mut_constructor_call(receiver).then_some(receiver)
+}
+
+fn is_slice_cursor_mut_constructor_call(expr: &Expr) -> bool {
+    if let ExprKind::Call(callee, _) = &unwrap_cast_and_paren(expr).kind
+        && let ExprKind::Path(_, path) = &unwrap_paren(callee).kind
+    {
+        let segs = &path.segments;
+        if segs.len() >= 2 {
+            let ctor = segs[segs.len() - 1].ident.name.as_str();
+            let owner = segs[segs.len() - 2].ident.name.as_str();
+            return owner == "SliceCursorMut"
+                && matches!(
+                    ctor,
+                    "new" | "with_pos" | "from_mut" | "from_raw_parts" | "from_raw_parts_mut"
                 );
         }
     }
@@ -12869,6 +13187,7 @@ mod tests {
             alloc_wrappers: FxHashMap::default(),
             free_like_wrappers: FxHashSet::default(),
             demoted_fields: FxHashSet::default(),
+            field_cursor_fields: analysis.offset_sign_result.field_access_signs.clone(),
             impl_self_lifetimes: Vec::new(),
             ast_to_hir: AstToHir::default(),
             bytemuck: Cell::new(false),

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -965,26 +965,30 @@ fn collect_c_exposed_signature_structs<'tcx>(
             .copied()
             .chain(std::iter::once(sig.output()))
         {
-            collect_local_structs_from_ty(ty, &mut structs);
+            collect_local_structs_from_ty(rust_program.tcx, ty, &mut structs);
         }
     }
     structs
 }
 
-fn collect_local_structs_from_ty<'tcx>(ty: ty::Ty<'tcx>, structs: &mut FxHashSet<LocalDefId>) {
+fn collect_local_structs_from_ty<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: ty::Ty<'tcx>,
+    structs: &mut FxHashSet<LocalDefId>,
+) {
     match ty.kind() {
         ty::TyKind::RawPtr(pointee, _) => {
-            collect_local_structs_from_ty(*pointee, structs);
+            collect_local_structs_from_ty(tcx, *pointee, structs);
         }
         ty::TyKind::Ref(_, pointee, _) => {
-            collect_local_structs_from_ty(*pointee, structs);
+            collect_local_structs_from_ty(tcx, *pointee, structs);
         }
         ty::TyKind::Array(elem, _) | ty::TyKind::Slice(elem) => {
-            collect_local_structs_from_ty(*elem, structs);
+            collect_local_structs_from_ty(tcx, *elem, structs);
         }
         ty::TyKind::Tuple(elems) => {
             for elem in elems.iter() {
-                collect_local_structs_from_ty(elem, structs);
+                collect_local_structs_from_ty(tcx, elem, structs);
             }
         }
         ty::TyKind::Adt(adt_def, args) => {
@@ -996,7 +1000,7 @@ fn collect_local_structs_from_ty<'tcx>(ty: ty::Ty<'tcx>, structs: &mut FxHashSet
             }
             for arg in args.iter() {
                 if let ty::GenericArgKind::Type(arg_ty) = arg.kind() {
-                    collect_local_structs_from_ty(arg_ty, structs);
+                    collect_local_structs_from_ty(tcx, arg_ty, structs);
                 }
             }
         }

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -632,7 +632,15 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                             )
                         {
                             self.transform_rhs(rhs, hir_rhs, lhs_kind);
-                        } else if lhs_hir_id.is_none() {
+                        } else if lhs_hir_id.is_none()
+                            && !self.try_bridge_raw_projection_root(
+                                rhs,
+                                hir_rhs,
+                                hir_lhs,
+                                lhs_kind,
+                                lhs_inner_ty,
+                            )
+                        {
                             self.transform_rhs(rhs, hir_rhs, lhs_kind);
                         }
                     }
@@ -1890,18 +1898,60 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         ) else {
             return false;
         };
-        let info = self.raw_bridge_bindings.get(&lhs_hir_id).or_else(|| {
-            self.alloc_wrappers
-                .contains_key(&lhs_hir_id.owner.def_id)
-                .then_some(&current_info)
-        });
+        let info = self
+            .raw_bridge_bindings
+            .get(&lhs_hir_id)
+            .cloned()
+            .or_else(|| {
+                self.alloc_wrappers
+                    .contains_key(&lhs_hir_id.owner.def_id)
+                    .then_some(current_info.clone())
+            })
+            .or_else(|| {
+                (matches!(current_info, RawBridgeInfo::Scalar)
+                    && ty_supports_scalar_box_from_raw_bridge(lhs_inner_ty))
+                .then_some(current_info.clone())
+            });
         let Some(info) = info else {
             return false;
         };
-        if &current_info != info {
+        if current_info != info {
             return false;
         }
-        *rhs = self.raw_bridge_expr(lhs_inner_ty, m, info);
+        *rhs = self.raw_bridge_expr(lhs_inner_ty, m, &info);
+        true
+    }
+
+    fn try_bridge_raw_projection_root(
+        &self,
+        rhs: &mut Expr,
+        hir_rhs: &'tcx hir::Expr<'tcx>,
+        hir_lhs: &'tcx hir::Expr<'tcx>,
+        lhs_kind: PtrKind,
+        lhs_inner_ty: ty::Ty<'tcx>,
+    ) -> bool {
+        let PtrKind::Raw(m) = lhs_kind else {
+            return false;
+        };
+        if !ty_supports_scalar_box_from_raw_bridge(lhs_inner_ty) {
+            return false;
+        }
+        if hir_struct_field_slot(self.tcx, hir_lhs).is_none() {
+            return false;
+        }
+        let Some(info) = hir_raw_bridge_info(
+            self.tcx,
+            lhs_inner_ty,
+            hir_rhs,
+            Some(&self.alloc_wrappers),
+            None,
+        ) else {
+            return false;
+        };
+        if !matches!(info, RawBridgeInfo::Scalar) {
+            return false;
+        }
+        *rhs = self.raw_bridge_expr(lhs_inner_ty, m, &info);
         true
     }
 
@@ -1911,7 +1961,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         let default_expr_str = pprust::expr_to_string(&default_expr);
         match info {
             RawBridgeInfo::Scalar => utils::expr!(
-                "Box::into_raw(Box::new({})) as *{} {}",
+                "Box::leak(Box::new({})) as *{} {}",
                 default_expr_str,
                 if m { "mut" } else { "const" },
                 ty,
@@ -1994,44 +2044,75 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         if let Some(field_free) = self.rewrite_owned_field_free_call(hir_expr, args) {
             return Some(field_free);
         }
-        let (hir_id, _harg) =
-            hir_free_like_arg_local_id(self.tcx, hir_expr, &self.free_like_wrappers)?;
-        if hir_call_matches_foreign_name(self.tcx, hir_expr, "free")
-            && matches!(
-                self.effective_ptr_kind(hir_id),
-                Some(PtrKind::Box | PtrKind::OptBox | PtrKind::BoxedSlice | PtrKind::OptBoxedSlice)
-            )
+        if let Some((hir_id, _harg)) =
+            hir_free_like_arg_local_id(self.tcx, hir_expr, &self.free_like_wrappers)
         {
-            let local_name = self.tcx.hir_name(hir_id).to_string();
-            return match self.effective_ptr_kind(hir_id) {
-                Some(PtrKind::Box | PtrKind::BoxedSlice) => {
-                    Some(utils::expr!("drop({local_name})"))
-                }
-                Some(PtrKind::OptBox | PtrKind::OptBoxedSlice) => {
-                    Some(utils::expr!("drop(({local_name}).take())"))
-                }
-                _ => None,
-            };
+            if hir_call_matches_foreign_name(self.tcx, hir_expr, "free")
+                && matches!(
+                    self.effective_ptr_kind(hir_id),
+                    Some(
+                        PtrKind::Box
+                            | PtrKind::OptBox
+                            | PtrKind::BoxedSlice
+                            | PtrKind::OptBoxedSlice
+                    )
+                )
+            {
+                let local_name = self.tcx.hir_name(hir_id).to_string();
+                return match self.effective_ptr_kind(hir_id) {
+                    Some(PtrKind::Box | PtrKind::BoxedSlice) => {
+                        Some(utils::expr!("drop({local_name})"))
+                    }
+                    Some(PtrKind::OptBox | PtrKind::OptBoxedSlice) => {
+                        Some(utils::expr!("drop(({local_name}).take())"))
+                    }
+                    _ => None,
+                };
+            }
+            if let Some(info) = self.raw_bridge_bindings.get(&hir_id) {
+                let [arg] = args else { return None };
+                let arg_ty = self.tcx.typeck(hir_expr.hir_id.owner).node_type(hir_id);
+                let (inner_ty, _) = unwrap_ptr_from_mir_ty(arg_ty)?;
+                let arg_str = pprust::expr_to_string(arg);
+                let inner_ty_str = mir_ty_to_string(inner_ty, self.tcx);
+                return Some(match info {
+                    RawBridgeInfo::Scalar => scalar_box_from_raw_free_expr(&arg_str, &inner_ty_str),
+                    RawBridgeInfo::Array { len_expr } => {
+                        array_box_from_raw_free_expr(&arg_str, &inner_ty_str, len_expr)
+                    }
+                });
+            }
         }
-        let info = self.raw_bridge_bindings.get(&hir_id)?;
+        self.rewrite_scalar_box_from_raw_free_call(hir_expr, args)
+    }
+
+    fn rewrite_scalar_box_from_raw_free_call(
+        &self,
+        hir_expr: &'tcx hir::Expr<'tcx>,
+        args: &[P<Expr>],
+    ) -> Option<Expr> {
+        if !hir_call_matches_foreign_name(self.tcx, hir_expr, "free") {
+            return None;
+        }
+        let hir::ExprKind::Call(_, hir_args) = hir_expr.kind else {
+            return None;
+        };
+        let [hir_arg] = hir_args else { return None };
         let [arg] = args else { return None };
-        let arg_ty = self.tcx.typeck(hir_expr.hir_id.owner).node_type(hir_id);
+        let hir_arg = hir_unwrap_casts(hir_arg);
+        let arg_ty = self
+            .tcx
+            .typeck(hir_expr.hir_id.owner)
+            .expr_ty_adjusted(hir_arg);
         let (inner_ty, _) = unwrap_ptr_from_mir_ty(arg_ty)?;
-        let arg_str = pprust::expr_to_string(arg);
+        if !ty_supports_scalar_box_from_raw_bridge(inner_ty) {
+            return None;
+        }
+        let mut raw_arg = (**arg).clone();
+        self.transform_rhs(&mut raw_arg, hir_arg, PtrKind::Raw(true));
+        let arg_str = pprust::expr_to_string(&raw_arg);
         let inner_ty_str = mir_ty_to_string(inner_ty, self.tcx);
-        Some(match info {
-            RawBridgeInfo::Scalar => utils::expr!(
-                "if !({0}).is_null() {{ drop(unsafe {{ Box::from_raw(({0}) as *mut {1}) }}); }}",
-                arg_str,
-                inner_ty_str,
-            ),
-            RawBridgeInfo::Array { len_expr } => utils::expr!(
-                "if !({0}).is_null() {{ drop(unsafe {{ Box::from_raw(std::ptr::slice_from_raw_parts_mut(({0}) as *mut {1}, ({2}) as usize)) }}); }}",
-                arg_str,
-                inner_ty_str,
-                len_expr,
-            ),
-        })
+        Some(scalar_box_from_raw_free_expr(&arg_str, &inner_ty_str))
     }
 
     fn rewrite_owned_field_free_call(
@@ -8900,6 +8981,30 @@ fn ty_supports_raw_bridge_default_expr<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>
     }
 }
 
+fn ty_supports_scalar_box_from_raw_bridge(ty: ty::Ty<'_>) -> bool {
+    matches!(
+        ty.kind(),
+        ty::TyKind::Adt(adt_def, _) if adt_def.did().is_local() && adt_def.is_struct()
+    )
+}
+
+fn scalar_box_from_raw_free_expr(arg_str: &str, inner_ty_str: &str) -> Expr {
+    utils::expr!(
+        "{{ let __crat_raw_free = {}; if !(__crat_raw_free).is_null() {{ drop(unsafe {{ Box::from_raw((__crat_raw_free) as *mut {}) }}); }} }}",
+        arg_str,
+        inner_ty_str,
+    )
+}
+
+fn array_box_from_raw_free_expr(arg_str: &str, inner_ty_str: &str, len_expr: &str) -> Expr {
+    utils::expr!(
+        "{{ let __crat_raw_free = {}; if !(__crat_raw_free).is_null() {{ drop(unsafe {{ Box::from_raw(std::ptr::slice_from_raw_parts_mut((__crat_raw_free) as *mut {}, ({}) as usize)) }}); }} }}",
+        arg_str,
+        inner_ty_str,
+        len_expr,
+    )
+}
+
 fn fieldless_enum_zero_variant<'tcx>(
     tcx: TyCtxt<'tcx>,
     adt_def: ty::AdtDef<'tcx>,
@@ -8958,9 +9063,10 @@ fn raw_bridge_info_from_call<'tcx>(
     let ty_name = (!ty_contains_param(lhs_inner_ty)).then(|| mir_ty_to_string(lhs_inner_ty, tcx));
     match (name, args) {
         (name, [bytes]) if name == Symbol::intern("malloc") => {
-            if ty_name
-                .as_ref()
-                .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, bytes, ty_name))
+            if hir_size_of_call_matches_expected(tcx, bytes, lhs_inner_ty)
+                || ty_name
+                    .as_ref()
+                    .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, bytes, ty_name))
             {
                 Some(RawBridgeInfo::Scalar)
             } else if scalar_arg_rejected(bytes) {
@@ -8972,9 +9078,10 @@ fn raw_bridge_info_from_call<'tcx>(
         }
         (name, [count, elem_size]) if name == Symbol::intern("calloc") => {
             if hir_is_literal_one(tcx, count)
-                && ty_name
-                    .as_ref()
-                    .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, elem_size, ty_name))
+                && (hir_size_of_call_matches_expected(tcx, elem_size, lhs_inner_ty)
+                    || ty_name
+                        .as_ref()
+                        .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, elem_size, ty_name)))
             {
                 Some(RawBridgeInfo::Scalar)
             } else if scalar_arg_rejected(count) || scalar_arg_rejected(elem_size) {
@@ -9000,9 +9107,10 @@ fn raw_bridge_info_from_call<'tcx>(
         (name, [ptr, bytes])
             if name == Symbol::intern("realloc") && hir_is_null_like_ptr_arg(tcx, ptr) =>
         {
-            if ty_name
-                .as_ref()
-                .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, bytes, ty_name))
+            if hir_size_of_call_matches_expected(tcx, bytes, lhs_inner_ty)
+                || ty_name
+                    .as_ref()
+                    .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, bytes, ty_name))
             {
                 Some(RawBridgeInfo::Scalar)
             } else if scalar_arg_rejected(bytes) {
@@ -14847,9 +14955,9 @@ pub unsafe fn free_nested() {
         let (analysis, after) = analyze_pointer_safety_for_code(code);
         assert_eq!(analysis.safe_box_sites.total(), 0);
         assert_eq!(after.frees, 0);
-        assert_eq!(after.bridge_calls.leak, 0);
+        assert_eq!(after.bridge_calls.leak, 1);
         assert_eq!(after.bridge_calls.from_raw, 1);
-        assert_eq!(after.bridge_calls.into_raw, 1);
+        assert_eq!(after.bridge_calls.into_raw, 0);
     }
 
     #[test]

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -9091,12 +9091,12 @@ mod tests {
         );
         let source_var_groups = SourceVarGroups::new(&input);
         let mutables = source_var_groups.postprocess_mut_res(&input, &mutability_result);
-        let (mutable_references, shared_references) =
+        let borrow_promotion_result =
             analyses::borrow::mutable_references_no_guarantee(&input, &mutables);
         let promoted_mut_ref_result =
-            source_var_groups.postprocess_promoted_mut_refs(mutable_references);
+            source_var_groups.postprocess_promoted_mut_refs(borrow_promotion_result.mutable_locals);
         let promoted_shared_ref_result =
-            source_var_groups.postprocess_promoted_mut_refs(shared_references);
+            source_var_groups.postprocess_promoted_mut_refs(borrow_promotion_result.shared_locals);
         let fatness_result = analyses::type_qualifier::foster::fatness::fatness_analysis(&input);
         let mut offset_sign_result = analyses::offset_sign::sign::offset_sign_analysis(&input);
         offset_sign_result.access_signs =

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -24,7 +24,7 @@ use utils::{
 };
 
 use super::{
-    Analysis, Config,
+    Analysis,
     collector::collect_diffs,
     decision::{PtrKind, SigDecision, SigDecisions},
 };
@@ -45,7 +45,6 @@ pub(crate) struct TransformVisitor<'a, 'tcx> {
     free_like_wrappers: FxHashSet<LocalDefId>,
     demoted_fields: FxHashSet<StructFieldSlot>,
     field_cursor_fields: FxHashSet<StructFieldSlot>,
-    c_exposed_signature_structs: FxHashSet<LocalDefId>,
     impl_self_lifetimes: Vec<(LocalDefId, Vec<Symbol>)>,
     ast_to_hir: AstToHir,
     pub bytemuck: Cell<bool>,
@@ -948,66 +947,6 @@ enum PtrCtx {
     Deref(bool),
 }
 
-fn collect_c_exposed_signature_structs<'tcx>(
-    rust_program: &RustProgram<'tcx>,
-    c_exposed_fns: &FxHashSet<String>,
-) -> FxHashSet<LocalDefId> {
-    let mut structs = FxHashSet::default();
-    for did in &rust_program.functions {
-        let name = rust_program.tcx.item_name(did.to_def_id());
-        if !c_exposed_fns.contains(name.as_str()) {
-            continue;
-        }
-        let sig = rust_program.tcx.fn_sig(*did).skip_binder().skip_binder();
-        for ty in sig
-            .inputs()
-            .iter()
-            .copied()
-            .chain(std::iter::once(sig.output()))
-        {
-            collect_local_structs_from_ty(rust_program.tcx, ty, &mut structs);
-        }
-    }
-    structs
-}
-
-fn collect_local_structs_from_ty<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    ty: ty::Ty<'tcx>,
-    structs: &mut FxHashSet<LocalDefId>,
-) {
-    match ty.kind() {
-        ty::TyKind::RawPtr(pointee, _) => {
-            collect_local_structs_from_ty(tcx, *pointee, structs);
-        }
-        ty::TyKind::Ref(_, pointee, _) => {
-            collect_local_structs_from_ty(tcx, *pointee, structs);
-        }
-        ty::TyKind::Array(elem, _) | ty::TyKind::Slice(elem) => {
-            collect_local_structs_from_ty(tcx, *elem, structs);
-        }
-        ty::TyKind::Tuple(elems) => {
-            for elem in elems.iter() {
-                collect_local_structs_from_ty(tcx, elem, structs);
-            }
-        }
-        ty::TyKind::Adt(adt_def, args) => {
-            if adt_def.is_struct()
-                && !adt_def.is_union()
-                && let Some(local_did) = adt_def.did().as_local()
-            {
-                structs.insert(local_did);
-            }
-            for arg in args.iter() {
-                if let ty::GenericArgKind::Type(arg_ty) = arg.kind() {
-                    collect_local_structs_from_ty(tcx, arg_ty, structs);
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
 #[derive(Clone, Copy, Debug)]
 enum AllocatorRoot<'a> {
     Malloc {
@@ -1021,14 +960,11 @@ enum AllocatorRoot<'a> {
 
 impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     pub fn new(
-        config: &Config,
         rust_program: &RustProgram<'tcx>,
         analysis: &'analysis Analysis,
         ast_to_hir: AstToHir,
     ) -> TransformVisitor<'analysis, 'tcx> {
         let lifetime_plans = super::lifetimes::LifetimePlans::new(rust_program, analysis);
-        let c_exposed_signature_structs =
-            collect_c_exposed_signature_structs(rust_program, &config.c_exposed_fns);
         let mut sig_decs = SigDecisions::new(rust_program, analysis, &lifetime_plans); // TODO: Move outside
         let mut ptr_kinds = collect_diffs(rust_program, analysis, &sig_decs); // TODO: Move outside
         let free_like_wrappers = collect_local_free_wrappers(rust_program.tcx);
@@ -1184,7 +1120,6 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             free_like_wrappers,
             demoted_fields,
             field_cursor_fields,
-            c_exposed_signature_structs,
             impl_self_lifetimes: Vec::new(),
             ast_to_hir,
             bytemuck: Cell::new(false),
@@ -1193,9 +1128,6 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn field_ptr_kind(&self, field: StructFieldSlot) -> Option<PtrKind> {
-        if self.c_exposed_signature_structs.contains(&field.struct_did) {
-            return None;
-        }
         if struct_field_is_exactly_owning(self.analysis, field) {
             self.ownership_field_kind(field)
         } else {
@@ -1300,9 +1232,6 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn struct_has_field_rewrite_candidate(&self, struct_did: LocalDefId) -> bool {
-        if self.c_exposed_signature_structs.contains(&struct_did) {
-            return false;
-        }
         self.analysis
             .borrow_promotion_result
             .mutable_fields
@@ -1327,9 +1256,6 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn ordered_struct_lifetimes(&self, struct_did: LocalDefId) -> Vec<Symbol> {
-        if self.c_exposed_signature_structs.contains(&struct_did) {
-            return vec![];
-        }
         let Some(plan) = self.lifetime_plans.structs.get(&struct_did) else {
             return vec![];
         };
@@ -13358,7 +13284,6 @@ mod tests {
             free_like_wrappers: FxHashSet::default(),
             demoted_fields: FxHashSet::default(),
             field_cursor_fields: analysis.offset_sign_result.field_access_signs.clone(),
-            c_exposed_signature_structs: FxHashSet::default(),
             impl_self_lifetimes: Vec::new(),
             ast_to_hir: AstToHir::default(),
             bytemuck: Cell::new(false),

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -16,6 +16,7 @@ use rustc_hir::{
 };
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::Symbol;
+use smallvec::smallvec;
 use thin_vec::ThinVec;
 use utils::{
     ast::{unwrap_cast_and_paren, unwrap_cast_and_paren_mut, unwrap_paren, unwrap_paren_mut},
@@ -88,6 +89,13 @@ impl LocalRawParamSummary {
 }
 
 impl MutVisitor for TransformVisitor<'_, '_> {
+    fn flat_map_item(&mut self, item: P<Item>) -> smallvec::SmallVec<[P<Item>; 1]> {
+        if self.should_remove_generated_copy_clone_impl(&item) {
+            return smallvec![];
+        }
+        mut_visit::walk_flat_map_item(self, item)
+    }
+
     fn visit_item(&mut self, item: &mut Item) {
         let node_id = item.id;
         let mut fn_output_transform: Option<(LocalDefId, PtrKind)> = None;
@@ -1090,6 +1098,32 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             .structs
             .get(&field.struct_did)
             .and_then(|plan| plan.field_lifetimes.get(&field.field_index).copied())
+    }
+
+    fn should_remove_generated_copy_clone_impl(&self, item: &Item) -> bool {
+        if !utils::ast::is_automatically_derived(&item.attrs) {
+            return false;
+        }
+        let ItemKind::Impl(box impl_item) = &item.kind else {
+            return false;
+        };
+        let Some(of_trait) = &impl_item.of_trait else {
+            return false;
+        };
+        if !of_trait
+            .path
+            .segments
+            .last()
+            .is_some_and(|seg| matches!(seg.ident.name.as_str(), "Copy" | "Clone"))
+        {
+            return false;
+        }
+        let Some(struct_did) = self.local_struct_did_for_ast_ty(&impl_item.self_ty) else {
+            return false;
+        };
+        self.analysis
+            .struct_copy_result
+            .should_remove_generated_impl(struct_did)
     }
 
     fn struct_has_field_promotion_candidate(&self, struct_did: LocalDefId) -> bool {
@@ -2254,6 +2288,13 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         let need_cast = lhs_inner_ty != rhs_inner_ty;
 
         let def_id = hir_ptr.hir_id.owner.def_id;
+        if let PtrCtx::Rhs(PtrKind::OptRef(m)) = ctx
+            && let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
+            && let Some(PtrKind::OptRef(source_m)) = self.promoted_field_kind(field)
+        {
+            *ptr = self.opt_ref_from_opt_ref(e, m, source_m, lhs_inner_ty, rhs_inner_ty, def_id);
+            return PtrKind::OptRef(m);
+        }
 
         if pe.addr_of {
             let addr_source_mut = addr_of_mutability(e).unwrap_or(false);
@@ -2840,6 +2881,10 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     assert!(pe.projs.is_empty());
                     *ptr = self.ref_from_ref(pe.base, m, m1, lhs_inner_ty, rhs_inner_ty, def_id);
                     return PtrKind::Ref(m);
+                }
+                (PtrCtx::Deref(false), PtrKind::OptRef(false)) if !need_cast => {
+                    assert!(pe.projs.is_empty());
+                    return PtrKind::OptRef(false);
                 }
                 (PtrCtx::Rhs(PtrKind::OptRef(m)) | PtrCtx::Deref(m), PtrKind::OptRef(m1)) => {
                     assert!(pe.projs.is_empty());
@@ -10041,6 +10086,7 @@ fn collect_demoted_promoted_fields(
         tcx,
         &promoted_fields,
         &analysis.borrow_promotion_result.mutable_fields,
+        &analysis.struct_copy_result,
         sig_decs,
         ptr_kinds,
     );
@@ -10539,6 +10585,7 @@ fn collect_struct_shape_demoted_fields(
     tcx: TyCtxt<'_>,
     promoted_fields: &FxHashSet<StructFieldSlot>,
     mutable_fields: &FxHashSet<StructFieldSlot>,
+    struct_copy_result: &crate::analyses::struct_copy::StructCopyAnalysisResult,
     sig_decs: &SigDecisions,
     ptr_kinds: &FxHashMap<HirId, PtrKind>,
 ) -> FxHashSet<StructFieldSlot> {
@@ -10546,7 +10593,8 @@ fn collect_struct_shape_demoted_fields(
 
     for &field in promoted_fields {
         if !struct_has_named_fields(tcx, field.struct_did)
-            || (mutable_fields.contains(&field) && struct_has_copy_impl(tcx, field.struct_did))
+            || (mutable_fields.contains(&field)
+                && struct_copy_result.must_preserve_copy(field.struct_did))
         {
             demoted.insert(field);
         }
@@ -10603,6 +10651,7 @@ fn emit_promotion_diagnostics(
         tcx,
         &promoted_fields,
         &analysis.borrow_promotion_result.mutable_fields,
+        &analysis.struct_copy_result,
         sig_decs,
         ptr_kinds,
     );
@@ -10829,35 +10878,6 @@ fn struct_has_named_fields(tcx: TyCtxt<'_>, did: LocalDefId) -> bool {
         return false;
     };
     matches!(variant_data, hir::VariantData::Struct { .. })
-}
-
-fn struct_has_copy_impl(tcx: TyCtxt<'_>, struct_did: LocalDefId) -> bool {
-    tcx.hir_crate(()).owners.iter().any(|owner| {
-        let Some(owner) = owner.as_owner() else {
-            return false;
-        };
-        let hir::OwnerNode::Item(item) = owner.node() else {
-            return false;
-        };
-        let hir::ItemKind::Impl(impl_) = item.kind else {
-            return false;
-        };
-        let Some(of_trait) = impl_.of_trait else {
-            return false;
-        };
-        if !of_trait
-            .path
-            .segments
-            .last()
-            .is_some_and(|seg| seg.ident.name.as_str() == "Copy")
-        {
-            return false;
-        }
-        let hir::TyKind::Path(qpath) = impl_.self_ty.kind else {
-            return false;
-        };
-        hir_local_struct_did_from_qpath(&qpath) == Some(struct_did)
-    })
 }
 
 fn collect_promoted_fields_in_by_value_ty(
@@ -11415,6 +11435,8 @@ mod tests {
         let borrow_promotion_result =
             analyses::borrow::mutable_references_no_guarantee(&input, &mutables);
         let borrow_lifetime_flows = borrow_promotion_result.lifetime_flows.clone();
+        let struct_copy_result =
+            analyses::struct_copy::analyze(&input, &borrow_promotion_result.mutable_fields);
         let promoted_mut_ref_result = source_var_groups
             .postprocess_promoted_mut_refs(borrow_promotion_result.mutable_locals.clone());
         let promoted_shared_ref_result = source_var_groups
@@ -11438,6 +11460,7 @@ mod tests {
             ownership_schemes,
             offset_sign_result,
             nullity_result,
+            struct_copy_result,
         };
 
         (input, analysis)

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -15,7 +15,7 @@ use rustc_hir::{
     intravisit::{self, Visitor},
 };
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_span::Symbol;
+use rustc_span::{Symbol, sym};
 use smallvec::smallvec;
 use thin_vec::ThinVec;
 use utils::{
@@ -24,7 +24,7 @@ use utils::{
 };
 
 use super::{
-    Analysis,
+    Analysis, Config,
     collector::collect_diffs,
     decision::{PtrKind, SigDecision, SigDecisions},
 };
@@ -45,6 +45,7 @@ pub(crate) struct TransformVisitor<'a, 'tcx> {
     free_like_wrappers: FxHashSet<LocalDefId>,
     demoted_fields: FxHashSet<StructFieldSlot>,
     field_cursor_fields: FxHashSet<StructFieldSlot>,
+    c_exposed_abi_fields: FxHashSet<StructFieldSlot>,
     impl_self_lifetimes: Vec<(LocalDefId, Vec<Symbol>)>,
     ast_to_hir: AstToHir,
     pub bytemuck: Cell<bool>,
@@ -947,6 +948,101 @@ enum PtrCtx {
     Deref(bool),
 }
 
+fn is_c_exposed_fn(tcx: TyCtxt<'_>, did: LocalDefId, c_exposed_fns: &FxHashSet<String>) -> bool {
+    let name = tcx.item_name(did.to_def_id());
+    c_exposed_fns.contains(name.as_str())
+        || tcx
+            .get_attrs(did.to_def_id(), sym::export_name)
+            .any(|attr| {
+                attr.value_str()
+                    .is_some_and(|s| c_exposed_fns.contains(s.as_str()))
+            })
+}
+
+fn is_local_c_abi_struct(tcx: TyCtxt<'_>, did: LocalDefId) -> bool {
+    let adt_def = tcx.adt_def(did);
+    let repr = adt_def.repr();
+    adt_def.is_struct() && !adt_def.is_union() && repr.c() && repr.pack.is_none()
+}
+
+fn collect_local_abi_struct_fields_from_ty(
+    tcx: TyCtxt<'_>,
+    ty: ty::Ty<'_>,
+    fields: &mut FxHashSet<StructFieldSlot>,
+) {
+    match ty.kind() {
+        ty::TyKind::RawPtr(pointee, _) | ty::TyKind::Ref(_, pointee, _) => {
+            collect_local_abi_struct_fields_from_ty(tcx, *pointee, fields);
+        }
+        ty::TyKind::Array(elem, _) | ty::TyKind::Slice(elem) => {
+            collect_local_abi_struct_fields_from_ty(tcx, *elem, fields);
+        }
+        ty::TyKind::Tuple(elems) => {
+            for elem in elems.iter() {
+                collect_local_abi_struct_fields_from_ty(tcx, elem, fields);
+            }
+        }
+        ty::TyKind::Adt(adt_def, args) => {
+            if let Some(struct_did) = adt_def.did().as_local()
+                && is_local_c_abi_struct(tcx, struct_did)
+            {
+                fields.extend(adt_def.non_enum_variant().fields.iter_enumerated().map(
+                    |(field_index, _)| StructFieldSlot {
+                        struct_did,
+                        field_index: field_index.index(),
+                    },
+                ));
+                return;
+            }
+            for arg in args.iter() {
+                if let ty::GenericArgKind::Type(arg_ty) = arg.kind() {
+                    collect_local_abi_struct_fields_from_ty(tcx, arg_ty, fields);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_c_exposed_abi_fields<'tcx>(
+    rust_program: &RustProgram<'tcx>,
+    c_exposed_fns: &FxHashSet<String>,
+    sig_decs: &SigDecisions,
+) -> FxHashSet<StructFieldSlot> {
+    let tcx = rust_program.tcx;
+    let mut fields = FxHashSet::default();
+
+    for did in &rust_program.functions {
+        if !is_c_exposed_fn(tcx, *did, c_exposed_fns) {
+            continue;
+        }
+        let Some(sig_dec) = sig_decs.data.get(did) else {
+            continue;
+        };
+        let sig = tcx.fn_sig(*did).skip_binder().skip_binder();
+        let direct_interface_fix = sig_dec
+            .input_decs
+            .iter()
+            .any(|dec| matches!(dec, Some(PtrKind::Slice(_) | PtrKind::SliceCursor(_))));
+
+        for (ty, dec) in sig.inputs().iter().copied().zip(&sig_dec.input_decs) {
+            if matches!(dec, Some(PtrKind::Slice(_) | PtrKind::SliceCursor(_))) {
+                if let Some((inner_ty, _)) = unwrap_ptr_from_mir_ty(ty) {
+                    collect_local_abi_struct_fields_from_ty(tcx, inner_ty, &mut fields);
+                }
+            } else if !direct_interface_fix {
+                collect_local_abi_struct_fields_from_ty(tcx, ty, &mut fields);
+            }
+        }
+
+        if !direct_interface_fix {
+            collect_local_abi_struct_fields_from_ty(tcx, sig.output(), &mut fields);
+        }
+    }
+
+    fields
+}
+
 #[derive(Clone, Copy, Debug)]
 enum AllocatorRoot<'a> {
     Malloc {
@@ -960,6 +1056,7 @@ enum AllocatorRoot<'a> {
 
 impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     pub fn new(
+        config: &Config,
         rust_program: &RustProgram<'tcx>,
         analysis: &'analysis Analysis,
         ast_to_hir: AstToHir,
@@ -1059,6 +1156,8 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         }
 
         let alloc_wrappers = collect_local_allocator_wrappers(rust_program.tcx);
+        let c_exposed_abi_fields =
+            collect_c_exposed_abi_fields(rust_program, &config.c_exposed_fns, &sig_decs);
         let demoted_fields =
             collect_demoted_promoted_fields(rust_program.tcx, analysis, &sig_decs, &ptr_kinds);
         emit_promotion_diagnostics(
@@ -1120,6 +1219,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             free_like_wrappers,
             demoted_fields,
             field_cursor_fields,
+            c_exposed_abi_fields,
             impl_self_lifetimes: Vec::new(),
             ast_to_hir,
             bytemuck: Cell::new(false),
@@ -1128,6 +1228,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn field_ptr_kind(&self, field: StructFieldSlot) -> Option<PtrKind> {
+        if self.c_exposed_abi_fields.contains(&field) {
+            return None;
+        }
         if struct_field_is_exactly_owning(self.analysis, field) {
             self.ownership_field_kind(field)
         } else {
@@ -1232,13 +1335,18 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn struct_has_field_rewrite_candidate(&self, struct_did: LocalDefId) -> bool {
-        self.analysis
-            .borrow_promotion_result
-            .mutable_fields
-            .iter()
-            .chain(self.analysis.borrow_promotion_result.shared_fields.iter())
-            .any(|field| field.struct_did == struct_did)
-            || self.struct_has_owning_box_field_candidate(struct_did)
+        self.tcx
+            .adt_def(struct_did)
+            .non_enum_variant()
+            .fields
+            .iter_enumerated()
+            .any(|(field_index, _)| {
+                self.field_ptr_kind(StructFieldSlot {
+                    struct_did,
+                    field_index: field_index.index(),
+                })
+                .is_some()
+            })
     }
 
     fn struct_has_owning_box_field_candidate(&self, struct_did: LocalDefId) -> bool {
@@ -1248,7 +1356,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             .fields
             .iter_enumerated()
             .any(|(field_index, _)| {
-                self.ownership_field_kind(StructFieldSlot {
+                self.field_ptr_kind(StructFieldSlot {
                     struct_did,
                     field_index: field_index.index(),
                 }) == Some(PtrKind::OptBox)
@@ -1264,11 +1372,18 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         field_lifetimes
             .into_iter()
             .filter(|(field_index, _)| {
-                self.promoted_field_kind(StructFieldSlot {
-                    struct_did,
-                    field_index: **field_index,
-                })
-                .is_some()
+                matches!(
+                    self.field_ptr_kind(StructFieldSlot {
+                        struct_did,
+                        field_index: **field_index,
+                    }),
+                    Some(
+                        PtrKind::Ref(_)
+                            | PtrKind::OptRef(_)
+                            | PtrKind::Slice(_)
+                            | PtrKind::SliceCursor(_)
+                    )
+                )
             })
             .map(|(_, lifetime)| *lifetime)
             .collect()
@@ -13284,6 +13399,7 @@ mod tests {
             free_like_wrappers: FxHashSet::default(),
             demoted_fields: FxHashSet::default(),
             field_cursor_fields: analysis.offset_sign_result.field_access_signs.clone(),
+            c_exposed_abi_fields: FxHashSet::default(),
             impl_self_lifetimes: Vec::new(),
             ast_to_hir: AstToHir::default(),
             bytemuck: Cell::new(false),

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -1408,9 +1408,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn local_struct_did_for_ast_ty(&self, ty: &Ty) -> Option<LocalDefId> {
-        let Some(hir_ty) = self.ast_to_hir.get_ty(ty.id, self.tcx) else {
-            return None;
-        };
+        let hir_ty = self.ast_to_hir.get_ty(ty.id, self.tcx)?;
         let hir::TyKind::Path(hir_qpath) = hir_ty.kind else {
             return None;
         };
@@ -1490,7 +1488,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             return None;
         };
         let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
-        let struct_did = self.local_struct_did_from_ty(typeck.expr_ty_adjusted(base))?;
+        let struct_did = hir_local_struct_did_from_ty(typeck.expr_ty_adjusted(base))?;
         let field_index = self.field_index_by_name(struct_did, ident.name)?;
         let field = StructFieldSlot {
             struct_did,
@@ -1548,16 +1546,6 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             return None;
         };
         def_id.as_local()
-    }
-
-    fn local_struct_did_from_ty(&self, ty: ty::Ty<'tcx>) -> Option<LocalDefId> {
-        match ty.kind() {
-            ty::TyKind::Adt(adt_def, _) if adt_def.did().is_local() && adt_def.is_struct() => {
-                Some(adt_def.did().expect_local())
-            }
-            ty::TyKind::Ref(_, inner, _) => self.local_struct_did_from_ty(*inner),
-            _ => None,
-        }
     }
 
     fn field_index_by_name(&self, struct_did: LocalDefId, field_name: Symbol) -> Option<usize> {
@@ -6000,20 +5988,18 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                                 pprust::expr_to_string(&e),
                                 pprust::expr_to_string(offset),
                             );
+                        } else if is_slice_cursor_mut_constructor_call(&e) {
+                            e = utils::expr!(
+                                "{{ let mut _c = ({}).as_deref(); _c.seek(({}) as isize); _c }}",
+                                pprust::expr_to_string(&e),
+                                pprust::expr_to_string(offset),
+                            );
                         } else {
-                            if is_slice_cursor_mut_constructor_call(&e) {
-                                e = utils::expr!(
-                                    "{{ let mut _c = ({}).as_deref(); _c.seek(({}) as isize); _c }}",
-                                    pprust::expr_to_string(&e),
-                                    pprust::expr_to_string(offset),
-                                );
-                            } else {
-                                e = utils::expr!(
-                                    "{{ let mut _c = crate::slice_cursor::SliceCursor::new(({}).as_slice()); _c.seek(({}) as isize); _c }}",
-                                    pprust::expr_to_string(&e),
-                                    pprust::expr_to_string(offset),
-                                );
-                            }
+                            e = utils::expr!(
+                                "{{ let mut _c = crate::slice_cursor::SliceCursor::new(({}).as_slice()); _c.seek(({}) as isize); _c }}",
+                                pprust::expr_to_string(&e),
+                                pprust::expr_to_string(offset),
+                            );
                         }
                     } else {
                         e = utils::expr!(
@@ -11364,12 +11350,6 @@ fn collect_field_conflict_demotion_reasons(
             for arg in args.iter() {
                 self.record_moved_mutable_fields_from_raw_pointee_arg(arg);
             }
-            if let Some(callee_did) = hir_called_local_fn(self.tcx, expr)
-                && let Some(sig_dec) = self.sig_decs.data.get(&callee_did)
-            {
-                let _ = sig_dec;
-                return;
-            }
         }
 
         fn record_raw_field_pointer_projection(&mut self, expr: &'tcx hir::Expr<'tcx>) {
@@ -12224,8 +12204,8 @@ fn collect_ownership_field_diagnostics<'tcx>(
 
     let block_reasons =
         collect_ownership_field_rhs_block_reasons(tcx, sig_decs, ptr_kinds, &scalar_fields);
-    for field in scalar_fields.keys().copied() {
-        if let Some(reasons) = block_reasons.get(&field) {
+    for field in scalar_fields.keys() {
+        if let Some(reasons) = block_reasons.get(field) {
             if reasons.is_empty() {
                 diagnostics.selected_opt_box += 1;
             } else {
@@ -12312,7 +12292,7 @@ fn collect_struct_shape_demoted_fields(
         {
             continue;
         }
-        collect_promoted_fields_in_by_value_ty(tcx, sig.output(), promoted_fields, &mut demoted);
+        collect_promoted_fields_in_by_value_ty(sig.output(), promoted_fields, &mut demoted);
     }
 
     demoted
@@ -12613,14 +12593,13 @@ fn struct_has_named_fields(tcx: TyCtxt<'_>, did: LocalDefId) -> bool {
 }
 
 fn collect_promoted_fields_in_by_value_ty(
-    tcx: TyCtxt<'_>,
     ty: ty::Ty<'_>,
     promoted_fields: &FxHashSet<StructFieldSlot>,
     demoted: &mut FxHashSet<StructFieldSlot>,
 ) {
     match ty.kind() {
         ty::TyKind::RawPtr(inner, _) | ty::TyKind::Ref(_, inner, _) => {
-            collect_promoted_fields_in_by_value_ty(tcx, *inner, promoted_fields, demoted);
+            collect_promoted_fields_in_by_value_ty(*inner, promoted_fields, demoted);
         }
         ty::TyKind::Adt(adt_def, args) => {
             if adt_def.did().is_local() && adt_def.is_struct() && !adt_def.is_union() {
@@ -12634,17 +12613,17 @@ fn collect_promoted_fields_in_by_value_ty(
             }
             for arg in args.iter() {
                 if let ty::GenericArgKind::Type(ty) = arg.kind() {
-                    collect_promoted_fields_in_by_value_ty(tcx, ty, promoted_fields, demoted);
+                    collect_promoted_fields_in_by_value_ty(ty, promoted_fields, demoted);
                 }
             }
         }
         ty::TyKind::Tuple(tys) => {
             for ty in tys.iter() {
-                collect_promoted_fields_in_by_value_ty(tcx, ty, promoted_fields, demoted);
+                collect_promoted_fields_in_by_value_ty(ty, promoted_fields, demoted);
             }
         }
         ty::TyKind::Array(ty, _) | ty::TyKind::Slice(ty) => {
-            collect_promoted_fields_in_by_value_ty(tcx, *ty, promoted_fields, demoted);
+            collect_promoted_fields_in_by_value_ty(*ty, promoted_fields, demoted);
         }
         _ => {}
     }

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -5559,14 +5559,17 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         };
         if !need_cast {
             e.clone()
-        } else if lhs_inner_ty.is_numeric() && rhs_inner_ty.is_numeric() {
+        } else if !m
+            && lhs_inner_ty.is_numeric()
+            && rhs_inner_ty.is_numeric()
+            && !utils::ast::has_side_effects(e)
+        {
+            self.bytemuck.set(true);
             utils::expr!(
-                "{}::from_raw_parts{}(({}).as_ptr() as *{} {}, 1_000_000)",
+                "{}::new(bytemuck::cast_slice::<_, {}>(({}).as_slice()))",
                 cursor_ty,
-                if m { "_mut" } else { "" },
-                pprust::expr_to_string(e),
-                if m { "mut" } else { "const" },
                 mir_ty_to_string(lhs_inner_ty, self.tcx),
+                pprust::expr_to_string(e),
             )
         } else {
             utils::expr!(

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -24,7 +24,7 @@ use utils::{
 };
 
 use super::{
-    Analysis,
+    Analysis, Config,
     collector::collect_diffs,
     decision::{PtrKind, SigDecision, SigDecisions},
 };
@@ -45,6 +45,7 @@ pub(crate) struct TransformVisitor<'a, 'tcx> {
     free_like_wrappers: FxHashSet<LocalDefId>,
     demoted_fields: FxHashSet<StructFieldSlot>,
     field_cursor_fields: FxHashSet<StructFieldSlot>,
+    c_exposed_signature_structs: FxHashSet<LocalDefId>,
     impl_self_lifetimes: Vec<(LocalDefId, Vec<Symbol>)>,
     ast_to_hir: AstToHir,
     pub bytemuck: Cell<bool>,
@@ -947,6 +948,66 @@ enum PtrCtx {
     Deref(bool),
 }
 
+fn collect_c_exposed_signature_structs<'tcx>(
+    rust_program: &RustProgram<'tcx>,
+    c_exposed_fns: &FxHashSet<String>,
+) -> FxHashSet<LocalDefId> {
+    let mut structs = FxHashSet::default();
+    for did in &rust_program.functions {
+        let name = rust_program.tcx.item_name(did.to_def_id());
+        if !c_exposed_fns.contains(name.as_str()) {
+            continue;
+        }
+        let sig = rust_program.tcx.fn_sig(*did).skip_binder().skip_binder();
+        for ty in sig
+            .inputs()
+            .iter()
+            .copied()
+            .chain(std::iter::once(sig.output()))
+        {
+            collect_local_structs_from_ty(rust_program.tcx, ty, &mut structs);
+        }
+    }
+    structs
+}
+
+fn collect_local_structs_from_ty<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: ty::Ty<'tcx>,
+    structs: &mut FxHashSet<LocalDefId>,
+) {
+    match ty.kind() {
+        ty::TyKind::RawPtr(pointee, _) => {
+            collect_local_structs_from_ty(tcx, *pointee, structs);
+        }
+        ty::TyKind::Ref(_, pointee, _) => {
+            collect_local_structs_from_ty(tcx, *pointee, structs);
+        }
+        ty::TyKind::Array(elem, _) | ty::TyKind::Slice(elem) => {
+            collect_local_structs_from_ty(tcx, *elem, structs);
+        }
+        ty::TyKind::Tuple(elems) => {
+            for elem in elems.iter() {
+                collect_local_structs_from_ty(tcx, elem, structs);
+            }
+        }
+        ty::TyKind::Adt(adt_def, args) => {
+            if adt_def.is_struct()
+                && !adt_def.is_union()
+                && let Some(local_did) = adt_def.did().as_local()
+            {
+                structs.insert(local_did);
+            }
+            for arg in args.iter() {
+                if let ty::GenericArgKind::Type(arg_ty) = arg.kind() {
+                    collect_local_structs_from_ty(tcx, arg_ty, structs);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 enum AllocatorRoot<'a> {
     Malloc {
@@ -960,11 +1021,14 @@ enum AllocatorRoot<'a> {
 
 impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     pub fn new(
+        config: &Config,
         rust_program: &RustProgram<'tcx>,
         analysis: &'analysis Analysis,
         ast_to_hir: AstToHir,
     ) -> TransformVisitor<'analysis, 'tcx> {
         let lifetime_plans = super::lifetimes::LifetimePlans::new(rust_program, analysis);
+        let c_exposed_signature_structs =
+            collect_c_exposed_signature_structs(rust_program, &config.c_exposed_fns);
         let mut sig_decs = SigDecisions::new(rust_program, analysis, &lifetime_plans); // TODO: Move outside
         let mut ptr_kinds = collect_diffs(rust_program, analysis, &sig_decs); // TODO: Move outside
         let free_like_wrappers = collect_local_free_wrappers(rust_program.tcx);
@@ -1120,6 +1184,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             free_like_wrappers,
             demoted_fields,
             field_cursor_fields,
+            c_exposed_signature_structs,
             impl_self_lifetimes: Vec::new(),
             ast_to_hir,
             bytemuck: Cell::new(false),
@@ -1128,6 +1193,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn field_ptr_kind(&self, field: StructFieldSlot) -> Option<PtrKind> {
+        if self.c_exposed_signature_structs.contains(&field.struct_did) {
+            return None;
+        }
         if struct_field_is_exactly_owning(self.analysis, field) {
             self.ownership_field_kind(field)
         } else {
@@ -1232,6 +1300,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn struct_has_field_rewrite_candidate(&self, struct_did: LocalDefId) -> bool {
+        if self.c_exposed_signature_structs.contains(&struct_did) {
+            return false;
+        }
         self.analysis
             .borrow_promotion_result
             .mutable_fields
@@ -1256,6 +1327,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn ordered_struct_lifetimes(&self, struct_did: LocalDefId) -> Vec<Symbol> {
+        if self.c_exposed_signature_structs.contains(&struct_did) {
+            return vec![];
+        }
         let Some(plan) = self.lifetime_plans.structs.get(&struct_did) else {
             return vec![];
         };
@@ -13284,6 +13358,7 @@ mod tests {
             free_like_wrappers: FxHashSet::default(),
             demoted_fields: FxHashSet::default(),
             field_cursor_fields: analysis.offset_sign_result.field_access_signs.clone(),
+            c_exposed_signature_structs: FxHashSet::default(),
             impl_self_lifetimes: Vec::new(),
             ast_to_hir: AstToHir::default(),
             bytemuck: Cell::new(false),

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -41,6 +41,7 @@ pub(crate) struct TransformVisitor<'a, 'tcx> {
     ptr_kinds: FxHashMap<HirId, PtrKind>,
     forced_raw_bindings: FxHashSet<HirId>,
     raw_bridge_bindings: FxHashMap<HirId, RawBridgeInfo>,
+    raw_scalar_bridge_fields: FxHashSet<StructFieldSlot>,
     alloc_wrappers: FxHashMap<LocalDefId, AllocWrapperInfo>,
     free_like_wrappers: FxHashSet<LocalDefId>,
     demoted_fields: FxHashSet<StructFieldSlot>,
@@ -1156,6 +1157,8 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         }
 
         let alloc_wrappers = collect_local_allocator_wrappers(rust_program.tcx);
+        let raw_scalar_bridge_fields =
+            collect_raw_scalar_bridge_fields(rust_program.tcx, &alloc_wrappers);
         let c_exposed_abi_fields =
             collect_c_exposed_abi_fields(rust_program, &config.c_exposed_fns, &sig_decs);
         let demoted_fields =
@@ -1215,6 +1218,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             ptr_kinds,
             forced_raw_bindings,
             raw_bridge_bindings,
+            raw_scalar_bridge_fields,
             alloc_wrappers,
             free_like_wrappers,
             demoted_fields,
@@ -2036,7 +2040,10 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         if !ty_supports_scalar_box_from_raw_bridge(lhs_inner_ty) {
             return false;
         }
-        if hir_struct_field_slot(self.tcx, hir_lhs).is_none() {
+        let Some(field) = hir_struct_field_slot(self.tcx, hir_lhs) else {
+            return false;
+        };
+        if !self.raw_scalar_bridge_fields.contains(&field) {
             return false;
         }
         let Some(info) = hir_raw_bridge_info(
@@ -2200,6 +2207,11 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         let [hir_arg] = hir_args else { return None };
         let [arg] = args else { return None };
         let hir_arg = hir_unwrap_casts(hir_arg);
+        if let Some(field) = hir_struct_field_slot(self.tcx, hir_arg)
+            && !self.raw_scalar_bridge_fields.contains(&field)
+        {
+            return None;
+        }
         let arg_ty = self
             .tcx
             .typeck(hir_expr.hir_id.owner)
@@ -10159,6 +10171,125 @@ fn collect_local_raw_param_summaries(
     summaries
 }
 
+fn collect_raw_scalar_bridge_fields(
+    tcx: TyCtxt<'_>,
+    alloc_wrappers: &FxHashMap<LocalDefId, AllocWrapperInfo>,
+) -> FxHashSet<StructFieldSlot> {
+    #[derive(Default)]
+    struct State {
+        saw_scalar: bool,
+        disqualified: bool,
+    }
+
+    struct RawScalarFieldBridgeVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        typeck: &'a rustc_middle::ty::TypeckResults<'tcx>,
+        alloc_wrappers: &'a FxHashMap<LocalDefId, AllocWrapperInfo>,
+        states: &'a mut FxHashMap<StructFieldSlot, State>,
+        local_bridges: FxHashMap<HirId, RawBridgeInfo>,
+    }
+
+    impl<'tcx> RawScalarFieldBridgeVisitor<'_, 'tcx> {
+        fn raw_bridge_info_for_rhs(
+            &self,
+            lhs_inner_ty: ty::Ty<'tcx>,
+            rhs: &'tcx hir::Expr<'tcx>,
+        ) -> Option<RawBridgeInfo> {
+            if !ty_supports_scalar_box_from_raw_bridge(lhs_inner_ty) {
+                return None;
+            }
+            if hir_is_null_like_ptr_arg(self.tcx, rhs) {
+                return None;
+            }
+
+            hir_raw_bridge_info(self.tcx, lhs_inner_ty, rhs, Some(self.alloc_wrappers), None)
+        }
+
+        fn record_local_assignment(&mut self, lhs_hir_id: HirId, rhs: &'tcx hir::Expr<'tcx>) {
+            let lhs_ty = self.typeck.node_type(lhs_hir_id);
+            let Some((lhs_inner_ty, _)) = unwrap_ptr_from_mir_ty(lhs_ty) else {
+                self.local_bridges.remove(&lhs_hir_id);
+                return;
+            };
+            if let Some(info) = self.raw_bridge_info_for_rhs(lhs_inner_ty, rhs) {
+                self.local_bridges.insert(lhs_hir_id, info);
+            } else if !hir_is_null_like_ptr_arg(self.tcx, rhs) {
+                self.local_bridges.remove(&lhs_hir_id);
+            }
+        }
+
+        fn record_field_assignment(
+            &mut self,
+            lhs: &'tcx hir::Expr<'tcx>,
+            rhs: &'tcx hir::Expr<'tcx>,
+        ) {
+            let Some(field) = hir_struct_field_slot(self.tcx, lhs) else {
+                return;
+            };
+            let lhs_ty = self.typeck.expr_ty_adjusted(lhs);
+            let Some((lhs_inner_ty, _)) = unwrap_ptr_from_mir_ty(lhs_ty) else {
+                return;
+            };
+            if !ty_supports_scalar_box_from_raw_bridge(lhs_inner_ty) {
+                return;
+            }
+            if hir_is_null_like_ptr_arg(self.tcx, rhs) {
+                return;
+            }
+
+            let info = self.raw_bridge_info_for_rhs(lhs_inner_ty, rhs).or_else(|| {
+                hir_unwrapped_local_id(rhs)
+                    .and_then(|hir_id| self.local_bridges.get(&hir_id).cloned())
+            });
+            let state = self.states.entry(field).or_default();
+            match info {
+                Some(RawBridgeInfo::Scalar) => state.saw_scalar = true,
+                Some(RawBridgeInfo::Array { .. }) | None => state.disqualified = true,
+            }
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for RawScalarFieldBridgeVisitor<'_, 'tcx> {
+        fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) -> Self::Result {
+            if let hir::StmtKind::Let(let_stmt) = stmt.kind
+                && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
+                && let Some(init) = let_stmt.init
+            {
+                self.record_local_assignment(hir_id, init);
+            }
+            intravisit::walk_stmt(self, stmt);
+        }
+
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            if let hir::ExprKind::Assign(lhs, rhs, _) = expr.kind {
+                if let Some(lhs_hir_id) = hir_unwrapped_local_id(lhs) {
+                    self.record_local_assignment(lhs_hir_id, rhs);
+                } else {
+                    self.record_field_assignment(lhs, rhs);
+                }
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut states = FxHashMap::default();
+    for_each_hir_fn_body(tcx, |body, typeck| {
+        let mut visitor = RawScalarFieldBridgeVisitor {
+            tcx,
+            typeck,
+            alloc_wrappers,
+            states: &mut states,
+            local_bridges: FxHashMap::default(),
+        };
+        visitor.visit_body(body);
+    });
+
+    states
+        .into_iter()
+        .filter_map(|(field, state)| (state.saw_scalar && !state.disqualified).then_some(field))
+        .collect()
+}
+
 fn collect_raw_bridge_bindings(
     tcx: TyCtxt<'_>,
     ptr_kinds: &FxHashMap<HirId, PtrKind>,
@@ -13395,6 +13526,7 @@ mod tests {
             ptr_kinds: FxHashMap::default(),
             forced_raw_bindings: FxHashSet::default(),
             raw_bridge_bindings: FxHashMap::default(),
+            raw_scalar_bridge_fields: FxHashSet::default(),
             alloc_wrappers: FxHashMap::default(),
             free_like_wrappers: FxHashSet::default(),
             demoted_fields: FxHashSet::default(),

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -16,6 +16,7 @@ use rustc_hir::{
 };
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::Symbol;
+use thin_vec::ThinVec;
 use utils::{
     ast::{unwrap_cast_and_paren, unwrap_cast_and_paren_mut, unwrap_paren, unwrap_paren_mut},
     ir::{AstToHir, is_option, mir_ty_to_string},
@@ -26,16 +27,23 @@ use super::{
     collector::collect_diffs,
     decision::{PtrKind, SigDecision, SigDecisions},
 };
-use crate::utils::rustc::RustProgram;
+use crate::{analyses::borrow::StructFieldSlot, utils::rustc::RustProgram};
 
-pub(crate) struct TransformVisitor<'tcx> {
+pub(crate) struct TransformVisitor<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
+    analysis: &'a Analysis,
     sig_decs: SigDecisions,
+    // Function signatures should use the normalized decisions above; plans are retained for
+    // later struct field lifetime emission.
+    #[allow(dead_code)]
+    lifetime_plans: super::lifetimes::LifetimePlans,
     ptr_kinds: FxHashMap<HirId, PtrKind>,
     forced_raw_bindings: FxHashSet<HirId>,
     raw_bridge_bindings: FxHashMap<HirId, RawBridgeInfo>,
     alloc_wrappers: FxHashMap<LocalDefId, AllocWrapperInfo>,
     free_like_wrappers: FxHashSet<LocalDefId>,
+    demoted_fields: FxHashSet<StructFieldSlot>,
+    impl_self_lifetimes: Vec<(LocalDefId, Vec<Symbol>)>,
     ast_to_hir: AstToHir,
     pub bytemuck: Cell<bool>,
     pub slice_cursor: Cell<bool>,
@@ -79,12 +87,36 @@ impl LocalRawParamSummary {
     }
 }
 
-impl MutVisitor for TransformVisitor<'_> {
+impl MutVisitor for TransformVisitor<'_, '_> {
     fn visit_item(&mut self, item: &mut Item) {
         let node_id = item.id;
         let mut fn_output_transform: Option<(LocalDefId, PtrKind)> = None;
         match &mut item.kind {
-            ItemKind::Impl(_) => return,
+            ItemKind::Impl(box impl_item) => {
+                let Some(struct_did) = self.local_struct_did_for_ast_ty(&impl_item.self_ty) else {
+                    return;
+                };
+                if !self.struct_has_field_promotion_candidate(struct_did) {
+                    return;
+                }
+                let lifetimes = self.ordered_struct_lifetimes(struct_did);
+                if !lifetimes.is_empty() {
+                    super::lifetimes::ensure_lifetime_params(&mut impl_item.generics, &lifetimes);
+                    self.add_struct_lifetime_args_to_ty_with_lifetimes(
+                        &mut impl_item.self_ty,
+                        &lifetimes,
+                    );
+                }
+                self.impl_self_lifetimes.push((struct_did, lifetimes));
+                mut_visit::walk_item(self, item);
+                self.impl_self_lifetimes.pop();
+                return;
+            }
+            ItemKind::Struct(_, generics, VariantData::Struct { fields, .. }) => {
+                if let Some(struct_did) = self.ast_to_hir.global_map.get(&node_id).copied() {
+                    self.rewrite_struct_definition(struct_did, generics, fields);
+                }
+            }
             ItemKind::Fn(box fn_item) => {
                 let def_id = self.ast_to_hir.global_map[&node_id];
                 let mir_body = self
@@ -93,13 +125,57 @@ impl MutVisitor for TransformVisitor<'_> {
                     .borrow();
                 let sig_dec = self.sig_decs.data.get(&def_id).unwrap();
 
-                for ((local_decl, input_dec), param) in mir_body
+                if !sig_dec.signature_locked {
+                    let mut planned_lifetimes = Vec::new();
+                    for lifetime in sig_dec
+                        .input_lifetimes
+                        .iter()
+                        .copied()
+                        .flatten()
+                        .chain(sig_dec.output_lifetime)
+                    {
+                        if !planned_lifetimes.contains(&lifetime) {
+                            planned_lifetimes.push(lifetime);
+                        }
+                    }
+                    for (local_decl, input_dec) in
+                        mir_body.local_decls.iter().skip(1).zip(&sig_dec.input_decs)
+                    {
+                        if input_dec.is_some()
+                            && let Some((inner_ty, _)) = unwrap_ptr_from_mir_ty(local_decl.ty)
+                        {
+                            self.extend_lifetimes_for_ty(&mut planned_lifetimes, inner_ty);
+                        }
+                    }
+                    if sig_dec.output_dec.is_some() {
+                        let return_decl =
+                            &mir_body.local_decls[rustc_middle::mir::Local::from_u32(0)];
+                        if let Some((inner_ty, _)) = unwrap_ptr_from_mir_ty(return_decl.ty) {
+                            self.extend_lifetimes_for_ty(&mut planned_lifetimes, inner_ty);
+                        }
+                    }
+                    super::lifetimes::ensure_lifetime_params(
+                        &mut fn_item.generics,
+                        &planned_lifetimes,
+                    );
+                }
+
+                for (param_index, ((local_decl, input_dec), param)) in mir_body
                     .local_decls
                     .iter()
                     .skip(1)
                     .zip(&sig_dec.input_decs)
                     .zip(&mut fn_item.sig.decl.inputs)
+                    .enumerate()
                 {
+                    self.mark_param_mut_if_needed(param);
+                    let input_lifetime =
+                        sig_dec.input_lifetimes.get(param_index).copied().flatten();
+                    if matches!(local_decl.ty.kind(), ty::TyKind::Ref(..))
+                        && input_lifetime.is_none()
+                    {
+                        continue;
+                    }
                     match input_dec {
                         Some(PtrKind::Ref(m)) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -109,7 +185,7 @@ impl MutVisitor for TransformVisitor<'_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = mk_ref_ty(inner_ty, *m, self.tcx);
+                            *param.ty = self.mk_ref_ty_with_lifetime(inner_ty, *m, input_lifetime);
                         }
                         Some(PtrKind::OptRef(m)) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -119,7 +195,8 @@ impl MutVisitor for TransformVisitor<'_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = mk_opt_ref_ty(inner_ty, *m, self.tcx);
+                            *param.ty =
+                                self.mk_opt_ref_ty_with_lifetime(inner_ty, *m, input_lifetime);
                         }
                         Some(PtrKind::Box) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -129,7 +206,7 @@ impl MutVisitor for TransformVisitor<'_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = mk_box_ty(inner_ty, self.tcx);
+                            *param.ty = self.mk_box_ty(inner_ty);
                         }
                         Some(PtrKind::OptBox) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -139,7 +216,7 @@ impl MutVisitor for TransformVisitor<'_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = mk_opt_box_ty(inner_ty, self.tcx);
+                            *param.ty = self.mk_opt_box_ty(inner_ty);
                         }
                         Some(PtrKind::Slice(m)) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -149,7 +226,7 @@ impl MutVisitor for TransformVisitor<'_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = mk_slice_ty(inner_ty, *m, self.tcx);
+                            *param.ty = self.mk_slice_ty(inner_ty, *m);
                         }
                         Some(PtrKind::Raw(m)) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -159,7 +236,7 @@ impl MutVisitor for TransformVisitor<'_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = mk_raw_ptr_ty(inner_ty, *m, self.tcx);
+                            *param.ty = self.mk_raw_ptr_ty(inner_ty, *m);
                         }
                         Some(PtrKind::SliceCursor(m)) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -169,7 +246,7 @@ impl MutVisitor for TransformVisitor<'_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = mk_cursor_ty(inner_ty, *m, self.tcx);
+                            *param.ty = self.mk_cursor_ty(inner_ty, *m);
                             self.slice_cursor.set(true);
                         }
                         Some(PtrKind::BoxedSlice) => {
@@ -180,7 +257,7 @@ impl MutVisitor for TransformVisitor<'_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = mk_boxed_slice_ty(inner_ty, self.tcx);
+                            *param.ty = self.mk_boxed_slice_ty(inner_ty);
                         }
                         Some(PtrKind::OptBoxedSlice) => {
                             let (inner_ty, _) = unwrap_ptr_from_mir_ty(local_decl.ty)
@@ -190,12 +267,21 @@ impl MutVisitor for TransformVisitor<'_> {
                                         ty = local_decl.ty
                                     )
                                 });
-                            *param.ty = mk_opt_boxed_slice_ty(inner_ty, self.tcx);
+                            *param.ty = self.mk_opt_boxed_slice_ty(inner_ty);
                         }
                         None => continue,
                     }
 
-                    if input_dec.is_some_and(|kind| kind.is_mut())
+                    let needs_mut_binding = input_dec.is_some_and(|kind| {
+                        matches!(
+                            kind,
+                            PtrKind::OptRef(true)
+                                | PtrKind::OptBox
+                                | PtrKind::OptBoxedSlice
+                                | PtrKind::SliceCursor(true)
+                        ) || (input_lifetime.is_none() && kind.is_mut())
+                    });
+                    if needs_mut_binding
                         && let PatKind::Ident(binding_mode, ..) = &mut param.pat.kind
                     {
                         binding_mode.1 = Mutability::Mut;
@@ -229,17 +315,23 @@ impl MutVisitor for TransformVisitor<'_> {
                         && let FnRetTy::Ty(ret_ty) = &mut fn_item.sig.decl.output
                     {
                         *ret_ty = P(match output_dec {
-                            PtrKind::Ref(m) => mk_ref_ty(inner_ty, m, self.tcx),
-                            PtrKind::OptRef(m) => mk_opt_ref_ty(inner_ty, m, self.tcx),
-                            PtrKind::Box => mk_box_ty(inner_ty, self.tcx),
-                            PtrKind::OptBox => mk_opt_box_ty(inner_ty, self.tcx),
-                            PtrKind::Raw(m) => mk_raw_ptr_ty(inner_ty, m, self.tcx),
-                            PtrKind::BoxedSlice => mk_boxed_slice_ty(inner_ty, self.tcx),
-                            PtrKind::OptBoxedSlice => mk_opt_boxed_slice_ty(inner_ty, self.tcx),
-                            PtrKind::Slice(m) => mk_slice_ty(inner_ty, m, self.tcx),
+                            PtrKind::Ref(m) => {
+                                self.mk_ref_ty_with_lifetime(inner_ty, m, sig_dec.output_lifetime)
+                            }
+                            PtrKind::OptRef(m) => self.mk_opt_ref_ty_with_lifetime(
+                                inner_ty,
+                                m,
+                                sig_dec.output_lifetime,
+                            ),
+                            PtrKind::Box => self.mk_box_ty(inner_ty),
+                            PtrKind::OptBox => self.mk_opt_box_ty(inner_ty),
+                            PtrKind::Raw(m) => self.mk_raw_ptr_ty(inner_ty, m),
+                            PtrKind::BoxedSlice => self.mk_boxed_slice_ty(inner_ty),
+                            PtrKind::OptBoxedSlice => self.mk_opt_boxed_slice_ty(inner_ty),
+                            PtrKind::Slice(m) => self.mk_slice_ty(inner_ty, m),
                             PtrKind::SliceCursor(m) => {
                                 self.slice_cursor.set(true);
-                                mk_cursor_ty(inner_ty, m, self.tcx)
+                                self.mk_cursor_ty(inner_ty, m)
                             }
                         });
                     }
@@ -318,6 +410,14 @@ impl MutVisitor for TransformVisitor<'_> {
 
         if let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx)
             && let hir::PatKind::Binding(_, hir_id, _ident, _) = let_stmt.pat.kind
+            && self.local_binding_needs_mut_for_promoted_field_write(hir_id)
+            && let PatKind::Ident(binding_mode, ..) = &mut local.pat.kind
+        {
+            binding_mode.1 = Mutability::Mut;
+        }
+
+        if let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx)
+            && let hir::PatKind::Binding(_, hir_id, _ident, _) = let_stmt.pat.kind
             && let Some(mut lhs_kind) = self.effective_ptr_kind(hir_id)
         {
             let typeck = self.tcx.typeck(hir_id.owner);
@@ -350,31 +450,31 @@ impl MutVisitor for TransformVisitor<'_> {
 
             match lhs_kind {
                 PtrKind::Ref(m) => {
-                    local.ty = Some(P(mk_ref_ty(lhs_inner_ty, m, self.tcx)));
+                    local.ty = Some(P(self.mk_ref_ty(lhs_inner_ty, m)));
                 }
                 PtrKind::OptRef(m) => {
-                    local.ty = Some(P(mk_opt_ref_ty(lhs_inner_ty, m, self.tcx)));
+                    local.ty = Some(P(self.mk_opt_ref_ty(lhs_inner_ty, m)));
                 }
                 PtrKind::Box => {
-                    local.ty = Some(P(mk_box_ty(lhs_inner_ty, self.tcx)));
+                    local.ty = Some(P(self.mk_box_ty(lhs_inner_ty)));
                 }
                 PtrKind::OptBox => {
-                    local.ty = Some(P(mk_opt_box_ty(lhs_inner_ty, self.tcx)));
+                    local.ty = Some(P(self.mk_opt_box_ty(lhs_inner_ty)));
                 }
                 PtrKind::BoxedSlice => {
-                    local.ty = Some(P(mk_boxed_slice_ty(lhs_inner_ty, self.tcx)));
+                    local.ty = Some(P(self.mk_boxed_slice_ty(lhs_inner_ty)));
                 }
                 PtrKind::OptBoxedSlice => {
-                    local.ty = Some(P(mk_opt_boxed_slice_ty(lhs_inner_ty, self.tcx)));
+                    local.ty = Some(P(self.mk_opt_boxed_slice_ty(lhs_inner_ty)));
                 }
                 PtrKind::Slice(m) => {
-                    local.ty = Some(P(mk_slice_ty(lhs_inner_ty, m, self.tcx)));
+                    local.ty = Some(P(self.mk_slice_ty(lhs_inner_ty, m)));
                 }
                 PtrKind::Raw(m) => {
-                    local.ty = Some(P(mk_raw_ptr_ty(lhs_inner_ty, m, self.tcx)));
+                    local.ty = Some(P(self.mk_raw_ptr_ty(lhs_inner_ty, m)));
                 }
                 PtrKind::SliceCursor(m) => {
-                    local.ty = Some(P(mk_cursor_ty(lhs_inner_ty, m, self.tcx)));
+                    local.ty = Some(P(self.mk_cursor_ty(lhs_inner_ty, m)));
                     self.slice_cursor.set(true);
                 }
             }
@@ -398,12 +498,21 @@ impl MutVisitor for TransformVisitor<'_> {
         mut_visit::walk_expr(self, expr);
 
         match &mut expr.kind {
+            ExprKind::Struct(se) => {
+                self.rewrite_struct_literal_fields(expr.id, se);
+            }
             ExprKind::Assign(lhs, rhs, _) => {
                 let hir_expr = self.ast_to_hir.get_expr(expr.id, self.tcx).unwrap();
                 let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
                 let hir::ExprKind::Assign(hir_lhs, hir_rhs, _) = hir_expr.kind else {
                     panic!("{hir_expr:?}")
                 };
+                if let Some(field) = self.promoted_field_slot_for_hir_field(hir_lhs)
+                    && let Some(kind) = self.promoted_field_kind(field)
+                {
+                    self.transform_rhs(rhs, hir_rhs, kind);
+                    return;
+                }
                 let lhs_ty = typeck.expr_ty(hir_lhs);
                 let (_, m) = some_or!(unwrap_ptr_from_mir_ty(lhs_ty), return);
                 let (lhs_inner_ty, _) = unwrap_ptr_from_mir_ty(lhs_ty).unwrap();
@@ -568,6 +677,15 @@ impl MutVisitor for TransformVisitor<'_> {
                     let Some(param_kind) = param_kind else { continue };
 
                     self.transform_rhs(arg, harg, param_kind);
+                    if param_kind == PtrKind::OptRef(true)
+                        && hir_path_source_kind(self.tcx, &self.ptr_kinds, harg)
+                            == Some(PtrKind::OptRef(true))
+                    {
+                        *arg = P(utils::expr!(
+                            "({}).as_deref_mut()",
+                            pprust::expr_to_string(arg)
+                        ));
+                    }
                 }
 
                 if let Some(free_rewrite) = self.rewrite_direct_free_call(hir_expr, &args[..]) {
@@ -581,7 +699,13 @@ impl MutVisitor for TransformVisitor<'_> {
                 if seg.ident.name.as_str() == "is_null" =>
             {
                 let receiver = unwrap_paren(receiver);
-                if matches!(receiver.kind, ExprKind::Path(_, _))
+                let hir_receiver = self.ast_to_hir.get_expr(receiver.id, self.tcx);
+                if hir_receiver.is_some_and(|hir_receiver| {
+                    self.promoted_field_slot_for_hir_field(hir_receiver)
+                        .is_some()
+                }) {
+                    seg.ident.name = Symbol::intern("is_none");
+                } else if matches!(receiver.kind, ExprKind::Path(_, _))
                     && let Some(hir_id) = self.hir_id_of_path(receiver.id)
                     && let Some(ptr_kind) = self.effective_ptr_kind(hir_id)
                 {
@@ -686,6 +810,22 @@ impl MutVisitor for TransformVisitor<'_> {
                     ExprCtx::Lvalue => Some(true),
                 };
                 if let Some(m) = m {
+                    if let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
+                        && let Some(kind) = self.promoted_field_kind(field)
+                    {
+                        let field_str = pprust::expr_to_string(e);
+                        *expr = match kind {
+                            PtrKind::OptRef(true) if m => {
+                                utils::expr!("*({field_str}).as_deref_mut().unwrap()")
+                            }
+                            PtrKind::OptRef(true) => {
+                                utils::expr!("*({field_str}).as_deref().unwrap()")
+                            }
+                            PtrKind::OptRef(false) => utils::expr!("*({field_str}.unwrap())"),
+                            _ => unreachable!(),
+                        };
+                        return;
+                    }
                     // For SliceCursor with offset projections, try to emit base[offset] directly
                     let inner = unwrap_addr_of_deref(unwrap_cast_and_paren(e));
                     let hir_inner = hir_unwrap_addr_of_deref(hir_unwrap_cast(hir_e));
@@ -742,6 +882,11 @@ impl MutVisitor for TransformVisitor<'_> {
             _ => {}
         }
     }
+
+    fn visit_ty(&mut self, ty: &mut Ty) {
+        mut_visit::walk_ty(self, ty);
+        self.add_struct_lifetime_args_to_ty(ty);
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -761,14 +906,15 @@ enum AllocatorRoot<'a> {
     },
 }
 
-impl<'tcx> TransformVisitor<'tcx> {
+impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     pub fn new(
         rust_program: &RustProgram<'tcx>,
-        analysis: &Analysis,
+        analysis: &'analysis Analysis,
         ast_to_hir: AstToHir,
-    ) -> TransformVisitor<'tcx> {
-        let mut sig_decs = SigDecisions::new(rust_program, analysis); // TODO: Move outside
-        let mut ptr_kinds = collect_diffs(rust_program, analysis); // TODO: Move outside
+    ) -> TransformVisitor<'analysis, 'tcx> {
+        let lifetime_plans = super::lifetimes::LifetimePlans::new(rust_program, analysis);
+        let mut sig_decs = SigDecisions::new(rust_program, analysis, &lifetime_plans); // TODO: Move outside
+        let mut ptr_kinds = collect_diffs(rust_program, analysis, &sig_decs); // TODO: Move outside
         let free_like_wrappers = collect_local_free_wrappers(rust_program.tcx);
         let local_raw_free_summaries =
             collect_local_raw_free_summaries(rust_program.tcx, &free_like_wrappers);
@@ -796,10 +942,28 @@ impl<'tcx> TransformVisitor<'tcx> {
             if downgrade_unsupported_box_outputs(rust_program.tcx, &mut sig_decs, &ptr_kinds) {
                 changed = true;
             }
+            if downgrade_freed_borrow_outputs(rust_program.tcx, &mut sig_decs, &free_like_wrappers)
+            {
+                changed = true;
+            }
+            if downgrade_raw_cast_call_inputs(rust_program.tcx, &mut sig_decs) {
+                changed = true;
+            }
             let raw_call_result_bindings =
                 collect_raw_call_result_bindings(rust_program.tcx, &sig_decs, &ptr_kinds);
             let raw_local_assignment_bindings =
                 collect_raw_local_assignment_bindings(rust_program.tcx, &ptr_kinds);
+            for hir_id in &raw_local_assignment_bindings {
+                if param_index_for_binding(rust_program.tcx, *hir_id).is_some()
+                    && force_signature_input_raw_for_binding(
+                        rust_program.tcx,
+                        &mut sig_decs,
+                        *hir_id,
+                    )
+                {
+                    changed = true;
+                }
+            }
             let unsupported_box_target_bindings =
                 collect_unsupported_box_target_bindings(rust_program.tcx, &sig_decs, &ptr_kinds);
             let unsupported_box_usage_bindings = collect_unsupported_box_usage_bindings(
@@ -826,9 +990,28 @@ impl<'tcx> TransformVisitor<'tcx> {
             if !changed {
                 break;
             }
+            ptr_kinds = collect_diffs(rust_program, analysis, &sig_decs);
+            normalize_forced_raw_bindings(rust_program.tcx, &mut ptr_kinds, &forced_raw_bindings);
         }
 
         let alloc_wrappers = collect_local_allocator_wrappers(rust_program.tcx);
+        let demoted_fields =
+            collect_demoted_promoted_fields(rust_program.tcx, analysis, &sig_decs, &ptr_kinds);
+        let (demoted_field_source_bindings, raw_field_source_callees) =
+            collect_raw_field_source_bindings(rust_program.tcx, analysis, &demoted_fields);
+        let mut sig_changed = false;
+        for hir_id in &demoted_field_source_bindings {
+            sig_changed |=
+                force_signature_input_raw_for_binding(rust_program.tcx, &mut sig_decs, *hir_id);
+        }
+        for callee_did in raw_field_source_callees {
+            sig_changed |= force_signature_output_raw(rust_program.tcx, &mut sig_decs, callee_did);
+        }
+        forced_raw_bindings.extend(demoted_field_source_bindings);
+        if sig_changed {
+            ptr_kinds = collect_diffs(rust_program, analysis, &sig_decs);
+        }
+        normalize_forced_raw_bindings(rust_program.tcx, &mut ptr_kinds, &forced_raw_bindings);
         let raw_bridge_bindings = collect_raw_bridge_bindings(
             rust_program.tcx,
             &ptr_kinds,
@@ -839,15 +1022,590 @@ impl<'tcx> TransformVisitor<'tcx> {
 
         TransformVisitor {
             tcx: rust_program.tcx,
+            analysis,
             sig_decs,
+            lifetime_plans,
             ptr_kinds,
             forced_raw_bindings,
             raw_bridge_bindings,
             alloc_wrappers,
             free_like_wrappers,
+            demoted_fields,
+            impl_self_lifetimes: Vec::new(),
             ast_to_hir,
             bytemuck: Cell::new(false),
             slice_cursor: Cell::new(false),
+        }
+    }
+
+    fn promoted_field_kind(&self, field: StructFieldSlot) -> Option<PtrKind> {
+        if self.demoted_fields.contains(&field) {
+            return None;
+        }
+        if self
+            .analysis
+            .borrow_promotion_result
+            .mutable_fields
+            .contains(&field)
+        {
+            Some(PtrKind::OptRef(true))
+        } else if self
+            .analysis
+            .borrow_promotion_result
+            .shared_fields
+            .contains(&field)
+        {
+            Some(PtrKind::OptRef(false))
+        } else {
+            None
+        }
+    }
+
+    fn mark_param_mut_if_needed(&self, param: &mut Param) {
+        let Some(hir_pat) = self.ast_to_hir.get_pat(param.pat.id, self.tcx) else {
+            return;
+        };
+        let hir::PatKind::Binding(_, hir_id, _ident, _) = hir_pat.kind else {
+            return;
+        };
+        if !self.local_binding_needs_mut_for_promoted_field_write(hir_id) {
+            return;
+        }
+        let PatKind::Ident(binding_mode, ..) = &mut param.pat.kind else {
+            return;
+        };
+        binding_mode.1 = Mutability::Mut;
+    }
+
+    fn field_lifetime(&self, field: StructFieldSlot) -> Option<Symbol> {
+        self.lifetime_plans
+            .structs
+            .get(&field.struct_did)
+            .and_then(|plan| plan.field_lifetimes.get(&field.field_index).copied())
+    }
+
+    fn struct_has_field_promotion_candidate(&self, struct_did: LocalDefId) -> bool {
+        self.analysis
+            .borrow_promotion_result
+            .mutable_fields
+            .iter()
+            .chain(self.analysis.borrow_promotion_result.shared_fields.iter())
+            .any(|field| field.struct_did == struct_did)
+    }
+
+    fn ordered_struct_lifetimes(&self, struct_did: LocalDefId) -> Vec<Symbol> {
+        let Some(plan) = self.lifetime_plans.structs.get(&struct_did) else {
+            return vec![];
+        };
+        let mut field_lifetimes: Vec<_> = plan.field_lifetimes.iter().collect();
+        field_lifetimes.sort_by_key(|(field_index, _)| **field_index);
+        field_lifetimes
+            .into_iter()
+            .filter(|(field_index, _)| {
+                self.promoted_field_kind(StructFieldSlot {
+                    struct_did,
+                    field_index: **field_index,
+                })
+                .is_some()
+            })
+            .map(|(_, lifetime)| *lifetime)
+            .collect()
+    }
+
+    fn rewrite_struct_definition(
+        &self,
+        struct_did: LocalDefId,
+        generics: &mut Generics,
+        fields: &mut ThinVec<FieldDef>,
+    ) {
+        let lifetimes = self.ordered_struct_lifetimes(struct_did);
+        if lifetimes.is_empty() {
+            return;
+        }
+        super::lifetimes::ensure_lifetime_params(generics, &lifetimes);
+
+        for (field_index, field_def) in fields.iter_mut().enumerate() {
+            let field = StructFieldSlot {
+                struct_did,
+                field_index,
+            };
+            let Some(kind) = self.promoted_field_kind(field) else {
+                continue;
+            };
+            let Some(lifetime) = self.field_lifetime(field) else {
+                continue;
+            };
+            let TyKind::Ptr(mut_ty) = &field_def.ty.kind else {
+                continue;
+            };
+            let PtrKind::OptRef(mutability) = kind else {
+                continue;
+            };
+            field_def.ty = P(mk_opt_ref_ast_ty_with_lifetime(
+                self.ast_ty_string_with_promoted_lifetimes(&mut_ty.ty),
+                mutability,
+                lifetime,
+            ));
+        }
+    }
+
+    fn ast_ty_string_with_promoted_lifetimes(&self, ty: &Ty) -> String {
+        let mut ty = ty.clone();
+        self.add_promoted_lifetime_args_to_ast_ty(&mut ty);
+        pprust::ty_to_string(&ty)
+    }
+
+    fn add_promoted_lifetime_args_to_ast_ty(&self, ty: &mut Ty) {
+        struct FieldPointeeTyVisitor<'a, 'analysis, 'tcx> {
+            transform: &'a TransformVisitor<'analysis, 'tcx>,
+        }
+
+        impl MutVisitor for FieldPointeeTyVisitor<'_, '_, '_> {
+            fn visit_ty(&mut self, ty: &mut Ty) {
+                mut_visit::walk_ty(self, ty);
+                self.transform
+                    .add_promoted_lifetime_args_to_ast_ty_shallow(ty);
+            }
+        }
+
+        let mut visitor = FieldPointeeTyVisitor { transform: self };
+        visitor.visit_ty(ty);
+    }
+
+    fn add_promoted_lifetime_args_to_ast_ty_shallow(&self, ty: &mut Ty) {
+        let ty_str = pprust::ty_to_string(ty);
+        let Some(hir_ty) = self.ast_to_hir.get_ty(ty.id, self.tcx) else {
+            return;
+        };
+        let hir::TyKind::Path(qpath) = &hir_ty.kind else {
+            return;
+        };
+        let Some(struct_did) = self.local_struct_did_from_qpath(qpath) else {
+            return;
+        };
+        let lifetimes = self.ordered_struct_lifetimes(struct_did);
+        if lifetimes.is_empty() {
+            return;
+        }
+        let promoted_lifetime_args = lifetimes
+            .iter()
+            .map(|lifetime| format!("'{}", lifetime.as_str()))
+            .collect::<Vec<_>>();
+        *ty = utils::ty!(
+            "{}",
+            add_lifetime_args_to_type_path_string(
+                ty_str,
+                self.existing_lifetime_param_count(struct_did),
+                &promoted_lifetime_args,
+            )
+        );
+    }
+
+    fn add_struct_lifetime_args_to_ty(&self, ty: &mut Ty) {
+        let Some((struct_did, lifetimes)) = self.struct_lifetimes_for_ty(ty) else {
+            return;
+        };
+        if self
+            .impl_self_lifetimes
+            .last()
+            .is_some_and(|(impl_struct_did, _)| *impl_struct_did == struct_did)
+        {
+            self.add_struct_lifetime_args_to_ty_with_lifetimes(ty, &lifetimes);
+        } else {
+            self.add_struct_lifetime_args_to_ty_with_lifetime_count(ty, lifetimes.len());
+        }
+    }
+
+    fn struct_lifetimes_for_ty(&self, ty: &Ty) -> Option<(LocalDefId, Vec<Symbol>)> {
+        let struct_did = self.local_struct_did_for_ast_ty(ty)?;
+        let lifetimes = self.ordered_struct_lifetimes(struct_did);
+        if lifetimes.is_empty() {
+            return None;
+        }
+        Some((struct_did, lifetimes))
+    }
+
+    fn local_struct_did_for_ast_ty(&self, ty: &Ty) -> Option<LocalDefId> {
+        let Some(hir_ty) = self.ast_to_hir.get_ty(ty.id, self.tcx) else {
+            return None;
+        };
+        let hir::TyKind::Path(hir_qpath) = hir_ty.kind else {
+            return None;
+        };
+        self.local_struct_did_from_qpath(&hir_qpath)
+    }
+
+    fn add_struct_lifetime_args_to_ty_with_lifetimes(&self, ty: &mut Ty, lifetimes: &[Symbol]) {
+        let Some((struct_did, _)) = self.struct_lifetimes_for_ty(ty) else {
+            return;
+        };
+        let promoted_lifetime_args = lifetimes
+            .iter()
+            .map(|lifetime| format!("'{}", lifetime.as_str()))
+            .collect::<Vec<_>>();
+        self.add_struct_lifetime_args_to_ty_with_args(
+            ty,
+            struct_did,
+            lifetimes,
+            &promoted_lifetime_args,
+        );
+    }
+
+    fn add_struct_lifetime_args_to_ty_with_lifetime_count(
+        &self,
+        ty: &mut Ty,
+        lifetime_count: usize,
+    ) {
+        let Some((struct_did, lifetimes)) = self.struct_lifetimes_for_ty(ty) else {
+            return;
+        };
+        let promoted_lifetime_args = std::iter::repeat_n("'_", lifetime_count)
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        self.add_struct_lifetime_args_to_ty_with_args(
+            ty,
+            struct_did,
+            &lifetimes,
+            &promoted_lifetime_args,
+        );
+    }
+
+    fn add_struct_lifetime_args_to_ty_with_args(
+        &self,
+        ty: &mut Ty,
+        struct_did: LocalDefId,
+        expected_lifetimes: &[Symbol],
+        promoted_lifetime_args: &[String],
+    ) {
+        let TyKind::Path(None, path) = &ty.kind else {
+            return;
+        };
+        if path.segments.last().is_some_and(|seg| {
+            path_segment_has_expected_lifetimes(
+                seg,
+                self.existing_lifetime_param_count(struct_did),
+                expected_lifetimes,
+            )
+        }) {
+            return;
+        }
+        let ty_str = pprust::ty_to_string(ty);
+        *ty = utils::ty!(
+            "{}",
+            add_lifetime_args_to_type_path_string(
+                ty_str,
+                self.existing_lifetime_param_count(struct_did),
+                promoted_lifetime_args,
+            )
+        );
+    }
+
+    fn promoted_field_slot_for_hir_field(
+        &self,
+        hir_expr: &hir::Expr<'tcx>,
+    ) -> Option<StructFieldSlot> {
+        let hir::ExprKind::Field(base, ident) = hir_expr.kind else {
+            return None;
+        };
+        let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
+        let struct_did = self.local_struct_did_from_ty(typeck.expr_ty_adjusted(base))?;
+        let field_index = self.field_index_by_name(struct_did, ident.name)?;
+        let field = StructFieldSlot {
+            struct_did,
+            field_index,
+        };
+        self.promoted_field_kind(field).map(|_| field)
+    }
+
+    fn promoted_field_slot_for_ast_field(&self, ast_id: NodeId) -> Option<StructFieldSlot> {
+        let hir_field = self.ast_to_hir.get_expr_field(ast_id, self.tcx)?;
+        let hir::Node::Expr(parent) = self.tcx.parent_hir_node(hir_field.hir_id) else {
+            return None;
+        };
+        let hir::ExprKind::Struct(qpath, _, _) = parent.kind else {
+            return None;
+        };
+        let struct_did = self.local_struct_did_from_qpath(qpath)?;
+        let field_index = self.field_index_by_name(struct_did, hir_field.ident.name)?;
+        let field = StructFieldSlot {
+            struct_did,
+            field_index,
+        };
+        self.promoted_field_kind(field).map(|_| field)
+    }
+
+    fn rewrite_struct_literal_fields(&self, expr_id: NodeId, se: &mut StructExpr) {
+        let Some(hir_expr) = self.ast_to_hir.get_expr(expr_id, self.tcx) else {
+            return;
+        };
+        let hir::ExprKind::Struct(_, hir_fields, _) = hir_expr.kind else {
+            return;
+        };
+        for ast_field in &mut se.fields {
+            let Some(field) = self.promoted_field_slot_for_ast_field(ast_field.id) else {
+                continue;
+            };
+            let Some(kind) = self.promoted_field_kind(field) else {
+                continue;
+            };
+            let Some(hir_field) = hir_fields
+                .iter()
+                .find(|hir_field| hir_field.ident.name == ast_field.ident.name)
+            else {
+                continue;
+            };
+            self.transform_rhs(&mut ast_field.expr, hir_field.expr, kind);
+        }
+    }
+
+    fn local_struct_did_from_qpath(&self, qpath: &hir::QPath<'tcx>) -> Option<LocalDefId> {
+        let hir::QPath::Resolved(_, path) = qpath else {
+            return None;
+        };
+        let Res::Def(DefKind::Struct, def_id) = path.res else {
+            return None;
+        };
+        def_id.as_local()
+    }
+
+    fn local_struct_did_from_ty(&self, ty: ty::Ty<'tcx>) -> Option<LocalDefId> {
+        match ty.kind() {
+            ty::TyKind::Adt(adt_def, _) if adt_def.did().is_local() && adt_def.is_struct() => {
+                Some(adt_def.did().expect_local())
+            }
+            ty::TyKind::Ref(_, inner, _) => self.local_struct_did_from_ty(*inner),
+            _ => None,
+        }
+    }
+
+    fn field_index_by_name(&self, struct_did: LocalDefId, field_name: Symbol) -> Option<usize> {
+        self.tcx
+            .adt_def(struct_did)
+            .non_enum_variant()
+            .fields
+            .iter_enumerated()
+            .find_map(|(field_index, field)| {
+                (field.name == field_name).then_some(field_index.index())
+            })
+    }
+
+    fn extend_lifetimes_for_ty(&self, lifetimes: &mut Vec<Symbol>, ty: ty::Ty<'tcx>) {
+        for lifetime in self.lifetimes_for_ty(ty) {
+            if !lifetimes.contains(&lifetime) {
+                lifetimes.push(lifetime);
+            }
+        }
+    }
+
+    fn lifetimes_for_ty(&self, ty: ty::Ty<'tcx>) -> Vec<Symbol> {
+        let ty::TyKind::Adt(adt_def, _) = ty.kind() else {
+            return vec![];
+        };
+        if !adt_def.did().is_local() || !adt_def.is_struct() {
+            return vec![];
+        }
+        self.ordered_struct_lifetimes(adt_def.did().expect_local())
+    }
+
+    fn existing_lifetime_param_count_for_ty(&self, ty: ty::Ty<'tcx>) -> usize {
+        let ty::TyKind::Adt(adt_def, _) = ty.kind() else {
+            return 0;
+        };
+        if !adt_def.did().is_local() || !adt_def.is_struct() {
+            return 0;
+        }
+        self.existing_lifetime_param_count(adt_def.did().expect_local())
+    }
+
+    fn existing_lifetime_param_count(&self, did: LocalDefId) -> usize {
+        let hir::Node::Item(item) = self.tcx.hir_node_by_def_id(did) else {
+            return 0;
+        };
+        let Some(generics) = item.kind.generics() else {
+            return 0;
+        };
+        generics
+            .params
+            .iter()
+            .filter(|param| matches!(param.kind, hir::GenericParamKind::Lifetime { .. }))
+            .count()
+    }
+
+    fn ty_name(&self, ty: ty::Ty<'tcx>) -> String {
+        self.promoted_mir_ty_name(ty)
+    }
+
+    fn promoted_mir_ty_name(&self, ty: ty::Ty<'tcx>) -> String {
+        match ty.kind() {
+            ty::TyKind::Adt(adt_def, args) => {
+                let mut args = args
+                    .iter()
+                    .map(|arg| match arg.kind() {
+                        ty::GenericArgKind::Type(ty) => self.promoted_mir_ty_name(ty),
+                        ty::GenericArgKind::Const(cnst) => cnst.to_string(),
+                        ty::GenericArgKind::Lifetime(_) => "'_".to_string(),
+                    })
+                    .collect::<Vec<_>>();
+                let lifetimes = self.lifetimes_for_ty(ty);
+                if !lifetimes.is_empty() {
+                    let promoted_lifetime_args = lifetimes
+                        .iter()
+                        .map(|lifetime| format!("'{}", lifetime.as_str()))
+                        .collect::<Vec<_>>();
+                    let insert_at = self
+                        .existing_lifetime_param_count_for_ty(ty)
+                        .min(args.len());
+                    if !generic_args_have_lifetimes(&args, insert_at, promoted_lifetime_args.len())
+                    {
+                        for (offset, lifetime) in promoted_lifetime_args.into_iter().enumerate() {
+                            args.insert(insert_at + offset, lifetime);
+                        }
+                    }
+                }
+                let base = self.adt_type_name(*adt_def);
+                if args.is_empty() {
+                    base
+                } else {
+                    format!("{base}<{}>", args.join(", "))
+                }
+            }
+            ty::TyKind::RawPtr(pointee, mutability) => {
+                let m = if mutability.is_mut() { "mut" } else { "const" };
+                format!("*{m} {}", self.promoted_mir_ty_name(*pointee))
+            }
+            ty::TyKind::Ref(_, inner, mutability) => {
+                let m = if mutability.is_mut() { "mut " } else { "" };
+                format!("&{m}{}", self.promoted_mir_ty_name(*inner))
+            }
+            ty::TyKind::Array(elem, len) => {
+                format!("[{}; {len}]", self.promoted_mir_ty_name(*elem))
+            }
+            ty::TyKind::Slice(elem) => format!("[{}]", self.promoted_mir_ty_name(*elem)),
+            ty::TyKind::Tuple(elems) => {
+                let elems = elems
+                    .iter()
+                    .map(|elem| self.promoted_mir_ty_name(elem))
+                    .collect::<Vec<_>>();
+                format!("({})", elems.join(", "))
+            }
+            ty::TyKind::Param(param) => param.name.as_str().to_owned(),
+            _ => mir_ty_to_string(ty, self.tcx),
+        }
+    }
+
+    fn adt_type_name(&self, adt_def: ty::AdtDef<'tcx>) -> String {
+        let path_str = self.tcx.def_path_str(adt_def.did());
+        if path_str.starts_with("std") {
+            let name = self.tcx.item_name(adt_def.did());
+            if matches!(
+                name.as_str(),
+                "Option" | "Result" | "Vec" | "String" | "Box"
+            ) {
+                name.as_str().to_owned()
+            } else {
+                path_str
+            }
+        } else {
+            format!("crate::{path_str}")
+        }
+    }
+
+    fn mk_ref_ty(&self, ty: ty::Ty<'tcx>, mutability: bool) -> Ty {
+        self.mk_ref_ty_with_lifetime(ty, mutability, None)
+    }
+
+    fn mk_ref_ty_with_lifetime(
+        &self,
+        ty: ty::Ty<'tcx>,
+        mutability: bool,
+        lifetime: Option<Symbol>,
+    ) -> Ty {
+        let ty = self.ty_name(ty);
+        let m = if mutability { "mut " } else { "" };
+        let lifetime = lifetime
+            .map(|lifetime| format!("'{} ", lifetime.as_str()))
+            .unwrap_or_default();
+        utils::ty!("&{lifetime}{m}{ty}")
+    }
+
+    fn mk_opt_ref_ty(&self, ty: ty::Ty<'tcx>, mutability: bool) -> Ty {
+        self.mk_opt_ref_ty_with_lifetime(ty, mutability, None)
+    }
+
+    fn mk_opt_ref_ty_with_lifetime(
+        &self,
+        ty: ty::Ty<'tcx>,
+        mutability: bool,
+        lifetime: Option<Symbol>,
+    ) -> Ty {
+        let ty = self.ty_name(ty);
+        let m = if mutability { "mut " } else { "" };
+        let lifetime = lifetime
+            .map(|lifetime| format!("'{} ", lifetime.as_str()))
+            .unwrap_or_default();
+        utils::ty!("Option<&{lifetime}{m}{ty}>")
+    }
+
+    fn mk_box_ty(&self, ty: ty::Ty<'tcx>) -> Ty {
+        let ty = self.ty_name(ty);
+        utils::ty!("Box<{ty}>")
+    }
+
+    fn mk_opt_box_ty(&self, ty: ty::Ty<'tcx>) -> Ty {
+        let ty = self.ty_name(ty);
+        utils::ty!("Option<Box<{ty}>>")
+    }
+
+    fn mk_boxed_slice_ty(&self, ty: ty::Ty<'tcx>) -> Ty {
+        let ty = self.ty_name(ty);
+        utils::ty!("Box<[{ty}]>")
+    }
+
+    fn mk_opt_boxed_slice_ty(&self, ty: ty::Ty<'tcx>) -> Ty {
+        let ty = self.ty_name(ty);
+        utils::ty!("Option<Box<[{ty}]>>")
+    }
+
+    fn mk_cursor_ty(&self, ty: ty::Ty<'tcx>, mutability: bool) -> Ty {
+        let ty = self.ty_name(ty);
+        if mutability {
+            utils::ty!("crate::slice_cursor::SliceCursorMut<'_, {ty}>")
+        } else {
+            utils::ty!("crate::slice_cursor::SliceCursor<'_, {ty}>")
+        }
+    }
+
+    fn mk_slice_ty(&self, ty: ty::Ty<'tcx>, mutability: bool) -> Ty {
+        let ty = self.ty_name(ty);
+        if mutability {
+            utils::ty!("&mut [{ty}]")
+        } else {
+            utils::ty!("&[{ty}]")
+        }
+    }
+
+    fn mk_raw_ptr_ty(&self, ty: ty::Ty<'tcx>, mutability: bool) -> Ty {
+        let ty = self.ty_name(ty);
+        let m = if mutability { "mut" } else { "const" };
+        utils::ty!("*{m} {ty}")
+    }
+
+    fn raw_from_promoted_field_expr(
+        &self,
+        field_expr: &Expr,
+        mutability: bool,
+        inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let field_expr = pprust::expr_to_string(field_expr);
+        let inner_ty = self.ty_name(inner_ty);
+        if mutability {
+            utils::expr!(
+                "({field_expr}).as_deref_mut().map_or(std::ptr::null_mut(), |r| r as *mut {inner_ty})"
+            )
+        } else {
+            utils::expr!(
+                "({field_expr}).as_deref().map_or(std::ptr::null(), |r| r as *const {inner_ty})"
+            )
         }
     }
 
@@ -890,7 +1648,7 @@ impl<'tcx> TransformVisitor<'tcx> {
     }
 
     fn raw_bridge_expr(&self, lhs_inner_ty: ty::Ty<'tcx>, m: bool, info: &RawBridgeInfo) -> Expr {
-        let ty = mir_ty_to_string(lhs_inner_ty, self.tcx);
+        let ty = self.ty_name(lhs_inner_ty);
         let default_expr = self.default_value_expr(lhs_inner_ty);
         let default_expr_str = pprust::expr_to_string(&default_expr);
         match info {
@@ -924,6 +1682,9 @@ impl<'tcx> TransformVisitor<'tcx> {
     ) {
         let PtrKind::Raw(m) = output_kind else {
             self.transform_rhs(rhs, hir_rhs, output_kind);
+            if matches!(output_kind, PtrKind::Ref(_)) {
+                use_moving_opt_ref_unwraps_for_return(rhs);
+            }
             return;
         };
         let Some((rhs_inner_ty, _)) = unwrap_ptr_from_mir_ty(
@@ -1085,15 +1846,15 @@ impl<'tcx> TransformVisitor<'tcx> {
         target_kind: PtrKind,
         lhs_inner_ty: ty::Ty<'tcx>,
     ) -> bool {
-        struct UnsupportedBoxAssignmentVisitor<'a, 'tcx> {
-            transform: &'a TransformVisitor<'tcx>,
+        struct UnsupportedBoxAssignmentVisitor<'a, 'analysis, 'tcx> {
+            transform: &'a TransformVisitor<'analysis, 'tcx>,
             target_hir_id: HirId,
             target_kind: PtrKind,
             lhs_inner_ty: ty::Ty<'tcx>,
             found: bool,
         }
 
-        impl<'tcx> Visitor<'tcx> for UnsupportedBoxAssignmentVisitor<'_, 'tcx> {
+        impl<'tcx> Visitor<'tcx> for UnsupportedBoxAssignmentVisitor<'_, '_, 'tcx> {
             fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
                 if self.found {
                     return;
@@ -1134,6 +1895,46 @@ impl<'tcx> TransformVisitor<'tcx> {
         lhs_kind: PtrKind,
     ) -> PtrKind {
         self.transform_ptr(rhs, hir_rhs, PtrCtx::Rhs(lhs_kind))
+    }
+
+    fn local_binding_needs_mut_for_promoted_field_write(&self, target_hir_id: HirId) -> bool {
+        struct PromotedFieldWriteVisitor<'a, 'analysis, 'tcx> {
+            transform: &'a TransformVisitor<'analysis, 'tcx>,
+            target_hir_id: HirId,
+            found: bool,
+        }
+
+        impl<'tcx> Visitor<'tcx> for PromotedFieldWriteVisitor<'_, '_, 'tcx> {
+            fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+                if self.found {
+                    return;
+                }
+                if let hir::ExprKind::Unary(UnOp::Deref, field_expr) = expr.kind
+                    && matches!(self.transform.expr_ctx(expr), ExprCtx::Lvalue)
+                    && hir_field_base_local_id(field_expr)
+                        .is_some_and(|id| id == self.target_hir_id)
+                    && let Some(field) =
+                        self.transform.promoted_field_slot_for_hir_field(field_expr)
+                    && matches!(
+                        self.transform.promoted_field_kind(field),
+                        Some(PtrKind::OptRef(true))
+                    )
+                {
+                    self.found = true;
+                    return;
+                }
+                intravisit::walk_expr(self, expr);
+            }
+        }
+
+        let body = self.tcx.hir_body_owned_by(target_hir_id.owner.def_id);
+        let mut visitor = PromotedFieldWriteVisitor {
+            transform: self,
+            target_hir_id,
+            found: false,
+        };
+        visitor.visit_body(body);
+        visitor.found
     }
 
     fn transform_ptr(&self, ptr: &mut Expr, hir_ptr: &hir::Expr<'tcx>, ctx: PtrCtx) -> PtrKind {
@@ -1224,10 +2025,28 @@ impl<'tcx> TransformVisitor<'tcx> {
             }
         }
 
+        if let PtrCtx::Rhs(kind @ (PtrKind::Ref(_) | PtrKind::OptRef(_))) = ctx
+            && let Some(pe) = self.ptr_expr(e, hir_e)
+            && pe.projs.is_empty()
+            && !hir_expr_starts_with_cast(hir_ptr)
+            && self.ptr_source_kind(&pe) == Some(kind)
+        {
+            return kind;
+        }
+
         if let PtrCtx::Rhs(kind @ (PtrKind::Ref(_) | PtrKind::Box | PtrKind::BoxedSlice)) = ctx {
             debug_assert!(!kind.is_optional());
             self.transform_ptr(ptr, hir_ptr, PtrCtx::Rhs(kind.optional_variant()));
-            *ptr = utils::expr!("({}).unwrap()", pprust::expr_to_string(ptr));
+            *ptr = match kind {
+                PtrKind::Ref(m) if opt_ref_receiver_should_borrow(ptr) => {
+                    utils::expr!(
+                        "({}).as_deref{}().unwrap()",
+                        pprust::expr_to_string(ptr),
+                        if m { "_mut" } else { "" },
+                    )
+                }
+                _ => utils::expr!("({}).unwrap()", pprust::expr_to_string(ptr)),
+            };
             return kind;
         }
 
@@ -1253,6 +2072,20 @@ impl<'tcx> TransformVisitor<'tcx> {
         let typeck = self.tcx.typeck(hir_ptr.hir_id.owner);
         let lhs_ty = typeck.expr_ty_adjusted(hir_ptr);
         let rhs_ty = typeck.expr_ty(hir_unwrap_cast(hir_ptr));
+        if let PtrCtx::Rhs(kind @ PtrKind::OptRef(_)) = ctx
+            && let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
+            && self.promoted_field_kind(field) == Some(kind)
+        {
+            return kind;
+        }
+        if let PtrCtx::Rhs(PtrKind::Raw(m)) = ctx
+            && let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
+            && matches!(self.promoted_field_kind(field), Some(PtrKind::OptRef(_)))
+            && let Some((lhs_inner_ty, _)) = unwrap_ptr_from_mir_ty(lhs_ty)
+        {
+            *ptr = self.raw_from_promoted_field_expr(e, m, lhs_inner_ty);
+            return PtrKind::Raw(m);
+        }
         let mut pe = if let Some(pe) = self.ptr_expr(e, hir_e) {
             pe
         } else if let Some((rhs_inner_ty, rhs_mut)) = unwrap_ptr_from_mir_ty(rhs_ty) {
@@ -1591,11 +2424,8 @@ impl<'tcx> TransformVisitor<'tcx> {
                 }
                 PtrCtx::Rhs(PtrKind::OptRef(m)) | PtrCtx::Deref(m) => {
                     if !need_cast && !ty_updated {
-                        *ptr = utils::expr!(
-                            "Some(&{}({}))",
-                            if m { "mut " } else { "" },
-                            pprust::expr_to_string(e),
-                        );
+                        let target = borrow_target_expr_string(e);
+                        *ptr = utils::expr!("Some(&{}{})", if m { "mut " } else { "" }, target,);
                     } else if !ty_updated
                         && lhs_inner_ty.is_numeric()
                         && rhs_inner_ty.is_numeric()
@@ -2494,7 +3324,7 @@ impl<'tcx> TransformVisitor<'tcx> {
             ty::TyKind::RawPtr(pointee, mutability) => utils::expr!(
                 "std::ptr::null{}::<{}>()",
                 if mutability.is_mut() { "_mut" } else { "" },
-                mir_ty_to_string(*pointee, self.tcx),
+                self.ty_name(*pointee),
             ),
             ty::TyKind::Array(elem, _) => {
                 let elem_expr = self.default_value_expr(*elem);
@@ -2504,12 +3334,22 @@ impl<'tcx> TransformVisitor<'tcx> {
                 )
             }
             ty::TyKind::Adt(adt_def, args) if adt_def.did().is_local() && adt_def.is_struct() => {
-                let ty_name = mir_ty_to_string(ty, self.tcx);
+                let ty_name = strip_top_level_generic_args_from_type_path(self.ty_name(ty));
+                let struct_did = adt_def.did().expect_local();
                 let fields = adt_def
                     .all_fields()
-                    .map(|field| {
+                    .enumerate()
+                    .map(|(field_index, field)| {
                         let field_name = self.tcx.item_name(field.did).as_str().to_owned();
-                        let field_expr = self.default_value_expr(field.ty(self.tcx, args));
+                        let field_slot = StructFieldSlot {
+                            struct_did,
+                            field_index,
+                        };
+                        let field_expr = if self.promoted_field_kind(field_slot).is_some() {
+                            utils::expr!("None")
+                        } else {
+                            self.default_value_expr(field.ty(self.tcx, args))
+                        };
                         format!("{field_name}: {}", pprust::expr_to_string(&field_expr))
                     })
                     .collect::<Vec<_>>()
@@ -2517,18 +3357,18 @@ impl<'tcx> TransformVisitor<'tcx> {
                 utils::expr!("{} {{ {} }}", ty_name, fields)
             }
             ty::TyKind::Adt(adt_def, _) if adt_def.did().is_local() && adt_def.is_enum() => {
-                let ty_name = mir_ty_to_string(ty, self.tcx);
+                let ty_name = self.ty_name(ty);
                 let variant_name = fieldless_enum_zero_variant(self.tcx, *adt_def).unwrap();
                 utils::expr!("{}::{}", ty_name, variant_name)
             }
             ty::TyKind::Adt(adt_def, _) if adt_def.did().is_local() && adt_def.is_union() => {
-                let ty_name = mir_ty_to_string(ty, self.tcx);
+                let ty_name = self.ty_name(ty);
                 utils::expr!(
                     "unsafe {{ std::mem::MaybeUninit::<{ty_name}>::zeroed().assume_init() }}"
                 )
             }
             _ => {
-                let ty = mir_ty_to_string(ty, self.tcx);
+                let ty = self.ty_name(ty);
                 utils::expr!("<{ty} as Default>::default()")
             }
         }
@@ -2576,7 +3416,7 @@ impl<'tcx> TransformVisitor<'tcx> {
         lhs_inner_ty: ty::Ty<'tcx>,
     ) -> Option<PtrKind> {
         let alloc_root = self.allocator_root(expr)?;
-        let ty = mir_ty_to_string(lhs_inner_ty, self.tcx);
+        let ty = self.ty_name(lhs_inner_ty);
         let default_expr = self.default_value_expr(lhs_inner_ty);
         let default_expr_str = pprust::expr_to_string(&default_expr);
         match (target_kind, alloc_root) {
@@ -4501,68 +5341,10 @@ fn ty_is_slice_ref(ty: ty::Ty<'_>) -> bool {
 }
 
 #[inline]
-fn mk_ref_ty<'tcx>(ty: ty::Ty<'tcx>, mutability: bool, tcx: TyCtxt<'tcx>) -> Ty {
-    let ty = mir_ty_to_string(ty, tcx);
+fn mk_opt_ref_ast_ty_with_lifetime(inner_ty: String, mutability: bool, lifetime: Symbol) -> Ty {
     let m = if mutability { "mut " } else { "" };
-    utils::ty!("&{m}{ty}")
-}
-
-#[inline]
-fn mk_opt_ref_ty<'tcx>(ty: ty::Ty<'tcx>, mutability: bool, tcx: TyCtxt<'tcx>) -> Ty {
-    let ty = mir_ty_to_string(ty, tcx);
-    let m = if mutability { "mut " } else { "" };
-    utils::ty!("Option<&{m}{ty}>")
-}
-
-#[inline]
-fn mk_box_ty<'tcx>(ty: ty::Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Ty {
-    let ty = mir_ty_to_string(ty, tcx);
-    utils::ty!("Box<{ty}>")
-}
-
-#[inline]
-fn mk_opt_box_ty<'tcx>(ty: ty::Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Ty {
-    let ty = mir_ty_to_string(ty, tcx);
-    utils::ty!("Option<Box<{ty}>>")
-}
-
-#[inline]
-fn mk_boxed_slice_ty<'tcx>(ty: ty::Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Ty {
-    let ty = mir_ty_to_string(ty, tcx);
-    utils::ty!("Box<[{ty}]>")
-}
-
-#[inline]
-fn mk_opt_boxed_slice_ty<'tcx>(ty: ty::Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Ty {
-    let ty = mir_ty_to_string(ty, tcx);
-    utils::ty!("Option<Box<[{ty}]>>")
-}
-
-#[inline]
-fn mk_cursor_ty<'tcx>(ty: ty::Ty<'tcx>, mutability: bool, tcx: TyCtxt<'tcx>) -> Ty {
-    let ty = mir_ty_to_string(ty, tcx);
-    if mutability {
-        utils::ty!("crate::slice_cursor::SliceCursorMut<'_, {ty}>")
-    } else {
-        utils::ty!("crate::slice_cursor::SliceCursor<'_, {ty}>")
-    }
-}
-
-#[inline]
-fn mk_slice_ty<'tcx>(ty: ty::Ty<'tcx>, mutability: bool, tcx: TyCtxt<'tcx>) -> Ty {
-    let ty = mir_ty_to_string(ty, tcx);
-    if mutability {
-        utils::ty!("&mut [{ty}]")
-    } else {
-        utils::ty!("&[{ty}]")
-    }
-}
-
-#[inline]
-fn mk_raw_ptr_ty<'tcx>(ty: ty::Ty<'tcx>, mutability: bool, tcx: TyCtxt<'tcx>) -> Ty {
-    let ty = mir_ty_to_string(ty, tcx);
-    let m = if mutability { "mut" } else { "const" };
-    utils::ty!("*{m} {ty}")
+    let lifetime = lifetime.as_str();
+    utils::ty!("Option<&'{lifetime} {m}{inner_ty}>")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4733,6 +5515,13 @@ fn hir_unwrap_cast<'a, 'tcx>(expr: &'a hir::Expr<'tcx>) -> &'a hir::Expr<'tcx> {
     }
 }
 
+fn hir_expr_starts_with_cast(expr: &hir::Expr<'_>) -> bool {
+    matches!(
+        utils::hir::unwrap_drop_temps(expr).kind,
+        hir::ExprKind::Cast(..)
+    )
+}
+
 fn hir_unwrap_addr_of_deref<'a, 'tcx>(expr: &'a hir::Expr<'tcx>) -> &'a hir::Expr<'tcx> {
     if let hir::ExprKind::AddrOf(_, _, e) = utils::hir::unwrap_drop_temps(expr).kind
         && let hir::ExprKind::Unary(UnOp::Deref, e) = utils::hir::unwrap_drop_temps(e).kind
@@ -4798,6 +5587,133 @@ fn expr_snippet(tcx: TyCtxt<'_>, expr: &Expr) -> Option<String> {
         .span_to_snippet(expr.span)
         .ok()
         .map(|snippet| normalize_expr_snippet(&snippet))
+}
+
+fn borrow_target_expr_string(expr: &Expr) -> String {
+    let expr = unwrap_paren(expr);
+    let expr_str = pprust::expr_to_string(expr);
+    match expr.kind {
+        ExprKind::Path(..) | ExprKind::Field(..) | ExprKind::Index(..) => expr_str,
+        _ => format!("({expr_str})"),
+    }
+}
+
+fn add_lifetime_args_to_type_path_string(
+    ty_name: String,
+    existing_lifetime_count: usize,
+    promoted_lifetime_args: &[String],
+) -> String {
+    if promoted_lifetime_args.is_empty() {
+        return ty_name;
+    }
+    let Some(generic_start) = ty_name.find('<') else {
+        return format!("{}<{}>", ty_name, promoted_lifetime_args.join(", "));
+    };
+    let Some(generic_end) = matching_angle_bracket(&ty_name, generic_start) else {
+        return ty_name;
+    };
+
+    let prefix = &ty_name[..generic_start];
+    let suffix = &ty_name[generic_end + 1..];
+    let mut args = split_top_level_generic_args(&ty_name[generic_start + 1..generic_end]);
+    let insert_at = existing_lifetime_count.min(args.len());
+    if generic_args_have_lifetimes(&args, insert_at, promoted_lifetime_args.len()) {
+        return ty_name;
+    }
+    for (offset, lifetime) in promoted_lifetime_args.iter().enumerate() {
+        args.insert(insert_at + offset, lifetime.clone());
+    }
+
+    if args.is_empty() {
+        format!("{prefix}<{}>{suffix}", promoted_lifetime_args.join(", "))
+    } else {
+        format!("{prefix}<{}>{suffix}", args.join(", "))
+    }
+}
+
+fn strip_top_level_generic_args_from_type_path(ty_name: String) -> String {
+    let Some(generic_start) = ty_name.find('<') else {
+        return ty_name;
+    };
+    let Some(generic_end) = matching_angle_bracket(&ty_name, generic_start) else {
+        return ty_name;
+    };
+    format!(
+        "{}{}",
+        &ty_name[..generic_start],
+        &ty_name[generic_end + 1..]
+    )
+}
+
+fn matching_angle_bracket(s: &str, generic_start: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (offset, ch) in s[generic_start..].char_indices() {
+        match ch {
+            '<' => depth += 1,
+            '>' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(generic_start + offset);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn split_top_level_generic_args(args: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut depth = 0isize;
+    let mut start = 0usize;
+    for (index, ch) in args.char_indices() {
+        match ch {
+            '<' | '(' | '[' => depth += 1,
+            '>' | ')' | ']' => depth -= 1,
+            ',' if depth == 0 => {
+                let arg = args[start..index].trim();
+                if !arg.is_empty() {
+                    result.push(arg.to_string());
+                }
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    let arg = args[start..].trim();
+    if !arg.is_empty() {
+        result.push(arg.to_string());
+    }
+    result
+}
+
+fn generic_args_have_lifetimes(args: &[String], start: usize, count: usize) -> bool {
+    args.get(start..start + count)
+        .is_some_and(|args| args.iter().all(|arg| arg.trim_start().starts_with('\'')))
+}
+
+fn path_segment_has_expected_lifetimes(
+    seg: &PathSegment,
+    existing_lifetime_count: usize,
+    promoted_lifetimes: &[Symbol],
+) -> bool {
+    if promoted_lifetimes.is_empty() {
+        return true;
+    }
+    let Some(args) = &seg.args else {
+        return false;
+    };
+    let GenericArgs::AngleBracketed(args) = &**args else {
+        return false;
+    };
+    if args.args.len() < existing_lifetime_count + promoted_lifetimes.len() {
+        return false;
+    }
+    args.args
+        .iter()
+        .skip(existing_lifetime_count)
+        .take(promoted_lifetimes.len())
+        .all(|arg| matches!(arg, AngleBracketedArg::Arg(GenericArg::Lifetime(_))))
 }
 
 fn size_of_type_name_candidates(ty_name: &str) -> Vec<String> {
@@ -5060,6 +5976,22 @@ fn hir_is_literal_one(tcx: TyCtxt<'_>, expr: &hir::Expr<'_>) -> bool {
     hir_expr_snippet(tcx, hir_unwrap_casts(expr)).is_some_and(|snippet| snippet == "1")
 }
 
+fn ty_contains_param(ty: ty::Ty<'_>) -> bool {
+    match ty.kind() {
+        ty::TyKind::Param(_) => true,
+        ty::TyKind::Adt(_, args) => args.iter().any(|arg| match arg.kind() {
+            ty::GenericArgKind::Type(ty) => ty_contains_param(ty),
+            _ => false,
+        }),
+        ty::TyKind::RawPtr(inner, _)
+        | ty::TyKind::Ref(_, inner, _)
+        | ty::TyKind::Array(inner, _)
+        | ty::TyKind::Slice(inner) => ty_contains_param(*inner),
+        ty::TyKind::Tuple(elems) => elems.iter().any(ty_contains_param),
+        _ => false,
+    }
+}
+
 fn hir_is_null_ptr_constructor(expr: &hir::Expr<'_>) -> bool {
     let hir::ExprKind::Call(callee, args) = hir_unwrap_casts(expr).kind else {
         return false;
@@ -5095,7 +6027,8 @@ fn hir_supports_scalar_box_allocator_root<'tcx>(
     lhs_inner_ty: ty::Ty<'tcx>,
     rhs: &hir::Expr<'tcx>,
 ) -> bool {
-    let expected_ty_name = mir_ty_to_string(lhs_inner_ty, tcx);
+    let expected_ty_name =
+        (!ty_contains_param(lhs_inner_ty)).then(|| mir_ty_to_string(lhs_inner_ty, tcx));
     let hir::ExprKind::Call(_, args) = hir_unwrap_casts(rhs).kind else {
         return false;
     };
@@ -5105,18 +6038,24 @@ fn hir_supports_scalar_box_allocator_root<'tcx>(
     match (name, args) {
         (name, [bytes]) if name == Symbol::intern("malloc") => {
             hir_size_of_call_matches_expected(tcx, bytes, lhs_inner_ty)
-                || hir_is_exact_size_of_expr(tcx, bytes, &expected_ty_name)
+                || expected_ty_name
+                    .as_ref()
+                    .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, bytes, ty_name))
         }
         (name, [count, elem_size]) if name == Symbol::intern("calloc") => {
             hir_is_literal_one(tcx, count)
                 && (hir_size_of_call_matches_expected(tcx, elem_size, lhs_inner_ty)
-                    || hir_is_exact_size_of_expr(tcx, elem_size, &expected_ty_name))
+                    || expected_ty_name
+                        .as_ref()
+                        .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, elem_size, ty_name)))
         }
         (name, [ptr, bytes])
             if name == Symbol::intern("realloc") && hir_is_null_like_ptr_arg(tcx, ptr) =>
         {
             hir_size_of_call_matches_expected(tcx, bytes, lhs_inner_ty)
-                || hir_is_exact_size_of_expr(tcx, bytes, &expected_ty_name)
+                || expected_ty_name
+                    .as_ref()
+                    .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, bytes, ty_name))
         }
         _ => false,
     }
@@ -5687,7 +6626,7 @@ fn downgrade_conflicting_local_struct_call_inputs<'tcx>(
                 {
                     continue;
                 }
-                sig_dec.input_decs[idx] = Some(PtrKind::Raw(true));
+                sig_dec.set_input_dec(idx, Some(PtrKind::Raw(true)));
                 bindings.insert(param_hir_id);
                 changed = true;
             }
@@ -6046,9 +6985,43 @@ fn force_signature_input_raw_for_binding(
     if sig_dec.signature_locked {
         return false;
     }
-    if !matches!(sig_dec.input_decs.get(idx), Some(Some(PtrKind::Raw(_)))) {
-        sig_dec.input_decs[idx] = Some(PtrKind::Raw(true));
+    let raw_mut = unwrap_ptr_from_mir_ty(tcx.typeck(hir_id.owner).node_type(hir_id))
+        .map(|(_, mutability)| mutability.is_mut())
+        .unwrap_or(true);
+    let decision = match sig_dec.input_decs.get(idx).copied().flatten() {
+        Some(raw @ PtrKind::Raw(_)) => Some(raw),
+        _ => Some(PtrKind::Raw(raw_mut)),
+    };
+    if sig_dec.input_decs.get(idx).copied().flatten() == decision {
+        return false;
     }
+    sig_dec.set_input_dec(idx, decision);
+    true
+}
+
+fn force_signature_output_raw(
+    tcx: TyCtxt<'_>,
+    sig_decs: &mut SigDecisions,
+    did: LocalDefId,
+) -> bool {
+    let Some(sig_dec) = sig_decs.data.get_mut(&did) else {
+        return false;
+    };
+    if sig_dec.signature_locked {
+        return false;
+    }
+    let output_mut = sig_dec
+        .output_dec
+        .map(|kind| kind.is_mut())
+        .or_else(|| {
+            let sig = tcx.fn_sig(did).skip_binder().skip_binder();
+            let ty::TyKind::RawPtr(_, mutability) = sig.output().kind() else {
+                return None;
+            };
+            Some(mutability.is_mut())
+        })
+        .unwrap_or(true);
+    sig_dec.set_output_dec(Some(PtrKind::Raw(output_mut)));
     true
 }
 
@@ -6322,13 +7295,215 @@ fn downgrade_unsupported_box_inputs(
             if local_raw_param_summaries.get(&(*did, idx))
                 != Some(&LocalRawParamSummary::BorrowOnly)
             {
-                sig_dec.input_decs[idx] = Some(PtrKind::Raw(kind.is_mut()));
+                sig_dec.set_input_dec(idx, Some(PtrKind::Raw(kind.is_mut())));
                 bindings.insert(hir_id);
                 changed = true;
             }
         }
     }
     (changed, bindings)
+}
+
+fn downgrade_freed_borrow_outputs(
+    tcx: TyCtxt<'_>,
+    sig_decs: &mut SigDecisions,
+    free_like_wrappers: &FxHashSet<LocalDefId>,
+) -> bool {
+    struct FreedBorrowOutputVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        free_like_wrappers: &'a FxHashSet<LocalDefId>,
+        call_results: FxHashMap<HirId, LocalDefId>,
+        freed_locals: FxHashSet<HirId>,
+        freed_call_results: FxHashSet<LocalDefId>,
+    }
+
+    impl<'tcx> FreedBorrowOutputVisitor<'_, 'tcx> {
+        fn record_call_result(&mut self, hir_id: HirId, expr: &'tcx hir::Expr<'tcx>) {
+            let Some(callee_did) = hir_called_local_fn(self.tcx, expr) else {
+                return;
+            };
+            self.call_results.insert(hir_id, callee_did);
+        }
+
+        fn record_freed_call_result(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+            let is_direct_free = hir_call_matches_foreign_name(self.tcx, expr, "free");
+            let is_wrapper_free = hir_called_local_fn(self.tcx, expr)
+                .is_some_and(|def_id| self.free_like_wrappers.contains(&def_id));
+            if !is_direct_free && !is_wrapper_free {
+                return;
+            }
+            let hir::ExprKind::Call(_, args) = expr.kind else {
+                return;
+            };
+            let [arg] = args else { return };
+            if let Some(callee_did) = hir_called_local_fn(self.tcx, hir_unwrap_casts(arg)) {
+                self.freed_call_results.insert(callee_did);
+            }
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for FreedBorrowOutputVisitor<'_, 'tcx> {
+        fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) -> Self::Result {
+            if let hir::StmtKind::Let(let_stmt) = stmt.kind
+                && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
+                && let Some(init) = let_stmt.init
+            {
+                self.record_call_result(hir_id, init);
+            }
+            intravisit::walk_stmt(self, stmt);
+        }
+
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            if let hir::ExprKind::Assign(lhs, rhs, _) = expr.kind
+                && let Some(hir_id) = hir_unwrapped_local_id(lhs)
+            {
+                self.record_call_result(hir_id, rhs);
+            }
+            if let Some((hir_id, _)) =
+                hir_free_like_arg_local_id(self.tcx, expr, self.free_like_wrappers)
+            {
+                self.freed_locals.insert(hir_id);
+            } else {
+                self.record_freed_call_result(expr);
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut callees_to_raw = FxHashSet::default();
+    for maybe_owner in tcx.hir_crate(()).owners.iter() {
+        let Some(owner) = maybe_owner.as_owner() else {
+            continue;
+        };
+        let hir::OwnerNode::Item(item) = owner.node() else {
+            continue;
+        };
+        let hir::ItemKind::Fn { body, .. } = item.kind else {
+            continue;
+        };
+        let body = tcx.hir_body(body);
+        let mut visitor = FreedBorrowOutputVisitor {
+            tcx,
+            free_like_wrappers,
+            call_results: FxHashMap::default(),
+            freed_locals: FxHashSet::default(),
+            freed_call_results: FxHashSet::default(),
+        };
+        visitor.visit_body(body);
+        for freed_local in visitor.freed_locals {
+            if let Some(callee_did) = visitor.call_results.get(&freed_local) {
+                callees_to_raw.insert(*callee_did);
+            }
+        }
+        callees_to_raw.extend(visitor.freed_call_results);
+    }
+
+    let mut changed = false;
+    for callee_did in callees_to_raw {
+        let Some(sig_dec) = sig_decs.data.get_mut(&callee_did) else {
+            continue;
+        };
+        if sig_dec.signature_locked {
+            continue;
+        }
+        let Some(output_kind) = sig_dec.output_dec else {
+            continue;
+        };
+        if !is_borrow_like_decision(output_kind) && !output_kind.is_owning_box_like() {
+            continue;
+        }
+        let output_lifetime = sig_dec.output_lifetime;
+        sig_dec.set_output_dec(Some(PtrKind::Raw(output_kind.is_mut())));
+        if let Some(output_lifetime) = output_lifetime {
+            for idx in 0..sig_dec.input_decs.len() {
+                if sig_dec.input_lifetimes.get(idx).copied().flatten() != Some(output_lifetime) {
+                    continue;
+                }
+                let Some(input_kind) = sig_dec.input_decs[idx] else {
+                    continue;
+                };
+                if is_borrow_like_decision(input_kind) {
+                    sig_dec.set_input_dec(idx, Some(PtrKind::Raw(input_kind.is_mut())));
+                }
+            }
+        } else if output_kind.is_owning_box_like() {
+            for idx in 0..sig_dec.input_decs.len() {
+                let Some(input_kind) = sig_dec.input_decs[idx] else {
+                    continue;
+                };
+                sig_dec.set_input_dec(idx, Some(PtrKind::Raw(input_kind.is_mut())));
+            }
+        }
+        changed = true;
+    }
+    changed
+}
+
+fn downgrade_raw_cast_call_inputs(tcx: TyCtxt<'_>, sig_decs: &mut SigDecisions) -> bool {
+    struct RawCastCallVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        sig_decs: &'a mut SigDecisions,
+        changed: bool,
+    }
+
+    impl<'tcx> Visitor<'tcx> for RawCastCallVisitor<'_, 'tcx> {
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            let hir::ExprKind::Call(_, args) = expr.kind else {
+                intravisit::walk_expr(self, expr);
+                return;
+            };
+            let Some(callee_did) = hir_called_local_fn(self.tcx, expr) else {
+                intravisit::walk_expr(self, expr);
+                return;
+            };
+            let typeck = self.tcx.typeck(expr.hir_id.owner);
+            let Some(sig_dec) = self.sig_decs.data.get_mut(&callee_did) else {
+                intravisit::walk_expr(self, expr);
+                return;
+            };
+            if sig_dec.signature_locked {
+                intravisit::walk_expr(self, expr);
+                return;
+            }
+            for (idx, arg) in args.iter().enumerate() {
+                let Some((_, mutability)) = unwrap_ptr_from_mir_ty(typeck.expr_ty_adjusted(arg))
+                else {
+                    continue;
+                };
+                if hir_casted_pointer_local_source(self.tcx, typeck, arg).is_none() {
+                    continue;
+                }
+                let raw = PtrKind::Raw(mutability.is_mut());
+                if sig_dec.input_decs.get(idx).copied().flatten() != Some(raw) {
+                    sig_dec.set_input_dec(idx, Some(raw));
+                    self.changed = true;
+                }
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut changed = false;
+    for maybe_owner in tcx.hir_crate(()).owners.iter() {
+        let Some(owner) = maybe_owner.as_owner() else {
+            continue;
+        };
+        let hir::OwnerNode::Item(item) = owner.node() else {
+            continue;
+        };
+        let hir::ItemKind::Fn { body, .. } = item.kind else {
+            continue;
+        };
+        let body = tcx.hir_body(body);
+        let mut visitor = RawCastCallVisitor {
+            tcx,
+            sig_decs,
+            changed: false,
+        };
+        visitor.visit_body(body);
+        changed |= visitor.changed;
+    }
+    changed
 }
 
 fn downgrade_unsupported_box_outputs<'tcx>(
@@ -6365,7 +7540,7 @@ fn downgrade_unsupported_box_outputs<'tcx>(
     let changed = !to_raw.is_empty();
     for did in to_raw {
         if let Some(sig_dec) = sig_decs.data.get_mut(&did) {
-            sig_dec.output_dec = Some(PtrKind::Raw(true));
+            sig_dec.set_output_dec(Some(PtrKind::Raw(true)));
         }
     }
     changed
@@ -6629,6 +7804,18 @@ fn hir_unwrapped_local_id(expr: &hir::Expr<'_>) -> Option<HirId> {
     Some(hir_id)
 }
 
+fn hir_path_source_kind(
+    tcx: TyCtxt<'_>,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    expr: &hir::Expr<'_>,
+) -> Option<PtrKind> {
+    let hir_id = hir_unwrapped_local_id(expr)?;
+    ptr_kinds.get(&hir_id).copied().or_else(|| {
+        unwrap_ptr_from_mir_ty(tcx.typeck(hir_id.owner).node_type(hir_id))
+            .map(|(_, mutability)| PtrKind::Raw(mutability.is_mut()))
+    })
+}
+
 fn hir_local_ids_in_expr(expr: &hir::Expr<'_>) -> Vec<HirId> {
     struct LocalUseVisitor {
         locals: Vec<HirId>,
@@ -6881,7 +8068,7 @@ fn hir_wrapper_scalar_dag_status<'tcx>(
                 return WrapperScalarDagStatus::Rejected;
             }
             let mut status = hir_wrapper_scalar_dag_status(ctx, receiver, visiting, depth + 1);
-            for arg in args {
+            for arg in args.iter() {
                 status = combine_wrapper_scalar_dag_status(
                     status,
                     hir_wrapper_scalar_dag_status(ctx, arg, visiting, depth + 1),
@@ -6950,6 +8137,9 @@ fn raw_array_len_expr_from_bytes<'tcx>(
     bytes: &hir::Expr<'_>,
 ) -> Option<String> {
     let bytes = hir_expr_verbatim_snippet(tcx, hir_unwrap_casts(bytes))?;
+    if ty_contains_param(lhs_inner_ty) {
+        return None;
+    }
     let ty = mir_ty_to_string(lhs_inner_ty, tcx);
     Some(format!(
         "((({bytes}) as usize) / std::mem::size_of::<{ty}>())"
@@ -6977,10 +8167,13 @@ fn raw_bridge_info_from_call<'tcx>(
     if !ty_supports_raw_bridge_default_expr(tcx, lhs_inner_ty) {
         return None;
     }
-    let ty_name = mir_ty_to_string(lhs_inner_ty, tcx);
+    let ty_name = (!ty_contains_param(lhs_inner_ty)).then(|| mir_ty_to_string(lhs_inner_ty, tcx));
     match (name, args) {
         (name, [bytes]) if name == Symbol::intern("malloc") => {
-            if hir_is_exact_size_of_expr(tcx, bytes, &ty_name) {
+            if ty_name
+                .as_ref()
+                .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, bytes, ty_name))
+            {
                 Some(RawBridgeInfo::Scalar)
             } else if scalar_arg_rejected(bytes) {
                 None
@@ -6990,12 +8183,17 @@ fn raw_bridge_info_from_call<'tcx>(
             }
         }
         (name, [count, elem_size]) if name == Symbol::intern("calloc") => {
-            if hir_is_literal_one(tcx, count) && hir_is_exact_size_of_expr(tcx, elem_size, &ty_name)
+            if hir_is_literal_one(tcx, count)
+                && ty_name
+                    .as_ref()
+                    .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, elem_size, ty_name))
             {
                 Some(RawBridgeInfo::Scalar)
             } else if scalar_arg_rejected(count) || scalar_arg_rejected(elem_size) {
                 None
-            } else if hir_is_exact_size_of_expr(tcx, count, &ty_name)
+            } else if ty_name
+                .as_ref()
+                .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, count, ty_name))
                 || (byte_sized_elem && hir_is_exact_c_char_size_of_expr(tcx, count))
             {
                 if byte_sized_elem {
@@ -7014,7 +8212,10 @@ fn raw_bridge_info_from_call<'tcx>(
         (name, [ptr, bytes])
             if name == Symbol::intern("realloc") && hir_is_null_like_ptr_arg(tcx, ptr) =>
         {
-            if hir_is_exact_size_of_expr(tcx, bytes, &ty_name) {
+            if ty_name
+                .as_ref()
+                .is_some_and(|ty_name| hir_is_exact_size_of_expr(tcx, bytes, ty_name))
+            {
                 Some(RawBridgeInfo::Scalar)
             } else if scalar_arg_rejected(bytes) {
                 None
@@ -8341,6 +9542,22 @@ fn collect_raw_local_assignment_bindings(
     }
 
     impl<'tcx> Visitor<'tcx> for RawLocalBindingVisitor<'_, 'tcx> {
+        fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) -> Self::Result {
+            if let hir::StmtKind::Let(let_stmt) = stmt.kind
+                && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
+                && let Some(init) = let_stmt.init
+                && self.tcx.typeck(hir_id.owner).node_type(hir_id).is_raw_ptr()
+                && let Some(rhs_hir_id) =
+                    hir_casted_pointer_local_source(self.tcx, self.tcx.typeck(hir_id.owner), init)
+            {
+                self.bindings.insert(hir_id);
+                if raw_pointer_binding_is_const(self.tcx, rhs_hir_id) {
+                    self.bindings.insert(rhs_hir_id);
+                }
+            }
+            intravisit::walk_stmt(self, stmt);
+        }
+
         fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
             if let hir::ExprKind::Assign(lhs, rhs, _) = expr.kind
                 && let hir::ExprKind::Path(hir::QPath::Resolved(_, lhs_path)) = lhs.kind
@@ -8383,6 +9600,33 @@ fn collect_raw_local_assignment_bindings(
         bindings.extend(visitor.bindings);
     }
     bindings
+}
+
+fn hir_casted_pointer_local_source<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    typeck: &rustc_middle::ty::TypeckResults<'tcx>,
+    expr: &hir::Expr<'tcx>,
+) -> Option<HirId> {
+    match expr.kind {
+        hir::ExprKind::Cast(inner, _) | hir::ExprKind::DropTemps(inner) => {
+            if let Some(hir_id) = hir_unwrapped_local_id(inner)
+                && let Some((source_inner_ty, _)) =
+                    unwrap_ptr_from_mir_ty(tcx.typeck(hir_id.owner).node_type(hir_id))
+                && let Some((target_inner_ty, _)) =
+                    unwrap_ptr_from_mir_ty(typeck.expr_ty_adjusted(expr))
+                && source_inner_ty == target_inner_ty
+            {
+                return Some(hir_id);
+            }
+            hir_casted_pointer_local_source(tcx, typeck, inner)
+        }
+        _ => None,
+    }
+}
+
+fn raw_pointer_binding_is_const(tcx: TyCtxt<'_>, hir_id: HirId) -> bool {
+    unwrap_ptr_from_mir_ty(tcx.typeck(hir_id.owner).node_type(hir_id))
+        .is_some_and(|(_, mutability)| !mutability.is_mut())
 }
 
 fn hir_deref_addr_of_local(expr: &hir::Expr<'_>) -> Option<HirId> {
@@ -8707,6 +9951,737 @@ fn collect_unsupported_box_usage_bindings(
     bindings
 }
 
+fn collect_demoted_promoted_fields(
+    tcx: TyCtxt<'_>,
+    analysis: &Analysis,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+) -> FxHashSet<StructFieldSlot> {
+    let mut promoted_fields = analysis.borrow_promotion_result.mutable_fields.clone();
+    promoted_fields.extend(
+        analysis
+            .borrow_promotion_result
+            .shared_fields
+            .iter()
+            .copied(),
+    );
+    if promoted_fields.is_empty() {
+        return FxHashSet::default();
+    }
+    let mut demoted_fields = collect_struct_shape_demoted_fields(
+        tcx,
+        &promoted_fields,
+        &analysis.borrow_promotion_result.mutable_fields,
+        sig_decs,
+        ptr_kinds,
+    );
+
+    struct FieldBorrowConflictVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        typeck: &'tcx rustc_middle::ty::TypeckResults<'tcx>,
+        sig_decs: &'a SigDecisions,
+        promoted_fields: &'a FxHashSet<StructFieldSlot>,
+        mutable_fields: &'a FxHashSet<StructFieldSlot>,
+        allocator_locals: FxHashSet<HirId>,
+        active_borrows: FxHashMap<HirId, FxHashMap<StructFieldSlot, bool>>,
+        ignored_borrow_exprs: FxHashSet<HirId>,
+        demoted_fields: FxHashSet<StructFieldSlot>,
+    }
+
+    impl<'tcx> FieldBorrowConflictVisitor<'_, 'tcx> {
+        fn record_field_borrow(&mut self, field: StructFieldSlot, rhs: &'tcx hir::Expr<'tcx>) {
+            if !self.promoted_fields.contains(&field) {
+                return;
+            }
+            let Some((local, new_mut)) = hir_raw_addr_local(rhs) else {
+                return;
+            };
+            self.ignored_borrow_exprs.insert(rhs.hir_id);
+            let fields = self.active_borrows.entry(local).or_default();
+            if !fields.is_empty() && (new_mut || fields.values().any(|existing_mut| *existing_mut))
+            {
+                self.demoted_fields.extend(fields.keys().copied());
+                self.demoted_fields.insert(field);
+            }
+            fields.insert(field, new_mut);
+        }
+
+        fn record_local_assignment(&mut self, lhs: &'tcx hir::Expr<'tcx>) {
+            let Some(local) = hir_unwrapped_local_id(lhs) else {
+                return;
+            };
+            if let Some(fields) = self.active_borrows.get(&local) {
+                self.demoted_fields.extend(fields.keys().copied());
+            }
+        }
+
+        fn record_conflicting_reborrow(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+            if self.ignored_borrow_exprs.contains(&expr.hir_id) {
+                return;
+            }
+            let Some((local, new_mut)) = hir_addr_local(expr) else {
+                return;
+            };
+            if let Some(fields) = self.active_borrows.get(&local)
+                && (new_mut || fields.values().any(|existing_mut| *existing_mut))
+            {
+                self.demoted_fields.extend(fields.keys().copied());
+            }
+        }
+
+        fn clear_field_borrow(&mut self, field: StructFieldSlot) {
+            for fields in self.active_borrows.values_mut() {
+                fields.remove(&field);
+            }
+        }
+
+        fn record_mutable_field_copy_to_slot(
+            &mut self,
+            lhs_field: StructFieldSlot,
+            rhs: &'tcx hir::Expr<'tcx>,
+        ) {
+            if !self.promoted_fields.contains(&lhs_field) {
+                return;
+            }
+            let Some(rhs_field) = hir_struct_field_slot(self.tcx, rhs) else {
+                return;
+            };
+            if !self.mutable_fields.contains(&rhs_field) {
+                return;
+            }
+            self.demoted_fields.insert(lhs_field);
+            self.demoted_fields.insert(rhs_field);
+        }
+
+        fn promoted_field_slots_in_expr(
+            &self,
+            expr: &'tcx hir::Expr<'tcx>,
+        ) -> FxHashSet<StructFieldSlot> {
+            struct FieldUseVisitor<'a, 'tcx> {
+                tcx: TyCtxt<'tcx>,
+                promoted_fields: &'a FxHashSet<StructFieldSlot>,
+                fields: FxHashSet<StructFieldSlot>,
+            }
+
+            impl<'tcx> Visitor<'tcx> for FieldUseVisitor<'_, 'tcx> {
+                fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+                    if let Some(field) = hir_struct_field_slot(self.tcx, expr)
+                        && self.promoted_fields.contains(&field)
+                    {
+                        self.fields.insert(field);
+                    }
+                    intravisit::walk_expr(self, expr);
+                }
+            }
+
+            let mut visitor = FieldUseVisitor {
+                tcx: self.tcx,
+                promoted_fields: self.promoted_fields,
+                fields: FxHashSet::default(),
+            };
+            visitor.visit_expr(expr);
+            visitor.fields
+        }
+
+        fn demote_promoted_fields_in_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+            self.demoted_fields
+                .extend(self.promoted_field_slots_in_expr(expr));
+        }
+
+        fn demote_moved_mutable_fields_from_raw_pointee_arg(
+            &mut self,
+            expr: &'tcx hir::Expr<'tcx>,
+        ) {
+            struct RawPointeeFieldMoveVisitor<'a, 'tcx> {
+                tcx: TyCtxt<'tcx>,
+                typeck: &'tcx rustc_middle::ty::TypeckResults<'tcx>,
+                promoted_fields: &'a FxHashSet<StructFieldSlot>,
+                mutable_fields: &'a FxHashSet<StructFieldSlot>,
+                demoted_fields: FxHashSet<StructFieldSlot>,
+            }
+
+            impl<'tcx> RawPointeeFieldMoveVisitor<'_, 'tcx> {
+                fn expr_contains_raw_deref(&self, expr: &'tcx hir::Expr<'tcx>) -> bool {
+                    struct RawDerefVisitor<'a, 'tcx> {
+                        typeck: &'a rustc_middle::ty::TypeckResults<'tcx>,
+                        found: bool,
+                    }
+
+                    impl<'tcx> Visitor<'tcx> for RawDerefVisitor<'_, 'tcx> {
+                        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+                            if self.found {
+                                return;
+                            }
+                            if let hir::ExprKind::Unary(hir::UnOp::Deref, inner) = expr.kind
+                                && self.typeck.expr_ty(inner).is_raw_ptr()
+                            {
+                                self.found = true;
+                                return;
+                            }
+                            intravisit::walk_expr(self, expr);
+                        }
+                    }
+
+                    let mut visitor = RawDerefVisitor {
+                        typeck: self.typeck,
+                        found: false,
+                    };
+                    visitor.visit_expr(expr);
+                    visitor.found
+                }
+            }
+
+            impl<'tcx> Visitor<'tcx> for RawPointeeFieldMoveVisitor<'_, 'tcx> {
+                fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+                    if let Some(field) = hir_struct_field_slot(self.tcx, expr)
+                        && self.promoted_fields.contains(&field)
+                        && self.mutable_fields.contains(&field)
+                        && let hir::ExprKind::Field(base, _) = expr.kind
+                        && self.expr_contains_raw_deref(base)
+                    {
+                        self.demoted_fields.insert(field);
+                    }
+                    intravisit::walk_expr(self, expr);
+                }
+            }
+
+            let mut visitor = RawPointeeFieldMoveVisitor {
+                tcx: self.tcx,
+                typeck: self.typeck,
+                promoted_fields: self.promoted_fields,
+                mutable_fields: self.mutable_fields,
+                demoted_fields: FxHashSet::default(),
+            };
+            visitor.visit_expr(expr);
+            self.demoted_fields.extend(visitor.demoted_fields);
+        }
+
+        fn expr_contains_allocator_call(&self, expr: &'tcx hir::Expr<'tcx>) -> bool {
+            struct AllocCallVisitor {
+                found: bool,
+            }
+
+            impl<'tcx> Visitor<'tcx> for AllocCallVisitor {
+                fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+                    if self.found {
+                        return;
+                    }
+                    if matches!(
+                        hir_call_name(expr),
+                        Some(name)
+                            if name == Symbol::intern("malloc")
+                                || name == Symbol::intern("calloc")
+                                || name == Symbol::intern("realloc")
+                    ) {
+                        self.found = true;
+                        return;
+                    }
+                    intravisit::walk_expr(self, expr);
+                }
+            }
+
+            let mut visitor = AllocCallVisitor { found: false };
+            visitor.visit_expr(expr);
+            visitor.found
+        }
+
+        fn expr_is_null_constructor(&self, expr: &'tcx hir::Expr<'tcx>) -> bool {
+            matches!(
+                hir_call_name(expr),
+                Some(name)
+                    if name == Symbol::intern("null") || name == Symbol::intern("null_mut")
+            )
+        }
+
+        fn expr_is_allocator_root_source(&self, expr: &'tcx hir::Expr<'tcx>) -> bool {
+            self.expr_contains_allocator_call(expr)
+                || hir_unwrapped_local_id(expr)
+                    .is_some_and(|hir_id| self.allocator_locals.contains(&hir_id))
+        }
+
+        fn expr_requires_raw_field_storage(&self, expr: &'tcx hir::Expr<'tcx>) -> bool {
+            if self.expr_is_null_constructor(expr) || hir_raw_addr_local(expr).is_some() {
+                return false;
+            }
+            if self.expr_is_allocator_root_source(expr) {
+                return true;
+            }
+            unwrap_ptr_from_mir_ty(self.typeck.expr_ty_adjusted(expr)).is_some()
+        }
+
+        fn record_allocator_binding(&mut self, hir_id: HirId, expr: &'tcx hir::Expr<'tcx>) {
+            if self.expr_contains_allocator_call(expr)
+                || hir_unwrapped_local_id(expr)
+                    .is_some_and(|rhs_id| self.allocator_locals.contains(&rhs_id))
+            {
+                self.allocator_locals.insert(hir_id);
+            }
+        }
+
+        fn record_raw_field_storage(&mut self, field: StructFieldSlot, rhs: &'tcx hir::Expr<'tcx>) {
+            if self.promoted_fields.contains(&field) && self.expr_requires_raw_field_storage(rhs) {
+                self.demoted_fields.insert(field);
+            }
+        }
+
+        fn record_raw_field_binding(&mut self, binding_hir_id: HirId, init: &'tcx hir::Expr<'tcx>) {
+            self.record_allocator_binding(binding_hir_id, init);
+            if unwrap_ptr_from_mir_ty(self.typeck.node_type(binding_hir_id)).is_none() {
+                return;
+            }
+            self.demote_promoted_fields_in_expr(init);
+        }
+
+        fn record_raw_field_call(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+            let hir::ExprKind::Call(_, args) = hir_unwrap_casts(expr).kind else {
+                return;
+            };
+            for arg in args.iter() {
+                self.demote_moved_mutable_fields_from_raw_pointee_arg(arg);
+            }
+            if let Some(callee_did) = hir_called_local_fn(self.tcx, expr)
+                && let Some(sig_dec) = self.sig_decs.data.get(&callee_did)
+            {
+                for (arg_index, arg) in args.iter().enumerate() {
+                    if matches!(
+                        sig_dec.input_decs.get(arg_index).copied().flatten(),
+                        Some(PtrKind::Raw(_) | PtrKind::Slice(_) | PtrKind::SliceCursor(_))
+                    ) {
+                        self.demote_promoted_fields_in_expr(arg);
+                    }
+                }
+                return;
+            }
+            for arg in args.iter() {
+                self.demote_promoted_fields_in_expr(arg);
+            }
+        }
+
+        fn record_mutable_field_copy(
+            &mut self,
+            lhs: &'tcx hir::Expr<'tcx>,
+            rhs: &'tcx hir::Expr<'tcx>,
+        ) {
+            let Some(lhs_field) = hir_struct_field_slot(self.tcx, lhs) else {
+                return;
+            };
+            self.record_mutable_field_copy_to_slot(lhs_field, rhs);
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for FieldBorrowConflictVisitor<'_, 'tcx> {
+        fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) -> Self::Result {
+            if let hir::StmtKind::Let(let_stmt) = stmt.kind
+                && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
+                && let Some(init) = let_stmt.init
+            {
+                self.record_raw_field_binding(hir_id, init);
+            }
+            intravisit::walk_stmt(self, stmt);
+        }
+
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            self.record_conflicting_reborrow(expr);
+            match expr.kind {
+                hir::ExprKind::Struct(qpath, fields, _) => {
+                    if let Some(struct_did) = hir_local_struct_did_from_qpath(qpath) {
+                        for field in fields {
+                            if let Some(field_index) =
+                                hir_field_index_by_name(self.tcx, struct_did, field.ident.name)
+                            {
+                                let field_slot = StructFieldSlot {
+                                    struct_did,
+                                    field_index,
+                                };
+                                self.record_mutable_field_copy_to_slot(field_slot, field.expr);
+                                self.record_field_borrow(field_slot, field.expr);
+                                self.record_raw_field_storage(field_slot, field.expr);
+                            }
+                        }
+                    }
+                }
+                hir::ExprKind::Assign(lhs, rhs, _) => {
+                    if let Some(lhs_hir_id) = hir_unwrapped_local_id(lhs) {
+                        self.record_allocator_binding(lhs_hir_id, rhs);
+                    }
+                    self.record_mutable_field_copy(lhs, rhs);
+                    self.record_local_assignment(lhs);
+                    if let Some(field) = hir_struct_field_slot(self.tcx, lhs) {
+                        self.clear_field_borrow(field);
+                        self.record_field_borrow(field, rhs);
+                        self.record_raw_field_storage(field, rhs);
+                    }
+                }
+                hir::ExprKind::AssignOp(_, lhs, _) => {
+                    self.record_local_assignment(lhs);
+                }
+                hir::ExprKind::Call(_, _) => self.record_raw_field_call(expr),
+                _ => {}
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    for_each_hir_fn_body(tcx, |body, typeck| {
+        let mut visitor = FieldBorrowConflictVisitor {
+            tcx,
+            typeck,
+            sig_decs,
+            promoted_fields: &promoted_fields,
+            mutable_fields: &analysis.borrow_promotion_result.mutable_fields,
+            allocator_locals: FxHashSet::default(),
+            active_borrows: FxHashMap::default(),
+            ignored_borrow_exprs: FxHashSet::default(),
+            demoted_fields: FxHashSet::default(),
+        };
+        visitor.visit_body(body);
+        demoted_fields.extend(visitor.demoted_fields);
+    });
+
+    demoted_fields
+}
+
+fn for_each_hir_fn_body<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    mut f: impl FnMut(&'tcx hir::Body<'tcx>, &'tcx rustc_middle::ty::TypeckResults<'tcx>),
+) {
+    for maybe_owner in tcx.hir_crate(()).owners.iter() {
+        let Some(owner) = maybe_owner.as_owner() else {
+            continue;
+        };
+        let body_id = match owner.node() {
+            hir::OwnerNode::Item(item) => match item.kind {
+                hir::ItemKind::Fn { body, .. } => body,
+                _ => continue,
+            },
+            hir::OwnerNode::ImplItem(item) => match item.kind {
+                hir::ImplItemKind::Fn(_, body) => body,
+                _ => continue,
+            },
+            _ => continue,
+        };
+        let body = tcx.hir_body(body_id);
+        f(body, tcx.typeck_body(body.id()));
+    }
+}
+
+fn collect_raw_field_source_bindings(
+    tcx: TyCtxt<'_>,
+    analysis: &Analysis,
+    demoted_fields: &FxHashSet<StructFieldSlot>,
+) -> (FxHashSet<HirId>, FxHashSet<LocalDefId>) {
+    let mut promoted_fields = analysis.borrow_promotion_result.mutable_fields.clone();
+    promoted_fields.extend(
+        analysis
+            .borrow_promotion_result
+            .shared_fields
+            .iter()
+            .copied(),
+    );
+
+    struct DemotedFieldSourceVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        typeck: &'tcx rustc_middle::ty::TypeckResults<'tcx>,
+        promoted_fields: &'a FxHashSet<StructFieldSlot>,
+        demoted_fields: &'a FxHashSet<StructFieldSlot>,
+        bindings: FxHashSet<HirId>,
+        callees: FxHashSet<LocalDefId>,
+    }
+
+    impl<'tcx> DemotedFieldSourceVisitor<'_, 'tcx> {
+        fn field_stays_raw(&self, field: StructFieldSlot) -> bool {
+            if self.demoted_fields.contains(&field) {
+                return true;
+            }
+            if self.promoted_fields.contains(&field) {
+                return false;
+            }
+            hir_field_is_raw_ptr(self.tcx, field)
+        }
+
+        fn record_rhs(&mut self, rhs: &'tcx hir::Expr<'tcx>) {
+            if let Some(callee_did) = hir_called_local_fn(self.tcx, rhs)
+                && self.typeck.expr_ty_adjusted(rhs).is_raw_ptr()
+            {
+                self.callees.insert(callee_did);
+            }
+            if let Some(hir_id) = hir_unwrapped_local_id(rhs)
+                && unwrap_ptr_from_mir_ty(self.tcx.typeck(hir_id.owner).node_type(hir_id)).is_some()
+            {
+                self.bindings.insert(hir_id);
+            }
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for DemotedFieldSourceVisitor<'_, 'tcx> {
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            match expr.kind {
+                hir::ExprKind::Struct(qpath, fields, _) => {
+                    if let Some(struct_did) = hir_local_struct_did_from_qpath(qpath)
+                        .or_else(|| hir_local_struct_did_from_ty(self.typeck.expr_ty(expr)))
+                    {
+                        for field in fields {
+                            if let Some(field_index) =
+                                hir_field_index_by_name(self.tcx, struct_did, field.ident.name)
+                            {
+                                let slot = StructFieldSlot {
+                                    struct_did,
+                                    field_index,
+                                };
+                                if self.field_stays_raw(slot) {
+                                    self.record_rhs(field.expr);
+                                }
+                            }
+                        }
+                    }
+                }
+                hir::ExprKind::Assign(lhs, rhs, _) => {
+                    if let Some(slot) = hir_struct_field_slot(self.tcx, lhs)
+                        && self.field_stays_raw(slot)
+                    {
+                        self.record_rhs(rhs);
+                    }
+                }
+                _ => {}
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut bindings = FxHashSet::default();
+    let mut callees = FxHashSet::default();
+    for_each_hir_fn_body(tcx, |body, typeck| {
+        let mut visitor = DemotedFieldSourceVisitor {
+            tcx,
+            typeck,
+            promoted_fields: &promoted_fields,
+            demoted_fields,
+            bindings: FxHashSet::default(),
+            callees: FxHashSet::default(),
+        };
+        visitor.visit_body(body);
+        bindings.extend(visitor.bindings);
+        callees.extend(visitor.callees);
+    });
+    (bindings, callees)
+}
+
+fn collect_struct_shape_demoted_fields(
+    tcx: TyCtxt<'_>,
+    promoted_fields: &FxHashSet<StructFieldSlot>,
+    mutable_fields: &FxHashSet<StructFieldSlot>,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+) -> FxHashSet<StructFieldSlot> {
+    let mut demoted = FxHashSet::default();
+
+    for &field in promoted_fields {
+        if !struct_has_named_fields(tcx, field.struct_did)
+            || (mutable_fields.contains(&field) && struct_has_copy_impl(tcx, field.struct_did))
+        {
+            demoted.insert(field);
+        }
+    }
+
+    for did in tcx.hir_crate(()).owners.iter().filter_map(|owner| {
+        let owner = owner.as_owner()?;
+        match owner.node() {
+            hir::OwnerNode::Item(item) => {
+                matches!(item.kind, hir::ItemKind::Fn { .. }).then_some(item.owner_id.def_id)
+            }
+            hir::OwnerNode::ForeignItem(item) => {
+                matches!(item.kind, hir::ForeignItemKind::Fn(..)).then_some(item.owner_id.def_id)
+            }
+            _ => None,
+        }
+    }) {
+        let sig = tcx.fn_sig(did).skip_binder().skip_binder();
+        if signature_output_rewrites_to_owning(tcx, sig_decs, ptr_kinds, did, sig.output()) {
+            continue;
+        }
+        collect_promoted_fields_in_by_value_ty(tcx, sig.output(), promoted_fields, &mut demoted);
+    }
+
+    demoted
+}
+
+fn signature_output_rewrites_to_owning<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    did: LocalDefId,
+    output_ty: ty::Ty<'tcx>,
+) -> bool {
+    let Some(output_dec) = sig_decs.data.get(&did).and_then(|sig| sig.output_dec) else {
+        return false;
+    };
+    if !output_dec.is_owning_box_like() {
+        return false;
+    }
+    let Some((inner_ty, _)) = unwrap_ptr_from_mir_ty(output_ty) else {
+        return false;
+    };
+    !fn_tail_returns_unsupported_box_binding(tcx, sig_decs, ptr_kinds, did, output_dec, inner_ty)
+}
+
+fn struct_has_named_fields(tcx: TyCtxt<'_>, did: LocalDefId) -> bool {
+    let hir::Node::Item(item) = tcx.hir_node_by_def_id(did) else {
+        return false;
+    };
+    let hir::ItemKind::Struct(_, _, variant_data) = item.kind else {
+        return false;
+    };
+    matches!(variant_data, hir::VariantData::Struct { .. })
+}
+
+fn struct_has_copy_impl(tcx: TyCtxt<'_>, struct_did: LocalDefId) -> bool {
+    tcx.hir_crate(()).owners.iter().any(|owner| {
+        let Some(owner) = owner.as_owner() else {
+            return false;
+        };
+        let hir::OwnerNode::Item(item) = owner.node() else {
+            return false;
+        };
+        let hir::ItemKind::Impl(impl_) = item.kind else {
+            return false;
+        };
+        let Some(of_trait) = impl_.of_trait else {
+            return false;
+        };
+        if !of_trait
+            .path
+            .segments
+            .last()
+            .is_some_and(|seg| seg.ident.name.as_str() == "Copy")
+        {
+            return false;
+        }
+        let hir::TyKind::Path(qpath) = impl_.self_ty.kind else {
+            return false;
+        };
+        hir_local_struct_did_from_qpath(&qpath) == Some(struct_did)
+    })
+}
+
+fn collect_promoted_fields_in_by_value_ty(
+    tcx: TyCtxt<'_>,
+    ty: ty::Ty<'_>,
+    promoted_fields: &FxHashSet<StructFieldSlot>,
+    demoted: &mut FxHashSet<StructFieldSlot>,
+) {
+    match ty.kind() {
+        ty::TyKind::RawPtr(inner, _) | ty::TyKind::Ref(_, inner, _) => {
+            collect_promoted_fields_in_by_value_ty(tcx, *inner, promoted_fields, demoted);
+        }
+        ty::TyKind::Adt(adt_def, args) => {
+            if adt_def.did().is_local() && adt_def.is_struct() && !adt_def.is_union() {
+                let struct_did = adt_def.did().expect_local();
+                demoted.extend(
+                    promoted_fields
+                        .iter()
+                        .copied()
+                        .filter(|field| field.struct_did == struct_did),
+                );
+            }
+            for arg in args.iter() {
+                if let ty::GenericArgKind::Type(ty) = arg.kind() {
+                    collect_promoted_fields_in_by_value_ty(tcx, ty, promoted_fields, demoted);
+                }
+            }
+        }
+        ty::TyKind::Tuple(tys) => {
+            for ty in tys.iter() {
+                collect_promoted_fields_in_by_value_ty(tcx, ty, promoted_fields, demoted);
+            }
+        }
+        ty::TyKind::Array(ty, _) | ty::TyKind::Slice(ty) => {
+            collect_promoted_fields_in_by_value_ty(tcx, *ty, promoted_fields, demoted);
+        }
+        _ => {}
+    }
+}
+
+fn hir_raw_addr_local(expr: &hir::Expr<'_>) -> Option<(HirId, bool)> {
+    let expr = hir_unwrap_casts(expr);
+    let hir::ExprKind::AddrOf(hir::BorrowKind::Raw, mutability, pointee) = expr.kind else {
+        return None;
+    };
+    Some((hir_unwrapped_local_id(pointee)?, mutability.is_mut()))
+}
+
+fn hir_addr_local(expr: &hir::Expr<'_>) -> Option<(HirId, bool)> {
+    let expr = hir_unwrap_casts(expr);
+    let hir::ExprKind::AddrOf(_, mutability, pointee) = expr.kind else {
+        return None;
+    };
+    Some((hir_unwrapped_local_id(pointee)?, mutability.is_mut()))
+}
+
+fn hir_struct_field_slot(tcx: TyCtxt<'_>, hir_expr: &hir::Expr<'_>) -> Option<StructFieldSlot> {
+    let hir::ExprKind::Field(base, ident) = hir_expr.kind else {
+        return None;
+    };
+    let typeck = tcx.typeck(hir_expr.hir_id.owner);
+    let struct_did = hir_local_struct_did_from_ty(typeck.expr_ty_adjusted(base))?;
+    let field_index = hir_field_index_by_name(tcx, struct_did, ident.name)?;
+    Some(StructFieldSlot {
+        struct_did,
+        field_index,
+    })
+}
+
+fn hir_field_base_local_id(hir_expr: &hir::Expr<'_>) -> Option<HirId> {
+    let hir::ExprKind::Field(base, _) = hir_expr.kind else {
+        return None;
+    };
+    hir_unwrapped_local_id(base)
+}
+
+fn hir_local_struct_did_from_qpath(qpath: &hir::QPath<'_>) -> Option<LocalDefId> {
+    let hir::QPath::Resolved(_, path) = qpath else {
+        return None;
+    };
+    let Res::Def(DefKind::Struct, def_id) = path.res else {
+        return None;
+    };
+    def_id.as_local()
+}
+
+fn hir_local_struct_did_from_ty(ty: ty::Ty<'_>) -> Option<LocalDefId> {
+    match ty.kind() {
+        ty::TyKind::Adt(adt_def, _) if adt_def.did().is_local() && adt_def.is_struct() => {
+            Some(adt_def.did().expect_local())
+        }
+        ty::TyKind::Ref(_, inner, _) => hir_local_struct_did_from_ty(*inner),
+        _ => None,
+    }
+}
+
+fn hir_field_index_by_name(
+    tcx: TyCtxt<'_>,
+    struct_did: LocalDefId,
+    field_name: Symbol,
+) -> Option<usize> {
+    tcx.adt_def(struct_did)
+        .non_enum_variant()
+        .fields
+        .iter_enumerated()
+        .find_map(|(field_index, field)| (field.name == field_name).then_some(field_index.index()))
+}
+
+fn hir_field_is_raw_ptr(tcx: TyCtxt<'_>, field: StructFieldSlot) -> bool {
+    let hir::Node::Item(item) = tcx.hir_node_by_def_id(field.struct_did) else {
+        return false;
+    };
+    let hir::ItemKind::Struct(_, _, variant_data) = item.kind else {
+        return false;
+    };
+    variant_data
+        .fields()
+        .get(field.field_index)
+        .is_some_and(|field_def| matches!(field_def.ty.kind, hir::TyKind::Ptr(_)))
+}
+
 fn downgrade_unsupported_allocator_box_kinds(
     tcx: TyCtxt<'_>,
     ptr_kinds: &FxHashMap<HirId, PtrKind>,
@@ -8853,6 +10828,18 @@ fn is_slice_ref_expr(expr: &Expr) -> bool {
     )
 }
 
+fn opt_ref_receiver_should_borrow(expr: &Expr) -> bool {
+    match &unwrap_paren(expr).kind {
+        ExprKind::Path(..) | ExprKind::Field(..) | ExprKind::Index(..) => true,
+        ExprKind::MethodCall(call)
+            if matches!(call.seg.ident.name.as_str(), "as_deref" | "as_deref_mut") =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
 fn hoist_opt_ref_borrow(expr: &mut Expr) {
     let mut visitor = OptRefBorrowVisitor::default();
     visitor.visit_expr(expr);
@@ -8876,6 +10863,37 @@ fn hoist_opt_ref_borrow(expr: &mut Expr) {
         visitor.visit_expr(expr);
         *expr = utils::expr!("{{ {lets} {} }}", pprust::expr_to_string(expr))
     }
+}
+
+fn use_moving_opt_ref_unwraps_for_return(expr: &mut Expr) {
+    struct ReturnOptRefUnwrapVisitor;
+
+    impl mut_visit::MutVisitor for ReturnOptRefUnwrapVisitor {
+        fn visit_expr(&mut self, expr: &mut Expr) {
+            mut_visit::walk_expr(self, expr);
+            let ExprKind::MethodCall(call) = &mut unwrap_paren_mut(expr).kind else {
+                return;
+            };
+            if call.seg.ident.name != rustc_span::sym::unwrap {
+                return;
+            }
+            let ExprKind::MethodCall(receiver_call) =
+                &mut unwrap_paren_mut(&mut call.receiver).kind
+            else {
+                return;
+            };
+            if !matches!(
+                receiver_call.seg.ident.name.as_str(),
+                "as_deref" | "as_deref_mut"
+            ) {
+                return;
+            }
+            let receiver = pprust::expr_to_string(&receiver_call.receiver);
+            *expr = utils::expr!("({receiver}).unwrap()");
+        }
+    }
+
+    ReturnOptRefUnwrapVisitor.visit_expr(expr);
 }
 
 #[derive(Default)]
@@ -9019,17 +11037,23 @@ mod tests {
         utils::rustc::RustProgram,
     };
 
-    fn synthetic_transform_visitor<'tcx>(tcx: TyCtxt<'tcx>) -> TransformVisitor<'tcx> {
+    fn synthetic_transform_visitor<'tcx>(tcx: TyCtxt<'tcx>) -> TransformVisitor<'static, 'tcx> {
+        let (_, analysis) = build_analysis(tcx);
+        let analysis = Box::leak(Box::new(analysis));
         TransformVisitor {
             tcx,
+            analysis,
             sig_decs: SigDecisions {
                 data: FxHashMap::default(),
             },
+            lifetime_plans: super::super::lifetimes::LifetimePlans::default(),
             ptr_kinds: FxHashMap::default(),
             forced_raw_bindings: FxHashSet::default(),
             raw_bridge_bindings: FxHashMap::default(),
             alloc_wrappers: FxHashMap::default(),
             free_like_wrappers: FxHashSet::default(),
+            demoted_fields: FxHashSet::default(),
+            impl_self_lifetimes: Vec::new(),
             ast_to_hir: AstToHir::default(),
             bytemuck: Cell::new(false),
             slice_cursor: Cell::new(false),
@@ -9093,10 +11117,11 @@ mod tests {
         let mutables = source_var_groups.postprocess_mut_res(&input, &mutability_result);
         let borrow_promotion_result =
             analyses::borrow::mutable_references_no_guarantee(&input, &mutables);
-        let promoted_mut_ref_result =
-            source_var_groups.postprocess_promoted_mut_refs(borrow_promotion_result.mutable_locals);
-        let promoted_shared_ref_result =
-            source_var_groups.postprocess_promoted_mut_refs(borrow_promotion_result.shared_locals);
+        let borrow_lifetime_flows = borrow_promotion_result.lifetime_flows.clone();
+        let promoted_mut_ref_result = source_var_groups
+            .postprocess_promoted_mut_refs(borrow_promotion_result.mutable_locals.clone());
+        let promoted_shared_ref_result = source_var_groups
+            .postprocess_promoted_mut_refs(borrow_promotion_result.shared_locals.clone());
         let fatness_result = analyses::type_qualifier::foster::fatness::fatness_analysis(&input);
         let mut offset_sign_result = analyses::offset_sign::sign::offset_sign_analysis(&input);
         offset_sign_result.access_signs =
@@ -9105,6 +11130,8 @@ mod tests {
         nullity_result.non_null_locals =
             source_var_groups.postprocess_non_null_locals(nullity_result.non_null_locals);
         let analysis = super::super::Analysis {
+            borrow_promotion_result,
+            borrow_lifetime_flows,
             promoted_mut_ref_result,
             promoted_shared_ref_result,
             mutability_result,
@@ -9734,7 +11761,9 @@ mod tests {
     fn analyze_pointer_safety_for_program(tcx: TyCtxt<'_>) -> PointerSafetyAnalysisResult {
         let (input, analysis) = build_analysis(tcx);
         let tracked_sites = collect_semantic_allocator_sites(tcx, &input);
-        let initial_ptr_kinds = collect_diffs(&input, &analysis);
+        let lifetime_plans = super::super::lifetimes::LifetimePlans::new(&input, &analysis);
+        let sig_decs = SigDecisions::new(&input, &analysis, &lifetime_plans);
+        let initial_ptr_kinds = collect_diffs(&input, &analysis, &sig_decs);
         let (_sig_decs, final_ptr_kinds, _reason_map, _usage_subreason_map) =
             simulate_transform_reasons(tcx, &input, &analysis);
 
@@ -9902,8 +11931,9 @@ mod tests {
         FxHashMap<HirId, Vec<&'static str>>,
         FxHashMap<HirId, Vec<&'static str>>,
     ) {
-        let mut sig_decs = SigDecisions::new(input, analysis);
-        let mut ptr_kinds = collect_diffs(input, analysis);
+        let lifetime_plans = super::super::lifetimes::LifetimePlans::new(input, analysis);
+        let mut sig_decs = SigDecisions::new(input, analysis, &lifetime_plans);
+        let mut ptr_kinds = collect_diffs(input, analysis, &sig_decs);
         let free_like_wrappers = collect_local_free_wrappers(tcx);
         let local_raw_free_summaries = collect_local_raw_free_summaries(tcx, &free_like_wrappers);
         let local_raw_param_summaries =
@@ -9932,6 +11962,9 @@ mod tests {
                 changed = true;
             }
             if downgrade_unsupported_box_outputs(tcx, &mut sig_decs, &ptr_kinds) {
+                changed = true;
+            }
+            if downgrade_freed_borrow_outputs(tcx, &mut sig_decs, &free_like_wrappers) {
                 changed = true;
             }
 
@@ -10608,7 +12641,9 @@ pub unsafe fn drive(mut ctx: *mut Ctx) {
                 consume_did,
                 SigDecision {
                     input_decs: vec![Some(PtrKind::Raw(true)), Some(PtrKind::OptRef(false))],
+                    input_lifetimes: vec![None, None],
                     output_dec: None,
+                    output_lifetime: None,
                     signature_locked: false,
                 },
             );
@@ -10616,7 +12651,9 @@ pub unsafe fn drive(mut ctx: *mut Ctx) {
                 drive_did,
                 SigDecision {
                     input_decs: vec![Some(PtrKind::OptRef(true))],
+                    input_lifetimes: vec![None],
                     output_dec: None,
+                    output_lifetime: None,
                     signature_locked: false,
                 },
             );
@@ -10642,7 +12679,9 @@ pub unsafe fn drive(mut ctx: *mut Ctx) {
                 consume_did,
                 SigDecision {
                     input_decs: vec![Some(PtrKind::Slice(true)), Some(PtrKind::OptRef(false))],
+                    input_lifetimes: vec![None, None],
                     output_dec: None,
+                    output_lifetime: None,
                     signature_locked: false,
                 },
             );
@@ -10650,7 +12689,9 @@ pub unsafe fn drive(mut ctx: *mut Ctx) {
                 drive_did,
                 SigDecision {
                     input_decs: vec![Some(PtrKind::OptRef(true))],
+                    input_lifetimes: vec![None],
                     output_dec: None,
+                    output_lifetime: None,
                     signature_locked: false,
                 },
             );
@@ -10666,6 +12707,46 @@ pub unsafe fn drive(mut ctx: *mut Ctx) {
                 sig_decs.data[&drive_did].input_decs[0],
                 Some(PtrKind::Raw(true))
             );
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn force_signature_input_raw_for_binding_clears_input_lifetime() {
+        let code = r#"
+pub unsafe fn id(x: *mut i32) -> *mut i32 {
+    x
+}
+"#;
+
+        ::utils::compilation::run_compiler_on_str(code, |tcx| {
+            let did = find_fn_did(tcx, "id");
+            let x_hir_id = find_param_hir_id(tcx, "id", "x");
+            let lifetime = Symbol::intern("a");
+            let mut sig_decs = SigDecisions {
+                data: FxHashMap::default(),
+            };
+            sig_decs.data.insert(
+                did,
+                SigDecision {
+                    input_decs: vec![Some(PtrKind::OptRef(true))],
+                    input_lifetimes: vec![Some(lifetime)],
+                    output_dec: Some(PtrKind::OptRef(true)),
+                    output_lifetime: Some(lifetime),
+                    signature_locked: false,
+                },
+            );
+
+            assert!(force_signature_input_raw_for_binding(
+                tcx,
+                &mut sig_decs,
+                x_hir_id,
+            ));
+
+            let sig_dec = &sig_decs.data[&did];
+            assert_eq!(sig_dec.input_decs[0], Some(PtrKind::Raw(true)));
+            assert_eq!(sig_dec.input_lifetimes[0], None);
+            assert_eq!(sig_dec.output_lifetime, Some(lifetime));
         })
         .unwrap();
     }

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -104,7 +104,7 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                 let Some(struct_did) = self.local_struct_did_for_ast_ty(&impl_item.self_ty) else {
                     return;
                 };
-                if !self.struct_has_field_promotion_candidate(struct_did) {
+                if !self.struct_has_field_rewrite_candidate(struct_did) {
                     return;
                 }
                 let lifetimes = self.ordered_struct_lifetimes(struct_did);
@@ -418,7 +418,8 @@ impl MutVisitor for TransformVisitor<'_, '_> {
 
         if let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx)
             && let hir::PatKind::Binding(_, hir_id, _ident, _) = let_stmt.pat.kind
-            && self.local_binding_needs_mut_for_promoted_field_write(hir_id)
+            && (self.local_binding_needs_mut_for_promoted_field_write(hir_id)
+                || self.local_binding_needs_mut_for_owned_field_free(hir_id))
             && let PatKind::Ident(binding_mode, ..) = &mut local.pat.kind
         {
             binding_mode.1 = Mutability::Mut;
@@ -516,7 +517,7 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                     panic!("{hir_expr:?}")
                 };
                 if let Some(field) = self.promoted_field_slot_for_hir_field(hir_lhs)
-                    && let Some(kind) = self.promoted_field_kind(field)
+                    && let Some(kind) = self.field_ptr_kind(field)
                 {
                     let target_inner_ty =
                         unwrap_ptr_from_mir_ty(typeck.expr_ty(hir_lhs)).map(|(inner, _)| inner);
@@ -672,6 +673,11 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                 };
                 let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
 
+                if let Some(free_rewrite) = self.rewrite_direct_free_call(hir_expr, &args[..]) {
+                    *expr = free_rewrite;
+                    return;
+                }
+
                 for (i, (arg, harg)) in args.iter_mut().zip(hargs).enumerate() {
                     let ty = typeck.expr_ty_adjusted(harg);
                     let param_kind = sig_dec
@@ -692,7 +698,7 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                             == Some(PtrKind::OptRef(true))
                             || self
                                 .promoted_field_slot_for_hir_field(harg)
-                                .and_then(|field| self.promoted_field_kind(field))
+                                .and_then(|field| self.field_ptr_kind(field))
                                 == Some(PtrKind::OptRef(true)))
                     {
                         *arg = P(utils::expr!(
@@ -700,11 +706,6 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                             pprust::expr_to_string(arg)
                         ));
                     }
-                }
-
-                if let Some(free_rewrite) = self.rewrite_direct_free_call(hir_expr, &args[..]) {
-                    *expr = free_rewrite;
-                    return;
                 }
 
                 hoist_opt_ref_borrow(expr);
@@ -831,7 +832,7 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                 };
                 if let Some(m) = m {
                     if let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
-                        && let Some(kind) = self.promoted_field_kind(field)
+                        && let Some(kind) = self.field_ptr_kind(field)
                     {
                         let field_str = pprust::expr_to_string(e);
                         *expr = match kind {
@@ -842,6 +843,12 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                                 utils::expr!("*({field_str}).as_deref().unwrap()")
                             }
                             PtrKind::OptRef(false) => utils::expr!("*({field_str}.unwrap())"),
+                            PtrKind::OptBox if m => {
+                                utils::expr!("*({field_str}).as_deref_mut().unwrap()")
+                            }
+                            PtrKind::OptBox => {
+                                utils::expr!("*({field_str}).as_deref().unwrap()")
+                            }
                             _ => unreachable!(),
                         };
                         return;
@@ -969,6 +976,18 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             if downgrade_raw_cast_call_inputs(rust_program.tcx, &mut sig_decs, &ptr_kinds) {
                 changed = true;
             }
+            let owned_field_free_bindings = collect_owned_field_free_owner_bindings(
+                rust_program.tcx,
+                analysis,
+                &sig_decs,
+                &ptr_kinds,
+                &free_like_wrappers,
+            );
+            for hir_id in owned_field_free_bindings {
+                if force_signature_input_mut_for_binding(rust_program.tcx, &mut sig_decs, hir_id) {
+                    changed = true;
+                }
+            }
             let raw_call_result_bindings =
                 collect_raw_call_result_bindings(rust_program.tcx, &sig_decs, &ptr_kinds);
             let raw_local_assignment_bindings =
@@ -1026,7 +1045,13 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             &demoted_fields,
         );
         let (demoted_field_source_bindings, raw_field_source_callees) =
-            collect_raw_field_source_bindings(rust_program.tcx, analysis, &demoted_fields);
+            collect_raw_field_source_bindings(
+                rust_program.tcx,
+                analysis,
+                &sig_decs,
+                &ptr_kinds,
+                &demoted_fields,
+            );
         let mut sig_changed = false;
         for hir_id in &demoted_field_source_bindings {
             sig_changed |=
@@ -1040,6 +1065,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             ptr_kinds = collect_diffs(rust_program, analysis, &sig_decs);
         }
         normalize_forced_raw_bindings(rust_program.tcx, &mut ptr_kinds, &forced_raw_bindings);
+        emit_ownership_field_diagnostics(rust_program.tcx, analysis, &sig_decs, &ptr_kinds);
         let raw_bridge_bindings = collect_raw_bridge_bindings(
             rust_program.tcx,
             &ptr_kinds,
@@ -1064,6 +1090,24 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             bytemuck: Cell::new(false),
             slice_cursor: Cell::new(false),
         }
+    }
+
+    fn field_ptr_kind(&self, field: StructFieldSlot) -> Option<PtrKind> {
+        if scalar_owning_raw_field_inner_ty(self.tcx, self.analysis, field).is_some() {
+            self.ownership_field_kind(field)
+        } else {
+            self.promoted_field_kind(field)
+        }
+    }
+
+    fn ownership_field_kind(&self, field: StructFieldSlot) -> Option<PtrKind> {
+        ownership_field_ptr_kind(
+            self.tcx,
+            self.analysis,
+            &self.sig_decs,
+            &self.ptr_kinds,
+            field,
+        )
     }
 
     fn promoted_field_kind(&self, field: StructFieldSlot) -> Option<PtrKind> {
@@ -1136,15 +1180,31 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         self.analysis
             .struct_copy_result
             .should_remove_generated_impl(struct_did)
+            || self.struct_has_owning_box_field_candidate(struct_did)
     }
 
-    fn struct_has_field_promotion_candidate(&self, struct_did: LocalDefId) -> bool {
+    fn struct_has_field_rewrite_candidate(&self, struct_did: LocalDefId) -> bool {
         self.analysis
             .borrow_promotion_result
             .mutable_fields
             .iter()
             .chain(self.analysis.borrow_promotion_result.shared_fields.iter())
             .any(|field| field.struct_did == struct_did)
+            || self.struct_has_owning_box_field_candidate(struct_did)
+    }
+
+    fn struct_has_owning_box_field_candidate(&self, struct_did: LocalDefId) -> bool {
+        self.tcx
+            .adt_def(struct_did)
+            .non_enum_variant()
+            .fields
+            .iter_enumerated()
+            .any(|(field_index, _)| {
+                self.ownership_field_kind(StructFieldSlot {
+                    struct_did,
+                    field_index: field_index.index(),
+                }) == Some(PtrKind::OptBox)
+            })
     }
 
     fn ordered_struct_lifetimes(&self, struct_did: LocalDefId) -> Vec<Symbol> {
@@ -1173,33 +1233,36 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         fields: &mut ThinVec<FieldDef>,
     ) {
         let lifetimes = self.ordered_struct_lifetimes(struct_did);
-        if lifetimes.is_empty() {
-            return;
+        if !lifetimes.is_empty() {
+            super::lifetimes::ensure_lifetime_params(generics, &lifetimes);
         }
-        super::lifetimes::ensure_lifetime_params(generics, &lifetimes);
 
         for (field_index, field_def) in fields.iter_mut().enumerate() {
             let field = StructFieldSlot {
                 struct_did,
                 field_index,
             };
-            let Some(kind) = self.promoted_field_kind(field) else {
-                continue;
-            };
-            let Some(lifetime) = self.field_lifetime(field) else {
+            let Some(kind) = self.field_ptr_kind(field) else {
                 continue;
             };
             let TyKind::Ptr(mut_ty) = &field_def.ty.kind else {
                 continue;
             };
-            let PtrKind::OptRef(mutability) = kind else {
-                continue;
-            };
-            field_def.ty = P(mk_opt_ref_ast_ty_with_lifetime(
-                self.ast_ty_string_with_promoted_lifetimes(&mut_ty.ty),
-                mutability,
-                lifetime,
-            ));
+            let inner_ty = self.ast_ty_string_with_promoted_lifetimes(&mut_ty.ty);
+            match kind {
+                PtrKind::OptRef(mutability) => {
+                    let Some(lifetime) = self.field_lifetime(field) else {
+                        continue;
+                    };
+                    field_def.ty = P(mk_opt_ref_ast_ty_with_lifetime(
+                        inner_ty, mutability, lifetime,
+                    ));
+                }
+                PtrKind::OptBox => {
+                    field_def.ty = P(utils::ty!("Option<Box<{inner_ty}>>"));
+                }
+                _ => {}
+            }
         }
     }
 
@@ -1368,7 +1431,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             struct_did,
             field_index,
         };
-        self.promoted_field_kind(field).map(|_| field)
+        self.field_ptr_kind(field).map(|_| field)
     }
 
     fn promoted_field_slot_for_ast_field(&self, ast_id: NodeId) -> Option<StructFieldSlot> {
@@ -1385,7 +1448,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             struct_did,
             field_index,
         };
-        self.promoted_field_kind(field).map(|_| field)
+        self.field_ptr_kind(field).map(|_| field)
     }
 
     fn rewrite_struct_literal_fields(&self, expr_id: NodeId, se: &mut StructExpr) {
@@ -1399,7 +1462,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             let Some(field) = self.promoted_field_slot_for_ast_field(ast_field.id) else {
                 continue;
             };
-            let Some(kind) = self.promoted_field_kind(field) else {
+            let Some(kind) = self.field_ptr_kind(field) else {
                 continue;
             };
             let Some(hir_field) = hir_fields
@@ -1823,6 +1886,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         hir_expr: &'tcx hir::Expr<'tcx>,
         args: &[P<Expr>],
     ) -> Option<Expr> {
+        if let Some(field_free) = self.rewrite_owned_field_free_call(hir_expr, args) {
+            return Some(field_free);
+        }
         let (hir_id, _harg) =
             hir_free_like_arg_local_id(self.tcx, hir_expr, &self.free_like_wrappers)?;
         if hir_call_matches_foreign_name(self.tcx, hir_expr, "free")
@@ -1861,6 +1927,32 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 len_expr,
             ),
         })
+    }
+
+    fn rewrite_owned_field_free_call(
+        &self,
+        hir_expr: &'tcx hir::Expr<'tcx>,
+        args: &[P<Expr>],
+    ) -> Option<Expr> {
+        if !hir_call_matches_foreign_name(self.tcx, hir_expr, "free")
+            && !hir_called_local_fn(self.tcx, hir_expr)
+                .is_some_and(|def_id| self.free_like_wrappers.contains(&def_id))
+        {
+            return None;
+        }
+        let hir::ExprKind::Call(_, hir_args) = hir_expr.kind else {
+            return None;
+        };
+        let [hir_arg] = hir_args else { return None };
+        let [arg] = args else { return None };
+        let hir_field = hir_unwrap_casts(hir_arg);
+        let field = hir_struct_field_slot(self.tcx, hir_field)?;
+        if !matches!(self.field_ptr_kind(field), Some(PtrKind::OptBox)) {
+            return None;
+        }
+        let _ = arg;
+        let field_expr = hir_field_access_expr_string(self.tcx, hir_field)?;
+        Some(utils::expr!("drop(({}).take())", field_expr))
     }
 
     fn hir_id_of_path(&self, id: NodeId) -> Option<HirId> {
@@ -2123,8 +2215,8 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     && let Some(field) =
                         self.transform.promoted_field_slot_for_hir_field(field_expr)
                     && matches!(
-                        self.transform.promoted_field_kind(field),
-                        Some(PtrKind::OptRef(true))
+                        self.transform.field_ptr_kind(field),
+                        Some(PtrKind::OptRef(true) | PtrKind::OptBox)
                     )
                 {
                     self.found = true;
@@ -2136,6 +2228,49 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
 
         let body = self.tcx.hir_body_owned_by(target_hir_id.owner.def_id);
         let mut visitor = PromotedFieldWriteVisitor {
+            transform: self,
+            target_hir_id,
+            found: false,
+        };
+        visitor.visit_body(body);
+        visitor.found
+    }
+
+    fn local_binding_needs_mut_for_owned_field_free(&self, target_hir_id: HirId) -> bool {
+        struct OwnedFieldFreeVisitor<'a, 'analysis, 'tcx> {
+            transform: &'a TransformVisitor<'analysis, 'tcx>,
+            target_hir_id: HirId,
+            found: bool,
+        }
+
+        impl<'tcx> Visitor<'tcx> for OwnedFieldFreeVisitor<'_, '_, 'tcx> {
+            fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+                if self.found {
+                    return;
+                }
+                let is_direct_free =
+                    hir_call_matches_foreign_name(self.transform.tcx, expr, "free");
+                let is_wrapper_free = hir_called_local_fn(self.transform.tcx, expr)
+                    .is_some_and(|def_id| self.transform.free_like_wrappers.contains(&def_id));
+                if (is_direct_free || is_wrapper_free)
+                    && let hir::ExprKind::Call(_, args) = expr.kind
+                    && let [arg] = args
+                {
+                    let field_expr = hir_unwrap_casts(arg);
+                    if let Some(field) = hir_struct_field_slot(self.transform.tcx, field_expr)
+                        && self.transform.field_ptr_kind(field) == Some(PtrKind::OptBox)
+                        && hir_projection_root_local_id(field_expr) == Some(self.target_hir_id)
+                    {
+                        self.found = true;
+                        return;
+                    }
+                }
+                intravisit::walk_expr(self, expr);
+            }
+        }
+
+        let body = self.tcx.hir_body_owned_by(target_hir_id.owner.def_id);
+        let mut visitor = OwnedFieldFreeVisitor {
             transform: self,
             target_hir_id,
             found: false,
@@ -2281,13 +2416,13 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         let rhs_ty = typeck.expr_ty(hir_unwrap_cast(hir_ptr));
         if let PtrCtx::Rhs(kind @ PtrKind::OptRef(_)) = ctx
             && let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
-            && self.promoted_field_kind(field) == Some(kind)
+            && self.field_ptr_kind(field) == Some(kind)
         {
             return kind;
         }
         if let PtrCtx::Rhs(PtrKind::Raw(m)) = ctx
             && let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
-            && matches!(self.promoted_field_kind(field), Some(PtrKind::OptRef(_)))
+            && matches!(self.field_ptr_kind(field), Some(PtrKind::OptRef(_)))
             && let Some((lhs_inner_ty, _)) = unwrap_ptr_from_mir_ty(lhs_ty)
         {
             *ptr = self.raw_from_promoted_field_expr(e, m, lhs_inner_ty);
@@ -2429,7 +2564,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         let def_id = hir_ptr.hir_id.owner.def_id;
         if let PtrCtx::Rhs(PtrKind::OptRef(m)) = ctx
             && let Some(field) = self.promoted_field_slot_for_hir_field(hir_e)
-            && let Some(PtrKind::OptRef(source_m)) = self.promoted_field_kind(field)
+            && let Some(PtrKind::OptRef(source_m)) = self.field_ptr_kind(field)
         {
             *ptr = self.opt_ref_from_opt_ref(e, m, source_m, lhs_inner_ty, rhs_inner_ty, def_id);
             return PtrKind::OptRef(m);
@@ -3579,7 +3714,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             return self.effective_ptr_kind(hir_id);
         }
         if let Some(field) = self.promoted_field_slot_for_hir_field(pe.hir_base) {
-            return self.promoted_field_kind(field);
+            return self.field_ptr_kind(field);
         }
         if let hir::ExprKind::Call(func, _) = pe.hir_base.kind
             && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = func.kind
@@ -3635,7 +3770,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                             struct_did,
                             field_index,
                         };
-                        let field_expr = if self.promoted_field_kind(field_slot).is_some() {
+                        let field_expr = if self.field_ptr_kind(field_slot).is_some() {
                             utils::expr!("None")
                         } else {
                             self.default_value_expr(field.ty(self.tcx, args))
@@ -7462,6 +7597,30 @@ fn force_signature_input_raw_for_binding(
     true
 }
 
+fn force_signature_input_mut_for_binding(
+    tcx: TyCtxt<'_>,
+    sig_decs: &mut SigDecisions,
+    hir_id: HirId,
+) -> bool {
+    let Some((did, idx)) = param_index_for_binding(tcx, hir_id) else {
+        return false;
+    };
+    let Some(sig_dec) = sig_decs.data.get_mut(&did) else {
+        return false;
+    };
+    if sig_dec.signature_locked {
+        return false;
+    }
+    let decision = match sig_dec.input_decs.get(idx).copied().flatten() {
+        Some(PtrKind::Ref(false)) => Some(PtrKind::Ref(true)),
+        Some(PtrKind::OptRef(false)) => Some(PtrKind::OptRef(true)),
+        Some(PtrKind::Raw(false)) => Some(PtrKind::Raw(true)),
+        _ => return false,
+    };
+    sig_dec.set_input_dec(idx, decision);
+    true
+}
+
 fn force_signature_output_raw(
     tcx: TyCtxt<'_>,
     sig_decs: &mut SigDecisions,
@@ -10445,6 +10604,65 @@ fn collect_unsupported_box_usage_bindings(
     bindings
 }
 
+fn collect_owned_field_free_owner_bindings(
+    tcx: TyCtxt<'_>,
+    analysis: &Analysis,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    free_like_wrappers: &FxHashSet<LocalDefId>,
+) -> FxHashSet<HirId> {
+    struct OwnedFieldFreeVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        analysis: &'a Analysis,
+        sig_decs: &'a SigDecisions,
+        ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
+        free_like_wrappers: &'a FxHashSet<LocalDefId>,
+        bindings: FxHashSet<HirId>,
+    }
+
+    impl<'tcx> Visitor<'tcx> for OwnedFieldFreeVisitor<'_, 'tcx> {
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            let is_direct_free = hir_call_matches_foreign_name(self.tcx, expr, "free");
+            let is_wrapper_free = hir_called_local_fn(self.tcx, expr)
+                .is_some_and(|def_id| self.free_like_wrappers.contains(&def_id));
+            if (is_direct_free || is_wrapper_free)
+                && let hir::ExprKind::Call(_, args) = expr.kind
+                && let [arg] = args
+            {
+                let field_expr = hir_unwrap_casts(arg);
+                if let Some(field) = hir_struct_field_slot(self.tcx, field_expr)
+                    && ownership_field_ptr_kind(
+                        self.tcx,
+                        self.analysis,
+                        self.sig_decs,
+                        self.ptr_kinds,
+                        field,
+                    ) == Some(PtrKind::OptBox)
+                    && let Some(root) = hir_projection_root_local_id(field_expr)
+                {
+                    self.bindings.insert(root);
+                }
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut bindings = FxHashSet::default();
+    for_each_hir_fn_body(tcx, |body, _typeck| {
+        let mut visitor = OwnedFieldFreeVisitor {
+            tcx,
+            analysis,
+            sig_decs,
+            ptr_kinds,
+            free_like_wrappers,
+            bindings: FxHashSet::default(),
+        };
+        visitor.visit_body(body);
+        bindings.extend(visitor.bindings);
+    });
+    bindings
+}
+
 fn collect_demoted_promoted_fields(
     tcx: TyCtxt<'_>,
     analysis: &Analysis,
@@ -11030,6 +11248,8 @@ fn for_each_hir_fn_body<'tcx>(
 fn collect_raw_field_source_bindings(
     tcx: TyCtxt<'_>,
     analysis: &Analysis,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
     demoted_fields: &FxHashSet<StructFieldSlot>,
 ) -> (FxHashSet<HirId>, FxHashSet<LocalDefId>) {
     let mut promoted_fields = analysis.borrow_promotion_result.mutable_fields.clone();
@@ -11044,6 +11264,9 @@ fn collect_raw_field_source_bindings(
     struct DemotedFieldSourceVisitor<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
         typeck: &'tcx rustc_middle::ty::TypeckResults<'tcx>,
+        analysis: &'a Analysis,
+        sig_decs: &'a SigDecisions,
+        ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
         promoted_fields: &'a FxHashSet<StructFieldSlot>,
         demoted_fields: &'a FxHashSet<StructFieldSlot>,
         bindings: FxHashSet<HirId>,
@@ -11052,6 +11275,27 @@ fn collect_raw_field_source_bindings(
 
     impl<'tcx> DemotedFieldSourceVisitor<'_, 'tcx> {
         fn field_stays_raw(&self, field: StructFieldSlot) -> bool {
+            if scalar_owning_raw_field_inner_ty(self.tcx, self.analysis, field).is_some() {
+                return ownership_field_ptr_kind(
+                    self.tcx,
+                    self.analysis,
+                    self.sig_decs,
+                    self.ptr_kinds,
+                    field,
+                )
+                .is_none();
+            }
+            if ownership_field_ptr_kind(
+                self.tcx,
+                self.analysis,
+                self.sig_decs,
+                self.ptr_kinds,
+                field,
+            )
+            .is_some()
+            {
+                return false;
+            }
             if self.demoted_fields.contains(&field) {
                 return true;
             }
@@ -11116,6 +11360,9 @@ fn collect_raw_field_source_bindings(
         let mut visitor = DemotedFieldSourceVisitor {
             tcx,
             typeck,
+            analysis,
+            sig_decs,
+            ptr_kinds,
             promoted_fields: &promoted_fields,
             demoted_fields,
             bindings: FxHashSet::default(),
@@ -11126,6 +11373,643 @@ fn collect_raw_field_source_bindings(
         callees.extend(visitor.callees);
     });
     (bindings, callees)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum OwnershipFieldBlockReason {
+    NonRawFieldType,
+    NonScalarPointee,
+    CVoidOrFilePointee,
+    UnsupportedStructLiteralRhs,
+    UnsupportedAssignmentRhs,
+    UnsupportedCallRhs,
+    UnsupportedRawLocalSource,
+    AllocatorSizeMismatch,
+    ReallocOrBufferPattern,
+    CStringOrStrFunctionPattern,
+}
+
+impl OwnershipFieldBlockReason {
+    const ALL: [Self; 10] = [
+        Self::NonRawFieldType,
+        Self::NonScalarPointee,
+        Self::CVoidOrFilePointee,
+        Self::UnsupportedStructLiteralRhs,
+        Self::UnsupportedAssignmentRhs,
+        Self::UnsupportedCallRhs,
+        Self::UnsupportedRawLocalSource,
+        Self::AllocatorSizeMismatch,
+        Self::ReallocOrBufferPattern,
+        Self::CStringOrStrFunctionPattern,
+    ];
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NonRawFieldType => "non_raw_field_type",
+            Self::NonScalarPointee => "non_scalar_pointee",
+            Self::CVoidOrFilePointee => "c_void_or_file_pointee",
+            Self::UnsupportedStructLiteralRhs => "unsupported_struct_literal_rhs",
+            Self::UnsupportedAssignmentRhs => "unsupported_assignment_rhs",
+            Self::UnsupportedCallRhs => "unsupported_call_rhs",
+            Self::UnsupportedRawLocalSource => "unsupported_raw_local_source",
+            Self::AllocatorSizeMismatch => "allocator_size_mismatch",
+            Self::ReallocOrBufferPattern => "realloc_or_buffer_pattern",
+            Self::CStringOrStrFunctionPattern => "cstring_or_str_function_pattern",
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct OwnershipFieldDiagnostics {
+    total: usize,
+    selected_opt_box: usize,
+    blocked_total: usize,
+    block_reason_counts: FxHashMap<OwnershipFieldBlockReason, usize>,
+}
+
+impl OwnershipFieldDiagnostics {
+    fn record_blocked(&mut self, reasons: impl IntoIterator<Item = OwnershipFieldBlockReason>) {
+        self.blocked_total += 1;
+        let mut saw_reason = false;
+        for reason in reasons {
+            saw_reason = true;
+            *self.block_reason_counts.entry(reason).or_default() += 1;
+        }
+        if !saw_reason {
+            *self
+                .block_reason_counts
+                .entry(OwnershipFieldBlockReason::UnsupportedAssignmentRhs)
+                .or_default() += 1;
+        }
+    }
+}
+
+fn ownership_field_ptr_kind<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    analysis: &Analysis,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    field: StructFieldSlot,
+) -> Option<PtrKind> {
+    let inner_ty = scalar_owning_raw_field_inner_ty(tcx, analysis, field)?;
+    if field_has_unsupported_opt_box_rhs(tcx, sig_decs, ptr_kinds, field, inner_ty) {
+        return None;
+    }
+    Some(PtrKind::OptBox)
+}
+
+fn scalar_owning_raw_field_inner_ty<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    analysis: &Analysis,
+    field: StructFieldSlot,
+) -> Option<ty::Ty<'tcx>> {
+    owning_struct_field_scalar_inner_ty(tcx, analysis, field)?.ok()
+}
+
+fn owning_struct_field_scalar_inner_ty<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    analysis: &Analysis,
+    field: StructFieldSlot,
+) -> Option<Result<ty::Ty<'tcx>, OwnershipFieldBlockReason>> {
+    if !struct_field_is_exactly_owning(analysis, field) {
+        return None;
+    }
+
+    let struct_ty = tcx.type_of(field.struct_did).skip_binder();
+    let ty::TyKind::Adt(adt_def, args) = struct_ty.kind() else {
+        return Some(Err(OwnershipFieldBlockReason::NonRawFieldType));
+    };
+    let Some(field_ty) = adt_def
+        .all_fields()
+        .nth(field.field_index)
+        .map(|field| field.ty(tcx, args))
+    else {
+        return Some(Err(OwnershipFieldBlockReason::NonRawFieldType));
+    };
+    let ty::TyKind::RawPtr(inner_ty, _) = field_ty.kind() else {
+        return Some(Err(OwnershipFieldBlockReason::NonRawFieldType));
+    };
+    if inner_ty.is_c_void(tcx) || utils::file::contains_file_ty(*inner_ty, tcx) {
+        return Some(Err(OwnershipFieldBlockReason::CVoidOrFilePointee));
+    }
+    if matches!(
+        inner_ty.kind(),
+        ty::TyKind::RawPtr(..) | ty::TyKind::Ref(..) | ty::TyKind::Slice(_) | ty::TyKind::Array(..)
+    ) {
+        return Some(Err(OwnershipFieldBlockReason::NonScalarPointee));
+    }
+    Some(Ok(*inner_ty))
+}
+
+fn struct_field_is_exactly_owning(analysis: &Analysis, field: StructFieldSlot) -> bool {
+    let Some(ownership_schemes) = analysis.ownership_schemes.as_ref() else {
+        return false;
+    };
+    let field_ownership =
+        ownership_schemes.struct_field_result(&field.struct_did.to_def_id(), field.field_index);
+    field_ownership.len() == 1
+        && field_ownership
+            .first()
+            .is_some_and(crate::analyses::ownership::Ownership::is_owning)
+}
+
+fn field_has_unsupported_opt_box_rhs<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    target_field: StructFieldSlot,
+    lhs_inner_ty: ty::Ty<'tcx>,
+) -> bool {
+    struct FieldBoxTargetVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        sig_decs: &'a SigDecisions,
+        ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
+        target_field: StructFieldSlot,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        found_unsupported: bool,
+    }
+
+    impl<'tcx> FieldBoxTargetVisitor<'_, 'tcx> {
+        fn rhs_supported(&self, rhs: &'tcx hir::Expr<'tcx>) -> bool {
+            if hir_rhs_supports_box_target(
+                self.tcx,
+                self.sig_decs,
+                self.ptr_kinds,
+                rhs,
+                PtrKind::OptBox,
+                self.lhs_inner_ty,
+            ) {
+                return true;
+            }
+            hir_unwrapped_local_id(rhs).is_some_and(|hir_id| {
+                matches!(self.ptr_kinds.get(&hir_id), Some(PtrKind::Raw(_)))
+                    && raw_local_has_supported_scalar_box_source(
+                        self.tcx,
+                        self.sig_decs,
+                        self.ptr_kinds,
+                        hir_id,
+                        self.lhs_inner_ty,
+                    )
+            })
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for FieldBoxTargetVisitor<'_, 'tcx> {
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            if self.found_unsupported {
+                return;
+            }
+            match expr.kind {
+                hir::ExprKind::Struct(qpath, fields, _) => {
+                    if let Some(struct_did) = hir_local_struct_did_from_qpath(qpath) {
+                        for field in fields {
+                            if let Some(field_index) =
+                                hir_field_index_by_name(self.tcx, struct_did, field.ident.name)
+                            {
+                                let slot = StructFieldSlot {
+                                    struct_did,
+                                    field_index,
+                                };
+                                if slot == self.target_field && !self.rhs_supported(field.expr) {
+                                    self.found_unsupported = true;
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+                hir::ExprKind::Assign(lhs, rhs, _) => {
+                    if hir_struct_field_slot(self.tcx, lhs) == Some(self.target_field)
+                        && !self.rhs_supported(rhs)
+                    {
+                        self.found_unsupported = true;
+                        return;
+                    }
+                }
+                _ => {}
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut found_unsupported = false;
+    for_each_hir_fn_body(tcx, |body, _typeck| {
+        if found_unsupported {
+            return;
+        }
+        let mut visitor = FieldBoxTargetVisitor {
+            tcx,
+            sig_decs,
+            ptr_kinds,
+            target_field,
+            lhs_inner_ty,
+            found_unsupported: false,
+        };
+        visitor.visit_body(body);
+        found_unsupported |= visitor.found_unsupported;
+    });
+    found_unsupported
+}
+
+fn collect_ownership_field_rhs_block_reasons<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    target_fields: &FxHashMap<StructFieldSlot, ty::Ty<'tcx>>,
+) -> FxHashMap<StructFieldSlot, FxHashSet<OwnershipFieldBlockReason>> {
+    struct FieldBoxTargetVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        sig_decs: &'a SigDecisions,
+        ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
+        target_fields: &'a FxHashMap<StructFieldSlot, ty::Ty<'tcx>>,
+        reasons: FxHashMap<StructFieldSlot, FxHashSet<OwnershipFieldBlockReason>>,
+    }
+
+    impl<'tcx> FieldBoxTargetVisitor<'_, 'tcx> {
+        fn record_rhs(
+            &mut self,
+            field: StructFieldSlot,
+            rhs: &'tcx hir::Expr<'tcx>,
+            fallback: OwnershipFieldBlockReason,
+        ) {
+            let Some(lhs_inner_ty) = self.target_fields.get(&field).copied() else {
+                return;
+            };
+            if let Some(reason) = opt_box_rhs_block_reason(
+                self.tcx,
+                self.sig_decs,
+                self.ptr_kinds,
+                rhs,
+                lhs_inner_ty,
+                fallback,
+            ) {
+                self.reasons.entry(field).or_default().insert(reason);
+            }
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for FieldBoxTargetVisitor<'_, 'tcx> {
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            match expr.kind {
+                hir::ExprKind::Struct(qpath, fields, _) => {
+                    if let Some(struct_did) = hir_local_struct_did_from_qpath(qpath) {
+                        for field in fields {
+                            if let Some(field_index) =
+                                hir_field_index_by_name(self.tcx, struct_did, field.ident.name)
+                            {
+                                let slot = StructFieldSlot {
+                                    struct_did,
+                                    field_index,
+                                };
+                                if self.target_fields.contains_key(&slot) {
+                                    self.record_rhs(
+                                        slot,
+                                        field.expr,
+                                        OwnershipFieldBlockReason::UnsupportedStructLiteralRhs,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                hir::ExprKind::Assign(lhs, rhs, _) => {
+                    if let Some(field) = hir_struct_field_slot(self.tcx, lhs)
+                        && self.target_fields.contains_key(&field)
+                    {
+                        self.record_rhs(
+                            field,
+                            rhs,
+                            OwnershipFieldBlockReason::UnsupportedAssignmentRhs,
+                        );
+                    }
+                }
+                _ => {}
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut reasons: FxHashMap<StructFieldSlot, FxHashSet<OwnershipFieldBlockReason>> =
+        FxHashMap::default();
+    for_each_hir_fn_body(tcx, |body, _typeck| {
+        let mut visitor = FieldBoxTargetVisitor {
+            tcx,
+            sig_decs,
+            ptr_kinds,
+            target_fields,
+            reasons: FxHashMap::default(),
+        };
+        visitor.visit_body(body);
+        for (field, field_reasons) in visitor.reasons {
+            reasons.entry(field).or_default().extend(field_reasons);
+        }
+    });
+    reasons
+}
+
+fn opt_box_rhs_block_reason<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    rhs: &'tcx hir::Expr<'tcx>,
+    lhs_inner_ty: ty::Ty<'tcx>,
+    fallback: OwnershipFieldBlockReason,
+) -> Option<OwnershipFieldBlockReason> {
+    if hir_rhs_supports_box_target(tcx, sig_decs, ptr_kinds, rhs, PtrKind::OptBox, lhs_inner_ty) {
+        return None;
+    }
+    if let Some(hir_id) = hir_unwrapped_local_id(rhs)
+        && matches!(ptr_kinds.get(&hir_id), Some(PtrKind::Raw(_)))
+    {
+        if raw_local_has_supported_scalar_box_source(tcx, sig_decs, ptr_kinds, hir_id, lhs_inner_ty)
+        {
+            return None;
+        }
+        return Some(
+            raw_local_scalar_box_source_block_reason(
+                tcx,
+                sig_decs,
+                ptr_kinds,
+                hir_id,
+                lhs_inner_ty,
+            )
+            .unwrap_or(OwnershipFieldBlockReason::UnsupportedRawLocalSource),
+        );
+    }
+    Some(direct_opt_box_rhs_block_reason(
+        tcx,
+        lhs_inner_ty,
+        rhs,
+        fallback,
+    ))
+}
+
+fn direct_opt_box_rhs_block_reason<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    lhs_inner_ty: ty::Ty<'tcx>,
+    rhs: &'tcx hir::Expr<'tcx>,
+    fallback: OwnershipFieldBlockReason,
+) -> OwnershipFieldBlockReason {
+    let Some(name) = hir_call_name(rhs) else {
+        return fallback;
+    };
+    if call_name_is_cstring_or_str_pattern(name) {
+        return OwnershipFieldBlockReason::CStringOrStrFunctionPattern;
+    }
+    if call_name_is_realloc_or_buffer_pattern(name) {
+        return OwnershipFieldBlockReason::ReallocOrBufferPattern;
+    }
+    if call_name_is_libc_allocator(name)
+        && !hir_supports_scalar_box_allocator_root(tcx, lhs_inner_ty, rhs)
+    {
+        return OwnershipFieldBlockReason::AllocatorSizeMismatch;
+    }
+    OwnershipFieldBlockReason::UnsupportedCallRhs
+}
+
+fn call_name_is_libc_allocator(name: Symbol) -> bool {
+    matches!(name.as_str(), "malloc" | "calloc" | "realloc")
+}
+
+fn call_name_is_realloc_or_buffer_pattern(name: Symbol) -> bool {
+    let name = name.as_str();
+    name.contains("realloc") || name.contains("allocarray")
+}
+
+fn call_name_is_cstring_or_str_pattern(name: Symbol) -> bool {
+    let name = name.as_str();
+    name.starts_with("str") || name.contains("_str") || name.contains("cstr")
+}
+
+fn raw_local_scalar_box_source_block_reason<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    target_hir_id: HirId,
+    lhs_inner_ty: ty::Ty<'tcx>,
+) -> Option<OwnershipFieldBlockReason> {
+    struct LocalSourceReasonVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        sig_decs: &'a SigDecisions,
+        ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
+        target_hir_id: HirId,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        reasons: FxHashSet<OwnershipFieldBlockReason>,
+    }
+
+    impl<'tcx> LocalSourceReasonVisitor<'_, 'tcx> {
+        fn record_source(&mut self, rhs: &'tcx hir::Expr<'tcx>) {
+            if hir_rhs_supports_box_target(
+                self.tcx,
+                self.sig_decs,
+                self.ptr_kinds,
+                rhs,
+                PtrKind::OptBox,
+                self.lhs_inner_ty,
+            ) {
+                return;
+            }
+            self.reasons.insert(direct_opt_box_rhs_block_reason(
+                self.tcx,
+                self.lhs_inner_ty,
+                rhs,
+                OwnershipFieldBlockReason::UnsupportedRawLocalSource,
+            ));
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for LocalSourceReasonVisitor<'_, 'tcx> {
+        fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) -> Self::Result {
+            if let hir::StmtKind::Let(let_stmt) = stmt.kind
+                && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
+                && hir_id == self.target_hir_id
+                && let Some(init) = let_stmt.init
+            {
+                self.record_source(init);
+            }
+            intravisit::walk_stmt(self, stmt);
+        }
+
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            if let hir::ExprKind::Assign(lhs, rhs, _) = expr.kind
+                && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = lhs.kind
+                && path.res == Res::Local(self.target_hir_id)
+            {
+                self.record_source(rhs);
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let body = tcx.hir_body_owned_by(target_hir_id.owner.def_id);
+    let mut visitor = LocalSourceReasonVisitor {
+        tcx,
+        sig_decs,
+        ptr_kinds,
+        target_hir_id,
+        lhs_inner_ty,
+        reasons: FxHashSet::default(),
+    };
+    visitor.visit_body(body);
+    OwnershipFieldBlockReason::ALL
+        .into_iter()
+        .find(|reason| visitor.reasons.contains(reason))
+}
+
+fn raw_local_has_supported_scalar_box_source<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    target_hir_id: HirId,
+    lhs_inner_ty: ty::Ty<'tcx>,
+) -> bool {
+    struct LocalSourceVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        sig_decs: &'a SigDecisions,
+        ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
+        target_hir_id: HirId,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        saw_supported_source: bool,
+        saw_unsupported_source: bool,
+    }
+
+    impl<'tcx> LocalSourceVisitor<'_, 'tcx> {
+        fn record_source(&mut self, rhs: &'tcx hir::Expr<'tcx>) {
+            if hir_rhs_supports_box_target(
+                self.tcx,
+                self.sig_decs,
+                self.ptr_kinds,
+                rhs,
+                PtrKind::OptBox,
+                self.lhs_inner_ty,
+            ) {
+                self.saw_supported_source = true;
+            } else {
+                self.saw_unsupported_source = true;
+            }
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for LocalSourceVisitor<'_, 'tcx> {
+        fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) -> Self::Result {
+            if let hir::StmtKind::Let(let_stmt) = stmt.kind
+                && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
+                && hir_id == self.target_hir_id
+                && let Some(init) = let_stmt.init
+            {
+                self.record_source(init);
+            }
+            intravisit::walk_stmt(self, stmt);
+        }
+
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            if let hir::ExprKind::Assign(lhs, rhs, _) = expr.kind
+                && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = lhs.kind
+                && path.res == Res::Local(self.target_hir_id)
+            {
+                self.record_source(rhs);
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let body = tcx.hir_body_owned_by(target_hir_id.owner.def_id);
+    let mut visitor = LocalSourceVisitor {
+        tcx,
+        sig_decs,
+        ptr_kinds,
+        target_hir_id,
+        lhs_inner_ty,
+        saw_supported_source: false,
+        saw_unsupported_source: false,
+    };
+    visitor.visit_body(body);
+    visitor.saw_supported_source && !visitor.saw_unsupported_source
+}
+
+fn collect_ownership_field_diagnostics<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    analysis: &Analysis,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+) -> OwnershipFieldDiagnostics {
+    let mut diagnostics = OwnershipFieldDiagnostics::default();
+    let mut scalar_fields = FxHashMap::default();
+
+    for maybe_owner in tcx.hir_crate(()).owners.iter() {
+        let Some(owner) = maybe_owner.as_owner() else {
+            continue;
+        };
+        let hir::OwnerNode::Item(item) = owner.node() else {
+            continue;
+        };
+        if !matches!(item.kind, hir::ItemKind::Struct(..)) {
+            continue;
+        }
+        let struct_did = item.owner_id.def_id;
+        let field_count = tcx.adt_def(struct_did).non_enum_variant().fields.len();
+        for field_index in 0..field_count {
+            let field = StructFieldSlot {
+                struct_did,
+                field_index,
+            };
+            let Some(inner_ty) = owning_struct_field_scalar_inner_ty(tcx, analysis, field) else {
+                continue;
+            };
+            diagnostics.total += 1;
+            let inner_ty = match inner_ty {
+                Ok(inner_ty) => inner_ty,
+                Err(reason) => {
+                    diagnostics.record_blocked([reason]);
+                    continue;
+                }
+            };
+            scalar_fields.insert(field, inner_ty);
+        }
+    }
+
+    let block_reasons =
+        collect_ownership_field_rhs_block_reasons(tcx, sig_decs, ptr_kinds, &scalar_fields);
+    for field in scalar_fields.keys().copied() {
+        if let Some(reasons) = block_reasons.get(&field) {
+            if reasons.is_empty() {
+                diagnostics.selected_opt_box += 1;
+            } else {
+                diagnostics.record_blocked(reasons.iter().copied());
+            }
+        } else {
+            diagnostics.selected_opt_box += 1;
+        }
+    }
+
+    diagnostics
+}
+
+fn emit_ownership_field_diagnostics(
+    tcx: TyCtxt<'_>,
+    analysis: &Analysis,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+) {
+    let diagnostics = collect_ownership_field_diagnostics(tcx, analysis, sig_decs, ptr_kinds);
+    eprintln!(
+        "[pointer-ownership-fields] fields total={} selected_opt_box={} blocked={}",
+        diagnostics.total, diagnostics.selected_opt_box, diagnostics.blocked_total,
+    );
+    for reason in OwnershipFieldBlockReason::ALL {
+        let fields = diagnostics
+            .block_reason_counts
+            .get(&reason)
+            .copied()
+            .unwrap_or_default();
+        if fields > 0 {
+            eprintln!(
+                "[pointer-ownership-fields] block reason={} fields={}",
+                reason.as_str(),
+                fields,
+            );
+        }
+    }
 }
 
 fn collect_struct_shape_demoted_fields(
@@ -11537,6 +12421,36 @@ fn hir_field_base_local_id(hir_expr: &hir::Expr<'_>) -> Option<HirId> {
         return None;
     };
     hir_unwrapped_local_id(base)
+}
+
+fn hir_projection_root_local_id(hir_expr: &hir::Expr<'_>) -> Option<HirId> {
+    match hir_unwrap_casts(hir_expr).kind {
+        hir::ExprKind::Path(hir::QPath::Resolved(_, path)) => match path.res {
+            Res::Local(hir_id) => Some(hir_id),
+            _ => None,
+        },
+        hir::ExprKind::Unary(hir::UnOp::Deref, inner) => hir_projection_root_local_id(inner),
+        hir::ExprKind::Field(base, _) => hir_projection_root_local_id(base),
+        _ => None,
+    }
+}
+
+fn hir_field_access_expr_string(tcx: TyCtxt<'_>, hir_expr: &hir::Expr<'_>) -> Option<String> {
+    match hir_unwrap_casts(hir_expr).kind {
+        hir::ExprKind::Path(hir::QPath::Resolved(_, path)) => match path.res {
+            Res::Local(hir_id) => Some(tcx.hir_name(hir_id).to_string()),
+            _ => None,
+        },
+        hir::ExprKind::Unary(hir::UnOp::Deref, inner) => {
+            Some(format!("(*{})", hir_field_access_expr_string(tcx, inner)?))
+        }
+        hir::ExprKind::Field(base, ident) => Some(format!(
+            "{}.{}",
+            hir_field_access_expr_string(tcx, base)?,
+            ident.name
+        )),
+        _ => None,
+    }
 }
 
 fn hir_local_struct_did_from_qpath(qpath: &hir::QPath<'_>) -> Option<LocalDefId> {
@@ -12208,6 +13122,53 @@ pub unsafe fn print_preallocated_like(buffer: *mut State) -> i32 {
                 "expected {expected} in Holder.p conflict reasons: {holder_p:?}; all reasons: {reasons:?}"
             );
         }
+    }
+
+    #[test]
+    fn ownership_field_diagnostics_count_selected_and_blocked_fields() {
+        let diagnostics = ::utils::compilation::run_compiler_on_str(
+            r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+}
+
+#[repr(C)]
+pub struct Good {
+    pub data: *mut i32,
+}
+
+#[repr(C)]
+pub struct Bad {
+    pub data: *mut i32,
+}
+
+pub unsafe fn stash_good(owner: *mut Good) {
+    (*owner).data = malloc(std::mem::size_of::<i32>());
+}
+
+pub unsafe fn stash_bad(owner: *mut Bad) {
+    (*owner).data = malloc(2 * std::mem::size_of::<i32>());
+}
+"#,
+            |tcx| {
+                let (input, analysis) = build_analysis(tcx);
+                let (sig_decs, ptr_kinds, _reason_map, _usage_subreason_map) =
+                    simulate_transform_reasons(tcx, &input, &analysis);
+                collect_ownership_field_diagnostics(tcx, &analysis, &sig_decs, &ptr_kinds)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(diagnostics.total, 2);
+        assert_eq!(diagnostics.selected_opt_box, 1);
+        assert_eq!(diagnostics.blocked_total, 1);
+        assert_eq!(
+            diagnostics
+                .block_reason_counts
+                .get(&OwnershipFieldBlockReason::AllocatorSizeMismatch)
+                .copied(),
+            Some(1),
+        );
     }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -946,7 +946,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             {
                 changed = true;
             }
-            if downgrade_raw_cast_call_inputs(rust_program.tcx, &mut sig_decs) {
+            if downgrade_raw_cast_call_inputs(rust_program.tcx, &mut sig_decs, &ptr_kinds) {
                 changed = true;
             }
             let raw_call_result_bindings =
@@ -6886,6 +6886,10 @@ fn is_mutable_borrow_like_decision(kind: PtrKind) -> bool {
     )
 }
 
+fn is_borrow_bridgeable_source_decision(kind: PtrKind) -> bool {
+    matches!(kind, PtrKind::Raw(_)) || is_borrow_like_decision(kind)
+}
+
 fn arg_may_mutably_borrow(arg_points_to_mutable: bool, decision: Option<PtrKind>) -> bool {
     decision.is_some_and(is_mutable_borrow_like_decision) || arg_points_to_mutable
 }
@@ -7439,10 +7443,15 @@ fn downgrade_freed_borrow_outputs(
     changed
 }
 
-fn downgrade_raw_cast_call_inputs(tcx: TyCtxt<'_>, sig_decs: &mut SigDecisions) -> bool {
+fn downgrade_raw_cast_call_inputs(
+    tcx: TyCtxt<'_>,
+    sig_decs: &mut SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+) -> bool {
     struct RawCastCallVisitor<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
         sig_decs: &'a mut SigDecisions,
+        ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
         changed: bool,
     }
 
@@ -7470,7 +7479,18 @@ fn downgrade_raw_cast_call_inputs(tcx: TyCtxt<'_>, sig_decs: &mut SigDecisions) 
                 else {
                     continue;
                 };
-                if hir_casted_pointer_local_source(self.tcx, typeck, arg).is_none() {
+                let Some(source_hir_id) = hir_casted_pointer_local_source(self.tcx, typeck, arg)
+                else {
+                    continue;
+                };
+                let input_dec = sig_dec.input_decs.get(idx).copied().flatten();
+                if input_dec.is_some_and(is_borrow_like_decision)
+                    && self
+                        .ptr_kinds
+                        .get(&source_hir_id)
+                        .copied()
+                        .is_some_and(is_borrow_bridgeable_source_decision)
+                {
                     continue;
                 }
                 let raw = PtrKind::Raw(mutability.is_mut());
@@ -7498,6 +7518,7 @@ fn downgrade_raw_cast_call_inputs(tcx: TyCtxt<'_>, sig_decs: &mut SigDecisions) 
         let mut visitor = RawCastCallVisitor {
             tcx,
             sig_decs,
+            ptr_kinds,
             changed: false,
         };
         visitor.visit_body(body);
@@ -9550,6 +9571,20 @@ fn collect_raw_local_assignment_bindings(
                 && let Some(rhs_hir_id) =
                     hir_casted_pointer_local_source(self.tcx, self.tcx.typeck(hir_id.owner), init)
             {
+                if self
+                    .ptr_kinds
+                    .get(&hir_id)
+                    .copied()
+                    .is_some_and(is_borrow_like_decision)
+                    && self
+                        .ptr_kinds
+                        .get(&rhs_hir_id)
+                        .copied()
+                        .is_some_and(is_borrow_bridgeable_source_decision)
+                {
+                    intravisit::walk_stmt(self, stmt);
+                    return;
+                }
                 self.bindings.insert(hir_id);
                 if raw_pointer_binding_is_const(self.tcx, rhs_hir_id) {
                     self.bindings.insert(rhs_hir_id);

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -532,10 +532,7 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                 let (lhs_inner_ty, _) = unwrap_ptr_from_mir_ty(lhs_ty).unwrap();
                 let lhs_hir_id = if let ExprKind::Path(_, _) = lhs.kind
                     && let Some(hir_id) = self.hir_id_of_path(lhs.id)
-                    && let ExprKind::Path(_, path) = &lhs.kind
-                    && let Some(seg) = path.segments.last()
                 {
-                    let _ = seg;
                     Some(hir_id)
                 } else {
                     None
@@ -4867,7 +4864,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 "if ({0}).is_null() {{
                     None
                 }} else {{
-                    Some(unsafe {{ Box::from_raw(({0}) as *mut {1}) }})
+                    Some(Box::from_raw(({0}) as *mut {1}))
                 }}",
                 pprust::expr_to_string(e),
                 lhs_ty,
@@ -4879,7 +4876,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     if _x.is_null() {{
                         None
                     }} else {{
-                        Some(unsafe {{ Box::from_raw(_x as *mut {}) }})
+                        Some(Box::from_raw(_x as *mut {}))
                     }}
                 }}",
                 pprust::expr_to_string(e),
@@ -8990,7 +8987,7 @@ fn ty_supports_scalar_box_from_raw_bridge(ty: ty::Ty<'_>) -> bool {
 
 fn scalar_box_from_raw_free_expr(arg_str: &str, inner_ty_str: &str) -> Expr {
     utils::expr!(
-        "{{ let __crat_raw_free = {}; if !(__crat_raw_free).is_null() {{ drop(unsafe {{ Box::from_raw((__crat_raw_free) as *mut {}) }}); }} }}",
+        "{{ let __crat_raw_free = {}; if !(__crat_raw_free).is_null() {{ drop(Box::from_raw((__crat_raw_free) as *mut {})); }} }}",
         arg_str,
         inner_ty_str,
     )
@@ -8998,7 +8995,7 @@ fn scalar_box_from_raw_free_expr(arg_str: &str, inner_ty_str: &str) -> Expr {
 
 fn array_box_from_raw_free_expr(arg_str: &str, inner_ty_str: &str, len_expr: &str) -> Expr {
     utils::expr!(
-        "{{ let __crat_raw_free = {}; if !(__crat_raw_free).is_null() {{ drop(unsafe {{ Box::from_raw(std::ptr::slice_from_raw_parts_mut((__crat_raw_free) as *mut {}, ({}) as usize)) }}); }} }}",
+        "{{ let __crat_raw_free = {}; if !(__crat_raw_free).is_null() {{ drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut((__crat_raw_free) as *mut {}, ({}) as usize))); }} }}",
         arg_str,
         inner_ty_str,
         len_expr,
@@ -12248,6 +12245,11 @@ fn emit_ownership_field_diagnostics(
     sig_decs: &SigDecisions,
     ptr_kinds: &FxHashMap<HirId, PtrKind>,
 ) {
+    let mode = std::env::var("CRAT_POINTER_OWNERSHIP_FIELD_DIAGNOSTICS").ok();
+    if !diagnostics_env_value_enabled(mode.as_deref()) {
+        return;
+    }
+
     let diagnostics = collect_ownership_field_diagnostics(tcx, analysis, sig_decs, ptr_kinds);
     eprintln!(
         "[pointer-ownership-fields] fields total={} selected_opt_box={} blocked={}",
@@ -12267,6 +12269,10 @@ fn emit_ownership_field_diagnostics(
             );
         }
     }
+}
+
+fn diagnostics_env_value_enabled(mode: Option<&str>) -> bool {
+    mode.is_some_and(|mode| !mode.is_empty() && mode != "0" && !mode.eq_ignore_ascii_case("false"))
 }
 
 fn collect_struct_shape_demoted_fields(
@@ -13599,6 +13605,17 @@ pub unsafe fn stash_bad(owner: *mut Bad) {
                 .copied(),
             Some(1),
         );
+    }
+
+    #[test]
+    fn diagnostics_env_value_enabled_requires_truthy_value() {
+        assert!(!diagnostics_env_value_enabled(None));
+        assert!(!diagnostics_env_value_enabled(Some("")));
+        assert!(!diagnostics_env_value_enabled(Some("0")));
+        assert!(!diagnostics_env_value_enabled(Some("false")));
+        assert!(!diagnostics_env_value_enabled(Some("FALSE")));
+        assert!(diagnostics_env_value_enabled(Some("1")));
+        assert!(diagnostics_env_value_enabled(Some("full")));
     }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -997,6 +997,14 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         let alloc_wrappers = collect_local_allocator_wrappers(rust_program.tcx);
         let demoted_fields =
             collect_demoted_promoted_fields(rust_program.tcx, analysis, &sig_decs, &ptr_kinds);
+        emit_promotion_diagnostics(
+            rust_program.tcx,
+            analysis,
+            &lifetime_plans,
+            &sig_decs,
+            &ptr_kinds,
+            &demoted_fields,
+        );
         let (demoted_field_source_bindings, raw_field_source_callees) =
             collect_raw_field_source_bindings(rust_program.tcx, analysis, &demoted_fields);
         let mut sig_changed = false;
@@ -1432,26 +1440,36 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn ty_name(&self, ty: ty::Ty<'tcx>) -> String {
-        self.promoted_mir_ty_name(ty)
+        self.promoted_mir_ty_name(ty, true)
     }
 
-    fn promoted_mir_ty_name(&self, ty: ty::Ty<'tcx>) -> String {
+    fn anonymous_ty_name(&self, ty: ty::Ty<'tcx>) -> String {
+        self.promoted_mir_ty_name(ty, false)
+    }
+
+    fn promoted_mir_ty_name(&self, ty: ty::Ty<'tcx>, use_named_struct_lifetimes: bool) -> String {
         match ty.kind() {
             ty::TyKind::Adt(adt_def, args) => {
                 let mut args = args
                     .iter()
                     .map(|arg| match arg.kind() {
-                        ty::GenericArgKind::Type(ty) => self.promoted_mir_ty_name(ty),
+                        ty::GenericArgKind::Type(ty) => {
+                            self.promoted_mir_ty_name(ty, use_named_struct_lifetimes)
+                        }
                         ty::GenericArgKind::Const(cnst) => cnst.to_string(),
                         ty::GenericArgKind::Lifetime(_) => "'_".to_string(),
                     })
                     .collect::<Vec<_>>();
                 let lifetimes = self.lifetimes_for_ty(ty);
                 if !lifetimes.is_empty() {
-                    let promoted_lifetime_args = lifetimes
-                        .iter()
-                        .map(|lifetime| format!("'{}", lifetime.as_str()))
-                        .collect::<Vec<_>>();
+                    let promoted_lifetime_args = if use_named_struct_lifetimes {
+                        lifetimes
+                            .iter()
+                            .map(|lifetime| format!("'{}", lifetime.as_str()))
+                            .collect::<Vec<_>>()
+                    } else {
+                        std::iter::repeat_n("'_".to_string(), lifetimes.len()).collect::<Vec<_>>()
+                    };
                     let insert_at = self
                         .existing_lifetime_param_count_for_ty(ty)
                         .min(args.len());
@@ -1471,20 +1489,32 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             }
             ty::TyKind::RawPtr(pointee, mutability) => {
                 let m = if mutability.is_mut() { "mut" } else { "const" };
-                format!("*{m} {}", self.promoted_mir_ty_name(*pointee))
+                format!(
+                    "*{m} {}",
+                    self.promoted_mir_ty_name(*pointee, use_named_struct_lifetimes)
+                )
             }
             ty::TyKind::Ref(_, inner, mutability) => {
                 let m = if mutability.is_mut() { "mut " } else { "" };
-                format!("&{m}{}", self.promoted_mir_ty_name(*inner))
+                format!(
+                    "&{m}{}",
+                    self.promoted_mir_ty_name(*inner, use_named_struct_lifetimes)
+                )
             }
             ty::TyKind::Array(elem, len) => {
-                format!("[{}; {len}]", self.promoted_mir_ty_name(*elem))
+                format!(
+                    "[{}; {len}]",
+                    self.promoted_mir_ty_name(*elem, use_named_struct_lifetimes)
+                )
             }
-            ty::TyKind::Slice(elem) => format!("[{}]", self.promoted_mir_ty_name(*elem)),
+            ty::TyKind::Slice(elem) => format!(
+                "[{}]",
+                self.promoted_mir_ty_name(*elem, use_named_struct_lifetimes)
+            ),
             ty::TyKind::Tuple(elems) => {
                 let elems = elems
                     .iter()
-                    .map(|elem| self.promoted_mir_ty_name(elem))
+                    .map(|elem| self.promoted_mir_ty_name(elem, use_named_struct_lifetimes))
                     .collect::<Vec<_>>();
                 format!("({})", elems.join(", "))
             }
@@ -1511,7 +1541,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn mk_ref_ty(&self, ty: ty::Ty<'tcx>, mutability: bool) -> Ty {
-        self.mk_ref_ty_with_lifetime(ty, mutability, None)
+        let ty = self.anonymous_ty_name(ty);
+        let m = if mutability { "mut " } else { "" };
+        utils::ty!("&{m}{ty}")
     }
 
     fn mk_ref_ty_with_lifetime(
@@ -1529,7 +1561,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     }
 
     fn mk_opt_ref_ty(&self, ty: ty::Ty<'tcx>, mutability: bool) -> Ty {
-        self.mk_opt_ref_ty_with_lifetime(ty, mutability, None)
+        let ty = self.anonymous_ty_name(ty);
+        let m = if mutability { "mut " } else { "" };
+        utils::ty!("Option<&{m}{ty}>")
     }
 
     fn mk_opt_ref_ty_with_lifetime(
@@ -10531,13 +10565,143 @@ fn collect_struct_shape_demoted_fields(
         }
     }) {
         let sig = tcx.fn_sig(did).skip_binder().skip_binder();
-        if signature_output_rewrites_to_owning(tcx, sig_decs, ptr_kinds, did, sig.output()) {
+        if signature_output_rewrites_to_owning(tcx, sig_decs, ptr_kinds, did, sig.output())
+            || signature_output_rewrites_to_borrow(sig_decs, did)
+        {
             continue;
         }
         collect_promoted_fields_in_by_value_ty(tcx, sig.output(), promoted_fields, &mut demoted);
     }
 
     demoted
+}
+
+fn emit_promotion_diagnostics(
+    tcx: TyCtxt<'_>,
+    analysis: &Analysis,
+    lifetime_plans: &super::lifetimes::LifetimePlans,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    demoted_fields: &FxHashSet<StructFieldSlot>,
+) {
+    let Ok(mode) = std::env::var("CRAT_POINTER_PROMOTION_DIAGNOSTICS") else {
+        return;
+    };
+    if mode.is_empty() || mode == "0" || mode.eq_ignore_ascii_case("false") {
+        return;
+    }
+
+    let mut promoted_fields = analysis.borrow_promotion_result.mutable_fields.clone();
+    promoted_fields.extend(
+        analysis
+            .borrow_promotion_result
+            .shared_fields
+            .iter()
+            .copied(),
+    );
+    let shape_demoted = collect_struct_shape_demoted_fields(
+        tcx,
+        &promoted_fields,
+        &analysis.borrow_promotion_result.mutable_fields,
+        sig_decs,
+        ptr_kinds,
+    );
+    let live_fields = promoted_fields
+        .iter()
+        .filter(|field| !demoted_fields.contains(field))
+        .count();
+    let planned_return_lifetimes = lifetime_plans.functions.len();
+    let promoted_return_lifetimes = lifetime_plans
+        .functions
+        .keys()
+        .filter(|did| {
+            sig_decs.data.get(did).is_some_and(|sig_dec| {
+                sig_dec.output_lifetime.is_some()
+                    && matches!(
+                        sig_dec.output_dec,
+                        Some(PtrKind::Ref(_) | PtrKind::OptRef(_))
+                    )
+            })
+        })
+        .count();
+
+    eprintln!(
+        "[pointer-promotion] fields total={} mutable={} shared={} shape_demoted={} final_demoted={} live={} returns_planned={} returns_live={}",
+        promoted_fields.len(),
+        analysis.borrow_promotion_result.mutable_fields.len(),
+        analysis.borrow_promotion_result.shared_fields.len(),
+        shape_demoted.len(),
+        demoted_fields.len(),
+        live_fields,
+        planned_return_lifetimes,
+        promoted_return_lifetimes,
+    );
+
+    if mode != "full" {
+        return;
+    }
+
+    let mut fields = promoted_fields.iter().copied().collect::<Vec<_>>();
+    fields.sort_by_key(|field| field_slot_label(tcx, *field));
+    for field in fields {
+        let mutability = if analysis
+            .borrow_promotion_result
+            .mutable_fields
+            .contains(&field)
+        {
+            "mut"
+        } else {
+            "shared"
+        };
+        let reason = if demoted_fields.contains(&field) {
+            if shape_demoted.contains(&field) {
+                "demoted_shape"
+            } else {
+                "demoted_conflict"
+            }
+        } else {
+            "live"
+        };
+        eprintln!(
+            "[pointer-promotion] field {reason} {mutability} {}",
+            field_slot_label(tcx, field)
+        );
+    }
+
+    let mut planned_returns = lifetime_plans.functions.keys().copied().collect::<Vec<_>>();
+    planned_returns.sort_by_key(|did| tcx.def_path_str(*did));
+    for did in planned_returns {
+        let Some(sig_dec) = sig_decs.data.get(&did) else {
+            continue;
+        };
+        let state = if sig_dec.output_lifetime.is_some()
+            && matches!(
+                sig_dec.output_dec,
+                Some(PtrKind::Ref(_) | PtrKind::OptRef(_))
+            ) {
+            "live"
+        } else {
+            "demoted"
+        };
+        eprintln!(
+            "[pointer-promotion] return {state} {} {:?}",
+            tcx.def_path_str(did),
+            sig_dec.output_dec
+        );
+    }
+}
+
+fn field_slot_label(tcx: TyCtxt<'_>, field: StructFieldSlot) -> String {
+    let struct_name = tcx.def_path_str(field.struct_did);
+    let field_name = tcx
+        .adt_def(field.struct_did)
+        .non_enum_variant()
+        .fields
+        .iter()
+        .nth(field.field_index)
+        .map(|field| field.name.as_str().to_owned())
+        .unwrap_or_else(|| format!("#{}", field.field_index));
+    format!("{struct_name}.{field_name}")
 }
 
 fn signature_output_rewrites_to_owning<'tcx>(
@@ -10557,6 +10721,17 @@ fn signature_output_rewrites_to_owning<'tcx>(
         return false;
     };
     !fn_tail_returns_unsupported_box_binding(tcx, sig_decs, ptr_kinds, did, output_dec, inner_ty)
+}
+
+fn signature_output_rewrites_to_borrow(sig_decs: &SigDecisions, did: LocalDefId) -> bool {
+    sig_decs.data.get(&did).is_some_and(|sig| {
+        matches!(
+            sig.output_dec,
+            Some(
+                PtrKind::Ref(_) | PtrKind::OptRef(_) | PtrKind::Slice(_) | PtrKind::SliceCursor(_)
+            )
+        )
+    })
 }
 
 fn struct_has_named_fields(tcx: TyCtxt<'_>, did: LocalDefId) -> bool {

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -965,30 +965,26 @@ fn collect_c_exposed_signature_structs<'tcx>(
             .copied()
             .chain(std::iter::once(sig.output()))
         {
-            collect_local_structs_from_ty(rust_program.tcx, ty, &mut structs);
+            collect_local_structs_from_ty(ty, &mut structs);
         }
     }
     structs
 }
 
-fn collect_local_structs_from_ty<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    ty: ty::Ty<'tcx>,
-    structs: &mut FxHashSet<LocalDefId>,
-) {
+fn collect_local_structs_from_ty<'tcx>(ty: ty::Ty<'tcx>, structs: &mut FxHashSet<LocalDefId>) {
     match ty.kind() {
         ty::TyKind::RawPtr(pointee, _) => {
-            collect_local_structs_from_ty(tcx, *pointee, structs);
+            collect_local_structs_from_ty(*pointee, structs);
         }
         ty::TyKind::Ref(_, pointee, _) => {
-            collect_local_structs_from_ty(tcx, *pointee, structs);
+            collect_local_structs_from_ty(*pointee, structs);
         }
         ty::TyKind::Array(elem, _) | ty::TyKind::Slice(elem) => {
-            collect_local_structs_from_ty(tcx, *elem, structs);
+            collect_local_structs_from_ty(*elem, structs);
         }
         ty::TyKind::Tuple(elems) => {
             for elem in elems.iter() {
-                collect_local_structs_from_ty(tcx, elem, structs);
+                collect_local_structs_from_ty(elem, structs);
             }
         }
         ty::TyKind::Adt(adt_def, args) => {
@@ -1000,7 +996,7 @@ fn collect_local_structs_from_ty<'tcx>(
             }
             for arg in args.iter() {
                 if let ty::GenericArgKind::Type(arg_ty) = arg.kind() {
-                    collect_local_structs_from_ty(tcx, arg_ty, structs);
+                    collect_local_structs_from_ty(arg_ty, structs);
                 }
             }
         }

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -10606,10 +10606,31 @@ fn emit_promotion_diagnostics(
         sig_decs,
         ptr_kinds,
     );
+    let usage_counts = count_promoted_field_usages(tcx, &promoted_fields);
     let live_fields = promoted_fields
         .iter()
         .filter(|field| !demoted_fields.contains(field))
         .count();
+    let promoted_structs = promoted_fields
+        .iter()
+        .map(|field| field.struct_did)
+        .collect::<FxHashSet<_>>()
+        .len();
+    let blocked_structs = promoted_fields
+        .iter()
+        .filter(|field| demoted_fields.contains(field))
+        .map(|field| field.struct_did)
+        .collect::<FxHashSet<_>>()
+        .len();
+    let promoted_field_usages = promoted_fields
+        .iter()
+        .map(|field| usage_counts.get(field).copied().unwrap_or_default())
+        .sum::<usize>();
+    let blocked_field_usages = promoted_fields
+        .iter()
+        .filter(|field| demoted_fields.contains(field))
+        .map(|field| usage_counts.get(field).copied().unwrap_or_default())
+        .sum::<usize>();
     let planned_return_lifetimes = lifetime_plans.functions.len();
     let promoted_return_lifetimes = lifetime_plans
         .functions
@@ -10626,12 +10647,16 @@ fn emit_promotion_diagnostics(
         .count();
 
     eprintln!(
-        "[pointer-promotion] fields total={} mutable={} shared={} shape_demoted={} final_demoted={} live={} returns_planned={} returns_live={}",
+        "[pointer-promotion] fields total={} structs={} usages={} mutable={} shared={} shape_demoted={} final_demoted={} blocked_structs={} blocked_usages={} live={} returns_planned={} returns_live={}",
         promoted_fields.len(),
+        promoted_structs,
+        promoted_field_usages,
         analysis.borrow_promotion_result.mutable_fields.len(),
         analysis.borrow_promotion_result.shared_fields.len(),
         shape_demoted.len(),
         demoted_fields.len(),
+        blocked_structs,
+        blocked_field_usages,
         live_fields,
         planned_return_lifetimes,
         promoted_return_lifetimes,
@@ -10663,8 +10688,9 @@ fn emit_promotion_diagnostics(
             "live"
         };
         eprintln!(
-            "[pointer-promotion] field {reason} {mutability} {}",
-            field_slot_label(tcx, field)
+            "[pointer-promotion] field {reason} {mutability} uses={} {}",
+            usage_counts.get(&field).copied().unwrap_or_default(),
+            field_slot_label(tcx, field),
         );
     }
 
@@ -10702,6 +10728,67 @@ fn field_slot_label(tcx: TyCtxt<'_>, field: StructFieldSlot) -> String {
         .map(|field| field.name.as_str().to_owned())
         .unwrap_or_else(|| format!("#{}", field.field_index));
     format!("{struct_name}.{field_name}")
+}
+
+fn count_promoted_field_usages(
+    tcx: TyCtxt<'_>,
+    promoted_fields: &FxHashSet<StructFieldSlot>,
+) -> FxHashMap<StructFieldSlot, usize> {
+    struct FieldUsageVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        typeck: &'tcx rustc_middle::ty::TypeckResults<'tcx>,
+        promoted_fields: &'a FxHashSet<StructFieldSlot>,
+        usages: FxHashMap<StructFieldSlot, usize>,
+    }
+
+    impl FieldUsageVisitor<'_, '_> {
+        fn record(&mut self, field: StructFieldSlot) {
+            if self.promoted_fields.contains(&field) {
+                *self.usages.entry(field).or_default() += 1;
+            }
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for FieldUsageVisitor<'_, 'tcx> {
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            if let Some(field) = hir_struct_field_slot(self.tcx, expr) {
+                self.record(field);
+            }
+
+            if let hir::ExprKind::Struct(qpath, fields, _) = expr.kind
+                && let Some(struct_did) = hir_local_struct_did_from_qpath(qpath)
+                    .or_else(|| hir_local_struct_did_from_ty(self.typeck.expr_ty(expr)))
+            {
+                for field in fields {
+                    if let Some(field_index) =
+                        hir_field_index_by_name(self.tcx, struct_did, field.ident.name)
+                    {
+                        self.record(StructFieldSlot {
+                            struct_did,
+                            field_index,
+                        });
+                    }
+                }
+            }
+
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let mut usages = FxHashMap::default();
+    for_each_hir_fn_body(tcx, |body, typeck| {
+        let mut visitor = FieldUsageVisitor {
+            tcx,
+            typeck,
+            promoted_fields,
+            usages: FxHashMap::default(),
+        };
+        visitor.visit_body(body);
+        for (field, count) in visitor.usages {
+            *usages.entry(field).or_default() += count;
+        }
+    });
+    usages
 }
 
 fn signature_output_rewrites_to_owning<'tcx>(

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -464,10 +464,10 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                     local.ty = Some(P(self.mk_opt_ref_ty(lhs_inner_ty, m)));
                 }
                 PtrKind::Box => {
-                    local.ty = Some(P(self.mk_box_ty(lhs_inner_ty)));
+                    local.ty = Some(P(self.mk_local_box_ty(lhs_inner_ty)));
                 }
                 PtrKind::OptBox => {
-                    local.ty = Some(P(self.mk_opt_box_ty(lhs_inner_ty)));
+                    local.ty = Some(P(self.mk_local_opt_box_ty(lhs_inner_ty)));
                 }
                 PtrKind::BoxedSlice => {
                     local.ty = Some(P(self.mk_boxed_slice_ty(lhs_inner_ty)));
@@ -518,7 +518,9 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                 if let Some(field) = self.promoted_field_slot_for_hir_field(hir_lhs)
                     && let Some(kind) = self.promoted_field_kind(field)
                 {
-                    self.transform_rhs(rhs, hir_rhs, kind);
+                    let target_inner_ty =
+                        unwrap_ptr_from_mir_ty(typeck.expr_ty(hir_lhs)).map(|(inner, _)| inner);
+                    self.transform_promoted_field_rhs(rhs, hir_rhs, kind, target_inner_ty);
                     return;
                 }
                 let lhs_ty = typeck.expr_ty(hir_lhs);
@@ -686,8 +688,12 @@ impl MutVisitor for TransformVisitor<'_, '_> {
 
                     self.transform_rhs(arg, harg, param_kind);
                     if param_kind == PtrKind::OptRef(true)
-                        && hir_path_source_kind(self.tcx, &self.ptr_kinds, harg)
+                        && (hir_path_source_kind(self.tcx, &self.ptr_kinds, harg)
                             == Some(PtrKind::OptRef(true))
+                            || self
+                                .promoted_field_slot_for_hir_field(harg)
+                                .and_then(|field| self.promoted_field_kind(field))
+                                == Some(PtrKind::OptRef(true)))
                     {
                         *arg = P(utils::expr!(
                             "({}).as_deref_mut()",
@@ -713,6 +719,12 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                         .is_some()
                 }) {
                     seg.ident.name = Symbol::intern("is_none");
+                } else if let Some(hir_receiver) = hir_receiver
+                    && let Some(pe) = self.ptr_expr(receiver, hir_receiver)
+                    && matches!(self.ptr_source_kind(&pe), Some(PtrKind::OptRef(_)))
+                    && !pe.projs.is_empty()
+                {
+                    *expr = utils::expr!("({}).is_none()", pprust::expr_to_string(pe.base));
                 } else if matches!(receiver.kind, ExprKind::Path(_, _))
                     && let Some(hir_id) = self.hir_id_of_path(receiver.id)
                     && let Some(ptr_kind) = self.effective_ptr_kind(hir_id)
@@ -1396,7 +1408,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             else {
                 continue;
             };
-            self.transform_rhs(&mut ast_field.expr, hir_field.expr, kind);
+            self.transform_promoted_field_rhs(&mut ast_field.expr, hir_field.expr, kind, None);
         }
     }
 
@@ -1619,8 +1631,18 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         utils::ty!("Box<{ty}>")
     }
 
+    fn mk_local_box_ty(&self, ty: ty::Ty<'tcx>) -> Ty {
+        let ty = self.anonymous_ty_name(ty);
+        utils::ty!("Box<{ty}>")
+    }
+
     fn mk_opt_box_ty(&self, ty: ty::Ty<'tcx>) -> Ty {
         let ty = self.ty_name(ty);
+        utils::ty!("Option<Box<{ty}>>")
+    }
+
+    fn mk_local_opt_box_ty(&self, ty: ty::Ty<'tcx>) -> Ty {
+        let ty = self.anonymous_ty_name(ty);
         utils::ty!("Option<Box<{ty}>>")
     }
 
@@ -1963,6 +1985,123 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         lhs_kind: PtrKind,
     ) -> PtrKind {
         self.transform_ptr(rhs, hir_rhs, PtrCtx::Rhs(lhs_kind))
+    }
+
+    fn transform_promoted_field_rhs(
+        &self,
+        rhs: &mut Expr,
+        hir_rhs: &hir::Expr<'tcx>,
+        field_kind: PtrKind,
+        target_inner_ty: Option<ty::Ty<'tcx>>,
+    ) -> PtrKind {
+        if self.try_transform_raw_pointer_to_promoted_field(
+            rhs,
+            hir_rhs,
+            field_kind,
+            target_inner_ty,
+        ) || self.try_transform_slice_to_promoted_field(
+            rhs,
+            hir_rhs,
+            field_kind,
+            target_inner_ty,
+        ) {
+            field_kind
+        } else {
+            self.transform_rhs(rhs, hir_rhs, field_kind)
+        }
+    }
+
+    fn try_transform_raw_pointer_to_promoted_field(
+        &self,
+        rhs: &mut Expr,
+        hir_rhs: &hir::Expr<'tcx>,
+        field_kind: PtrKind,
+        target_inner_ty: Option<ty::Ty<'tcx>>,
+    ) -> bool {
+        let PtrKind::OptRef(m) = field_kind else {
+            return false;
+        };
+        if is_null_like_ptr_arg(unwrap_addr_of_deref(unwrap_cast_and_paren(rhs)))
+            || hir_raw_addr_local(hir_rhs).is_some()
+            || matches!(
+                unwrap_cast_and_paren(rhs).kind,
+                ExprKind::AddrOf(BorrowKind::Ref, ..)
+            )
+        {
+            return false;
+        }
+        if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_unwrap_cast(hir_rhs).kind
+            && let Res::Local(hir_id) = path.res
+            && !matches!(self.effective_ptr_kind(hir_id), Some(PtrKind::Raw(_)))
+        {
+            return false;
+        }
+        let typeck = self.tcx.typeck(hir_rhs.hir_id.owner);
+        let Some((rhs_inner_ty, rhs_mut)) =
+            unwrap_ptr_from_mir_ty(typeck.expr_ty_adjusted(hir_rhs))
+        else {
+            return false;
+        };
+        let lhs_inner_ty = target_inner_ty.unwrap_or(rhs_inner_ty);
+        *rhs = self.opt_ref_from_raw_without_unsafe(
+            unwrap_addr_of_deref(unwrap_paren(rhs)),
+            m,
+            rhs_mut.is_mut(),
+            lhs_inner_ty,
+            rhs_inner_ty,
+        );
+        true
+    }
+
+    fn try_transform_slice_to_promoted_field(
+        &self,
+        rhs: &mut Expr,
+        hir_rhs: &hir::Expr<'tcx>,
+        field_kind: PtrKind,
+        target_inner_ty: Option<ty::Ty<'tcx>>,
+    ) -> bool {
+        let PtrKind::OptRef(m) = field_kind else {
+            return false;
+        };
+        let e = unwrap_addr_of_deref(unwrap_cast_and_paren(rhs));
+        let hir_e = hir_unwrap_addr_of_deref(hir_unwrap_cast(hir_rhs));
+        let Some(pe) = self.ptr_expr(e, hir_e) else {
+            return false;
+        };
+        if !pe.projs.is_empty() {
+            return false;
+        }
+        let source_mutability = match self.ptr_source_kind(&pe) {
+            Some(PtrKind::Slice(source_m)) | Some(PtrKind::SliceCursor(source_m)) => source_m,
+            _ => return false,
+        };
+        if m && !source_mutability {
+            return false;
+        }
+        let Some(rhs_inner_ty) = unwrap_ptr_or_arr_from_mir_ty(pe.base_ty, self.tcx) else {
+            return false;
+        };
+        let lhs_inner_ty = target_inner_ty.unwrap_or(rhs_inner_ty);
+        let ptr_method = if m { "as_mut_ptr" } else { "as_ptr" };
+        let ref_method = if m { "as_mut" } else { "as_ref" };
+        *rhs = if lhs_inner_ty == rhs_inner_ty {
+            utils::expr!(
+                "({}).{}().{}()",
+                pprust::expr_to_string(pe.base),
+                ptr_method,
+                ref_method,
+            )
+        } else {
+            utils::expr!(
+                "(({}).{}() as *{} {}).{}()",
+                pprust::expr_to_string(pe.base),
+                ptr_method,
+                if m { "mut" } else { "const" },
+                mir_ty_to_string(lhs_inner_ty, self.tcx),
+                ref_method,
+            )
+        };
+        true
     }
 
     fn local_binding_needs_mut_for_promoted_field_write(&self, target_hir_id: HirId) -> bool {
@@ -2840,8 +2979,22 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     return PtrKind::Raw(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::OptRef(m1)) => {
-                    assert!(pe.projs.is_empty());
-                    *ptr = self.raw_from_opt_ref(pe.base, m, m1, lhs_inner_ty, rhs_inner_ty);
+                    if pe.projs.is_empty() {
+                        *ptr = self.raw_from_opt_ref(pe.base, m, m1, lhs_inner_ty, rhs_inner_ty);
+                    } else if let Some((base, source_inner_ty)) =
+                        self.projected_opt_ref_slice_expr(&pe, m, m1)
+                    {
+                        *ptr = self.raw_from_slice_or_cursor(
+                            &base,
+                            m,
+                            m1,
+                            lhs_inner_ty,
+                            source_inner_ty,
+                        );
+                    } else {
+                        *ptr =
+                            self.raw_from_projected_opt_ref(&pe, m, m1, lhs_inner_ty, rhs_inner_ty);
+                    }
                     return PtrKind::Raw(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Raw(m)), PtrKind::Slice(m1)) => {
@@ -2882,22 +3035,63 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     *ptr = self.ref_from_ref(pe.base, m, m1, lhs_inner_ty, rhs_inner_ty, def_id);
                     return PtrKind::Ref(m);
                 }
-                (PtrCtx::Deref(false), PtrKind::OptRef(false)) if !need_cast => {
-                    assert!(pe.projs.is_empty());
+                (PtrCtx::Deref(false), PtrKind::OptRef(false))
+                    if !need_cast && pe.projs.is_empty() =>
+                {
                     return PtrKind::OptRef(false);
                 }
                 (PtrCtx::Rhs(PtrKind::OptRef(m)) | PtrCtx::Deref(m), PtrKind::OptRef(m1)) => {
-                    assert!(pe.projs.is_empty());
-                    // can be used for deref, so type must be specified
-                    *ptr = self.opt_ref_from_opt_ref(
-                        pe.base,
-                        m,
-                        m1,
-                        lhs_inner_ty,
-                        rhs_inner_ty,
-                        def_id,
-                    );
-                    return PtrKind::OptRef(m);
+                    if pe.projs.is_empty() {
+                        // can be used for deref, so type must be specified
+                        *ptr = self.opt_ref_from_opt_ref(
+                            pe.base,
+                            m,
+                            m1,
+                            lhs_inner_ty,
+                            rhs_inner_ty,
+                            def_id,
+                        );
+                        return PtrKind::OptRef(m);
+                    }
+                    if let Some((base, source_inner_ty)) =
+                        self.projected_opt_ref_slice_expr(&pe, m, m1)
+                    {
+                        match ctx {
+                            PtrCtx::Deref(_) => {
+                                *ptr = self.plain_slice_from_slice(
+                                    &base,
+                                    &pe,
+                                    m,
+                                    lhs_inner_ty,
+                                    source_inner_ty,
+                                );
+                                return PtrKind::Slice(m);
+                            }
+                            PtrCtx::Rhs(PtrKind::OptRef(_)) => {
+                                *ptr = self.opt_ref_from_slice_or_cursor(
+                                    &base,
+                                    m,
+                                    lhs_inner_ty,
+                                    source_inner_ty,
+                                    def_id,
+                                );
+                                return PtrKind::OptRef(m);
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                    if matches!(ctx, PtrCtx::Deref(_)) {
+                        *ptr = self.opt_ref_from_projected_opt_ref(
+                            &pe,
+                            m,
+                            m1,
+                            lhs_inner_ty,
+                            rhs_inner_ty,
+                        );
+                        return PtrKind::OptRef(m);
+                    }
+                    *ptr = self.raw_from_projected_opt_ref(&pe, m, m1, lhs_inner_ty, rhs_inner_ty);
+                    return PtrKind::Raw(m);
                 }
                 (PtrCtx::Rhs(PtrKind::OptRef(m)), PtrKind::BoxedSlice) => {
                     let (base, source_inner_ty) = self
@@ -3120,8 +3314,22 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     *ptr = result;
                     return PtrKind::SliceCursor(m);
                 }
-                (PtrCtx::Rhs(PtrKind::SliceCursor(_) | PtrKind::Slice(_)), PtrKind::OptRef(_)) => {
-                    panic!()
+                (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::OptRef(m1)) => {
+                    let (base, source_inner_ty) = self
+                        .projected_opt_ref_slice_expr(&pe, m, m1)
+                        .unwrap_or_else(|| panic!("{}", pprust::expr_to_string(ptr)));
+                    *ptr =
+                        self.plain_slice_from_slice(&base, &pe, m, lhs_inner_ty, source_inner_ty);
+                    return PtrKind::Slice(m);
+                }
+                (PtrCtx::Rhs(PtrKind::SliceCursor(m)), PtrKind::OptRef(m1)) => {
+                    self.slice_cursor.set(true);
+                    let (base, source_inner_ty) = self
+                        .projected_opt_ref_slice_expr(&pe, m, m1)
+                        .unwrap_or_else(|| panic!("{}", pprust::expr_to_string(ptr)));
+                    *ptr =
+                        self.cursor_from_plain_slice(&base, &pe, m, lhs_inner_ty, source_inner_ty);
+                    return PtrKind::SliceCursor(m);
                 }
                 (
                     PtrCtx::Rhs(PtrKind::Slice(_) | PtrKind::SliceCursor(_)),
@@ -3369,6 +3577,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
     fn ptr_source_kind(&self, pe: &PtrExpr<'_, 'tcx>) -> Option<PtrKind> {
         if let PtrExprBaseKind::Path(Res::Local(hir_id)) = pe.base_kind {
             return self.effective_ptr_kind(hir_id);
+        }
+        if let Some(field) = self.promoted_field_slot_for_hir_field(pe.hir_base) {
+            return self.promoted_field_kind(field);
         }
         if let hir::ExprKind::Call(func, _) = pe.hir_base.kind
             && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = func.kind
@@ -3882,6 +4093,25 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         self.apply_boxed_slice_projections(pe, m, &mut expr)
     }
 
+    fn projected_opt_ref_slice_expr(
+        &self,
+        pe: &PtrExpr<'_, 'tcx>,
+        m: bool,
+        source_mut: bool,
+    ) -> Option<(Expr, ty::Ty<'tcx>)> {
+        if m && !source_mut {
+            return None;
+        }
+        let source_inner_ty = unwrap_ptr_or_arr_from_mir_ty(pe.base_ty, self.tcx)?;
+        let raw = self.raw_from_opt_ref(pe.base, m, source_mut, source_inner_ty, source_inner_ty);
+        let mut expr = utils::expr!(
+            "std::slice::from_raw_parts{}({}, 1_000_000)",
+            if m { "_mut" } else { "" },
+            pprust::expr_to_string(&raw),
+        );
+        self.apply_borrowed_slice_projections(pe, m, &mut expr)
+    }
+
     fn apply_boxed_slice_projections(
         &self,
         pe: &PtrExpr<'_, 'tcx>,
@@ -3892,6 +4122,37 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         for proj in &pe.projs {
             match proj {
                 PtrExprProj::Offset(offset) => {
+                    *expr = utils::expr!(
+                        "({})[({}) as usize..]",
+                        pprust::expr_to_string(expr),
+                        pprust::expr_to_string(offset),
+                    );
+                }
+                PtrExprProj::Cast(ty) if ty.is_usize() => return None,
+                PtrExprProj::Cast(ty) => {
+                    let (to_ty, _) = unwrap_ptr_from_mir_ty(*ty)?;
+                    *expr = self.plain_slice_from_expr(expr, m, to_ty, from_ty);
+                    from_ty = to_ty;
+                }
+                PtrExprProj::IntegerOp(..) | PtrExprProj::IntegerBinOp(..) => return None,
+            }
+        }
+        Some((expr.clone(), from_ty))
+    }
+
+    fn apply_borrowed_slice_projections(
+        &self,
+        pe: &PtrExpr<'_, 'tcx>,
+        m: bool,
+        expr: &mut Expr,
+    ) -> Option<(Expr, ty::Ty<'tcx>)> {
+        let mut from_ty = unwrap_ptr_or_arr_from_mir_ty(pe.base_ty, self.tcx)?;
+        for proj in &pe.projs {
+            match proj {
+                PtrExprProj::Offset(offset) => {
+                    if !self.offset_expr_can_be_slice_index(offset) {
+                        return None;
+                    }
                     *expr = utils::expr!(
                         "({})[({}) as usize..]",
                         pprust::expr_to_string(expr),
@@ -4348,6 +4609,91 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         }
     }
 
+    fn raw_from_projected_opt_ref(
+        &self,
+        pe: &PtrExpr<'_, 'tcx>,
+        m: bool,
+        m1: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let source_inner_ty =
+            unwrap_ptr_or_arr_from_mir_ty(pe.base_ty, self.tcx).unwrap_or(rhs_inner_ty);
+        let mut raw = self.raw_from_opt_ref(pe.base, m, m1, source_inner_ty, source_inner_ty);
+        let mut from_ty = source_inner_ty;
+        for proj in &pe.projs {
+            match proj {
+                PtrExprProj::Offset(offset) => {
+                    raw = utils::expr!(
+                        "({}).offset({})",
+                        pprust::expr_to_string(&raw),
+                        pprust::expr_to_string(offset),
+                    );
+                }
+                PtrExprProj::Cast(ty) if ty.is_usize() => {
+                    raw = utils::expr!("({}) as usize", pprust::expr_to_string(&raw));
+                }
+                PtrExprProj::Cast(ty) => {
+                    let (to_ty, _) = unwrap_ptr_from_mir_ty(*ty).unwrap();
+                    raw = utils::expr!(
+                        "({}) as *{} {}",
+                        pprust::expr_to_string(&raw),
+                        if m { "mut" } else { "const" },
+                        mir_ty_to_string(to_ty, self.tcx),
+                    );
+                    from_ty = to_ty;
+                }
+                PtrExprProj::IntegerOp(expr, op) => {
+                    let method = match op {
+                        OpKind::WrappingAdd => "wrapping_add",
+                        OpKind::WrappingSub => "wrapping_sub",
+                    };
+                    raw = utils::expr!(
+                        "({}).{}({})",
+                        pprust::expr_to_string(&raw),
+                        method,
+                        pprust::expr_to_string(expr),
+                    );
+                }
+                PtrExprProj::IntegerBinOp(expr, op) => {
+                    let op_str = match op {
+                        BinOpKind::BitAnd => "&",
+                        BinOpKind::BitOr => "|",
+                        _ => panic!(),
+                    };
+                    raw = utils::expr!(
+                        "({}) {} ({})",
+                        pprust::expr_to_string(&raw),
+                        op_str,
+                        pprust::expr_to_string(expr),
+                    );
+                }
+            }
+        }
+        if from_ty != lhs_inner_ty {
+            utils::expr!(
+                "({}) as *{} {}",
+                pprust::expr_to_string(&raw),
+                if m { "mut" } else { "const" },
+                mir_ty_to_string(lhs_inner_ty, self.tcx),
+            )
+        } else {
+            raw
+        }
+    }
+
+    fn opt_ref_from_projected_opt_ref(
+        &self,
+        pe: &PtrExpr<'_, 'tcx>,
+        m: bool,
+        m1: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let raw = self.raw_from_projected_opt_ref(pe, m, m1, lhs_inner_ty, rhs_inner_ty);
+        self.opt_ref_from_raw(&raw, m, m, lhs_inner_ty, lhs_inner_ty)
+    }
+
     fn raw_from_slice_or_cursor(
         &self,
         e: &Expr,
@@ -4396,6 +4742,35 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         } else {
             utils::expr!(
                 "unsafe {{ (({}){} as *{} {}).as_{}() }}",
+                pprust::expr_to_string(e),
+                cast_mut,
+                if m { "mut" } else { "const" },
+                mir_ty_to_string(lhs_inner_ty, self.tcx),
+                if m { "mut" } else { "ref" },
+            )
+        }
+    }
+
+    fn opt_ref_from_raw_without_unsafe(
+        &self,
+        e: &Expr,
+        m: bool,
+        m1: bool,
+        lhs_inner_ty: ty::Ty<'tcx>,
+        rhs_inner_ty: ty::Ty<'tcx>,
+    ) -> Expr {
+        let need_cast = lhs_inner_ty != rhs_inner_ty;
+        let cast_mut = if m && !m1 { ".cast_mut()" } else { "" };
+        if !need_cast {
+            utils::expr!(
+                "({}){}.as_{}()",
+                pprust::expr_to_string(e),
+                cast_mut,
+                if m { "mut" } else { "ref" },
+            )
+        } else {
+            utils::expr!(
+                "(({}){} as *{} {}).as_{}()",
                 pprust::expr_to_string(e),
                 cast_mut,
                 if m { "mut" } else { "const" },
@@ -5062,10 +5437,15 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             }
             ExprKind::MethodCall(call) => {
                 let hir::ExprKind::MethodCall(seg, hreceiver, _, _) = hir_expr.kind else {
-                    panic!()
+                    return Some(PtrExpr::new(
+                        expr,
+                        hir_expr,
+                        base_ty,
+                        PtrExprBaseKind::Other,
+                    ));
                 };
                 let name = seg.ident.name.as_str();
-                if name == "offset" {
+                if name == "offset" || name == "add" {
                     let mut ptr_expr = self.ptr_expr(&call.receiver, hreceiver)?;
                     ptr_expr.push_offset(&call.args[0]);
                     Some(ptr_expr)
@@ -10090,20 +10470,113 @@ fn collect_demoted_promoted_fields(
         sig_decs,
         ptr_kinds,
     );
+    demoted_fields.extend(
+        collect_field_conflict_demotion_reasons(tcx, analysis, sig_decs, ptr_kinds)
+            .keys()
+            .copied(),
+    );
+
+    demoted_fields
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum ConflictDemotionReason {
+    ActiveBorrowOverlap,
+    LocalAssignmentWhileBorrowed,
+    ConflictingReborrow,
+    MutableFieldCopy,
+    RawPointeeFieldMove,
+    RawFieldPointerProjection,
+    RawStorageAllocator,
+    RawStoragePointer,
+    RawBindingFromField,
+    RawLocalCallArg,
+    RawUnknownCallArg,
+}
+
+impl ConflictDemotionReason {
+    const ALL: [Self; 11] = [
+        Self::ActiveBorrowOverlap,
+        Self::LocalAssignmentWhileBorrowed,
+        Self::ConflictingReborrow,
+        Self::MutableFieldCopy,
+        Self::RawPointeeFieldMove,
+        Self::RawFieldPointerProjection,
+        Self::RawStorageAllocator,
+        Self::RawStoragePointer,
+        Self::RawBindingFromField,
+        Self::RawLocalCallArg,
+        Self::RawUnknownCallArg,
+    ];
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ActiveBorrowOverlap => "active_borrow_overlap",
+            Self::LocalAssignmentWhileBorrowed => "local_assignment_while_borrowed",
+            Self::ConflictingReborrow => "conflicting_reborrow",
+            Self::MutableFieldCopy => "mutable_field_copy",
+            Self::RawPointeeFieldMove => "raw_pointee_field_move",
+            Self::RawFieldPointerProjection => "raw_field_pointer_projection",
+            Self::RawStorageAllocator => "raw_storage_allocator",
+            Self::RawStoragePointer => "raw_storage_pointer",
+            Self::RawBindingFromField => "raw_binding_from_field",
+            Self::RawLocalCallArg => "raw_local_call_arg",
+            Self::RawUnknownCallArg => "raw_unknown_call_arg",
+        }
+    }
+}
+
+fn collect_field_conflict_demotion_reasons(
+    tcx: TyCtxt<'_>,
+    analysis: &Analysis,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+) -> FxHashMap<StructFieldSlot, FxHashSet<ConflictDemotionReason>> {
+    let mut promoted_fields = analysis.borrow_promotion_result.mutable_fields.clone();
+    promoted_fields.extend(
+        analysis
+            .borrow_promotion_result
+            .shared_fields
+            .iter()
+            .copied(),
+    );
+    if promoted_fields.is_empty() {
+        return FxHashMap::default();
+    }
 
     struct FieldBorrowConflictVisitor<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
         typeck: &'tcx rustc_middle::ty::TypeckResults<'tcx>,
         sig_decs: &'a SigDecisions,
+        ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
         promoted_fields: &'a FxHashSet<StructFieldSlot>,
         mutable_fields: &'a FxHashSet<StructFieldSlot>,
         allocator_locals: FxHashSet<HirId>,
         active_borrows: FxHashMap<HirId, FxHashMap<StructFieldSlot, bool>>,
         ignored_borrow_exprs: FxHashSet<HirId>,
-        demoted_fields: FxHashSet<StructFieldSlot>,
+        conflict_reasons: FxHashMap<StructFieldSlot, FxHashSet<ConflictDemotionReason>>,
     }
 
     impl<'tcx> FieldBorrowConflictVisitor<'_, 'tcx> {
+        fn record_conflict(&mut self, field: StructFieldSlot, reason: ConflictDemotionReason) {
+            if self.promoted_fields.contains(&field) {
+                self.conflict_reasons
+                    .entry(field)
+                    .or_default()
+                    .insert(reason);
+            }
+        }
+
+        fn record_conflicts(
+            &mut self,
+            fields: impl IntoIterator<Item = StructFieldSlot>,
+            reason: ConflictDemotionReason,
+        ) {
+            for field in fields {
+                self.record_conflict(field, reason);
+            }
+        }
+
         fn record_field_borrow(&mut self, field: StructFieldSlot, rhs: &'tcx hir::Expr<'tcx>) {
             if !self.promoted_fields.contains(&field) {
                 return;
@@ -10112,13 +10585,25 @@ fn collect_demoted_promoted_fields(
                 return;
             };
             self.ignored_borrow_exprs.insert(rhs.hir_id);
-            let fields = self.active_borrows.entry(local).or_default();
-            if !fields.is_empty() && (new_mut || fields.values().any(|existing_mut| *existing_mut))
-            {
-                self.demoted_fields.extend(fields.keys().copied());
-                self.demoted_fields.insert(field);
+            let conflicting_fields = {
+                let fields = self.active_borrows.entry(local).or_default();
+                let has_conflict = !fields.is_empty()
+                    && (new_mut || fields.values().any(|existing_mut| *existing_mut));
+                let conflicting_fields = if has_conflict {
+                    fields.keys().copied().collect::<Vec<_>>()
+                } else {
+                    Vec::new()
+                };
+                fields.insert(field, new_mut);
+                conflicting_fields
+            };
+            if !conflicting_fields.is_empty() {
+                self.record_conflicts(
+                    conflicting_fields,
+                    ConflictDemotionReason::ActiveBorrowOverlap,
+                );
+                self.record_conflict(field, ConflictDemotionReason::ActiveBorrowOverlap);
             }
-            fields.insert(field, new_mut);
         }
 
         fn record_local_assignment(&mut self, lhs: &'tcx hir::Expr<'tcx>) {
@@ -10126,7 +10611,10 @@ fn collect_demoted_promoted_fields(
                 return;
             };
             if let Some(fields) = self.active_borrows.get(&local) {
-                self.demoted_fields.extend(fields.keys().copied());
+                self.record_conflicts(
+                    fields.keys().copied().collect::<Vec<_>>(),
+                    ConflictDemotionReason::LocalAssignmentWhileBorrowed,
+                );
             }
         }
 
@@ -10140,7 +10628,10 @@ fn collect_demoted_promoted_fields(
             if let Some(fields) = self.active_borrows.get(&local)
                 && (new_mut || fields.values().any(|existing_mut| *existing_mut))
             {
-                self.demoted_fields.extend(fields.keys().copied());
+                self.record_conflicts(
+                    fields.keys().copied().collect::<Vec<_>>(),
+                    ConflictDemotionReason::ConflictingReborrow,
+                );
             }
         }
 
@@ -10164,8 +10655,8 @@ fn collect_demoted_promoted_fields(
             if !self.mutable_fields.contains(&rhs_field) {
                 return;
             }
-            self.demoted_fields.insert(lhs_field);
-            self.demoted_fields.insert(rhs_field);
+            self.record_conflict(lhs_field, ConflictDemotionReason::MutableFieldCopy);
+            self.record_conflict(rhs_field, ConflictDemotionReason::MutableFieldCopy);
         }
 
         fn promoted_field_slots_in_expr(
@@ -10198,12 +10689,15 @@ fn collect_demoted_promoted_fields(
             visitor.fields
         }
 
-        fn demote_promoted_fields_in_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
-            self.demoted_fields
-                .extend(self.promoted_field_slots_in_expr(expr));
+        fn record_promoted_fields_in_expr(
+            &mut self,
+            expr: &'tcx hir::Expr<'tcx>,
+            reason: ConflictDemotionReason,
+        ) {
+            self.record_conflicts(self.promoted_field_slots_in_expr(expr), reason);
         }
 
-        fn demote_moved_mutable_fields_from_raw_pointee_arg(
+        fn record_moved_mutable_fields_from_raw_pointee_arg(
             &mut self,
             expr: &'tcx hir::Expr<'tcx>,
         ) {
@@ -10212,7 +10706,7 @@ fn collect_demoted_promoted_fields(
                 typeck: &'tcx rustc_middle::ty::TypeckResults<'tcx>,
                 promoted_fields: &'a FxHashSet<StructFieldSlot>,
                 mutable_fields: &'a FxHashSet<StructFieldSlot>,
-                demoted_fields: FxHashSet<StructFieldSlot>,
+                fields: FxHashSet<StructFieldSlot>,
             }
 
             impl<'tcx> RawPointeeFieldMoveVisitor<'_, 'tcx> {
@@ -10254,7 +10748,7 @@ fn collect_demoted_promoted_fields(
                         && let hir::ExprKind::Field(base, _) = expr.kind
                         && self.expr_contains_raw_deref(base)
                     {
-                        self.demoted_fields.insert(field);
+                        self.fields.insert(field);
                     }
                     intravisit::walk_expr(self, expr);
                 }
@@ -10265,10 +10759,10 @@ fn collect_demoted_promoted_fields(
                 typeck: self.typeck,
                 promoted_fields: self.promoted_fields,
                 mutable_fields: self.mutable_fields,
-                demoted_fields: FxHashSet::default(),
+                fields: FxHashSet::default(),
             };
             visitor.visit_expr(expr);
-            self.demoted_fields.extend(visitor.demoted_fields);
+            self.record_conflicts(visitor.fields, ConflictDemotionReason::RawPointeeFieldMove);
         }
 
         fn expr_contains_allocator_call(&self, expr: &'tcx hir::Expr<'tcx>) -> bool {
@@ -10314,14 +10808,58 @@ fn collect_demoted_promoted_fields(
                     .is_some_and(|hir_id| self.allocator_locals.contains(&hir_id))
         }
 
-        fn expr_requires_raw_field_storage(&self, expr: &'tcx hir::Expr<'tcx>) -> bool {
+        fn raw_field_storage_reason(
+            &self,
+            field: StructFieldSlot,
+            expr: &'tcx hir::Expr<'tcx>,
+        ) -> Option<ConflictDemotionReason> {
             if self.expr_is_null_constructor(expr) || hir_raw_addr_local(expr).is_some() {
-                return false;
+                return None;
             }
             if self.expr_is_allocator_root_source(expr) {
-                return true;
+                return Some(ConflictDemotionReason::RawStorageAllocator);
             }
-            unwrap_ptr_from_mir_ty(self.typeck.expr_ty_adjusted(expr)).is_some()
+            if self.raw_storage_source_loses_mutability(field, expr) {
+                return Some(ConflictDemotionReason::RawStoragePointer);
+            }
+            None
+        }
+
+        fn raw_storage_source_loses_mutability(
+            &self,
+            field: StructFieldSlot,
+            expr: &'tcx hir::Expr<'tcx>,
+        ) -> bool {
+            if !self.mutable_fields.contains(&field) {
+                return false;
+            }
+            if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_unwrap_cast(expr).kind
+                && let Res::Local(hir_id) = path.res
+            {
+                return matches!(
+                    self.ptr_kinds.get(&hir_id),
+                    Some(
+                        PtrKind::Ref(false)
+                            | PtrKind::OptRef(false)
+                            | PtrKind::Slice(false)
+                            | PtrKind::SliceCursor(false)
+                    )
+                );
+            }
+            if let Some(callee_did) = hir_called_local_fn(self.tcx, expr)
+                && let Some(sig_dec) = self.sig_decs.data.get(&callee_did)
+            {
+                return matches!(
+                    sig_dec.output_dec,
+                    Some(
+                        PtrKind::Ref(false)
+                            | PtrKind::OptRef(false)
+                            | PtrKind::Slice(false)
+                            | PtrKind::SliceCursor(false)
+                    )
+                );
+            }
+            false
         }
 
         fn record_allocator_binding(&mut self, hir_id: HirId, expr: &'tcx hir::Expr<'tcx>) {
@@ -10334,8 +10872,8 @@ fn collect_demoted_promoted_fields(
         }
 
         fn record_raw_field_storage(&mut self, field: StructFieldSlot, rhs: &'tcx hir::Expr<'tcx>) {
-            if self.promoted_fields.contains(&field) && self.expr_requires_raw_field_storage(rhs) {
-                self.demoted_fields.insert(field);
+            if let Some(reason) = self.raw_field_storage_reason(field, rhs) {
+                self.record_conflict(field, reason);
             }
         }
 
@@ -10344,7 +10882,7 @@ fn collect_demoted_promoted_fields(
             if unwrap_ptr_from_mir_ty(self.typeck.node_type(binding_hir_id)).is_none() {
                 return;
             }
-            self.demote_promoted_fields_in_expr(init);
+            self.record_promoted_fields_in_expr(init, ConflictDemotionReason::RawBindingFromField);
         }
 
         fn record_raw_field_call(&mut self, expr: &'tcx hir::Expr<'tcx>) {
@@ -10352,24 +10890,27 @@ fn collect_demoted_promoted_fields(
                 return;
             };
             for arg in args.iter() {
-                self.demote_moved_mutable_fields_from_raw_pointee_arg(arg);
+                self.record_moved_mutable_fields_from_raw_pointee_arg(arg);
             }
             if let Some(callee_did) = hir_called_local_fn(self.tcx, expr)
                 && let Some(sig_dec) = self.sig_decs.data.get(&callee_did)
             {
-                for (arg_index, arg) in args.iter().enumerate() {
-                    if matches!(
-                        sig_dec.input_decs.get(arg_index).copied().flatten(),
-                        Some(PtrKind::Raw(_) | PtrKind::Slice(_) | PtrKind::SliceCursor(_))
-                    ) {
-                        self.demote_promoted_fields_in_expr(arg);
-                    }
-                }
+                let _ = sig_dec;
                 return;
             }
-            for arg in args.iter() {
-                self.demote_promoted_fields_in_expr(arg);
+        }
+
+        fn record_raw_field_pointer_projection(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+            let hir::ExprKind::MethodCall(seg, receiver, _, _) = expr.kind else {
+                return;
+            };
+            if !matches!(seg.ident.name.as_str(), "wrapping_offset" | "sub") {
+                return;
             }
+            self.record_promoted_fields_in_expr(
+                receiver,
+                ConflictDemotionReason::RawFieldPointerProjection,
+            );
         }
 
         fn record_mutable_field_copy(
@@ -10397,6 +10938,7 @@ fn collect_demoted_promoted_fields(
 
         fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
             self.record_conflicting_reborrow(expr);
+            self.record_raw_field_pointer_projection(expr);
             match expr.kind {
                 hir::ExprKind::Struct(qpath, fields, _) => {
                     if let Some(struct_did) = hir_local_struct_did_from_qpath(qpath) {
@@ -10437,23 +10979,28 @@ fn collect_demoted_promoted_fields(
         }
     }
 
+    let mut conflict_reasons: FxHashMap<StructFieldSlot, FxHashSet<ConflictDemotionReason>> =
+        FxHashMap::default();
     for_each_hir_fn_body(tcx, |body, typeck| {
         let mut visitor = FieldBorrowConflictVisitor {
             tcx,
             typeck,
             sig_decs,
+            ptr_kinds,
             promoted_fields: &promoted_fields,
             mutable_fields: &analysis.borrow_promotion_result.mutable_fields,
             allocator_locals: FxHashSet::default(),
             active_borrows: FxHashMap::default(),
             ignored_borrow_exprs: FxHashSet::default(),
-            demoted_fields: FxHashSet::default(),
+            conflict_reasons: FxHashMap::default(),
         };
         visitor.visit_body(body);
-        demoted_fields.extend(visitor.demoted_fields);
+        for (field, reasons) in visitor.conflict_reasons {
+            conflict_reasons.entry(field).or_default().extend(reasons);
+        }
     });
 
-    demoted_fields
+    conflict_reasons
 }
 
 fn for_each_hir_fn_body<'tcx>(
@@ -10655,6 +11202,8 @@ fn emit_promotion_diagnostics(
         sig_decs,
         ptr_kinds,
     );
+    let conflict_reasons =
+        collect_field_conflict_demotion_reasons(tcx, analysis, sig_decs, ptr_kinds);
     let usage_counts = count_promoted_field_usages(tcx, &promoted_fields);
     let live_fields = promoted_fields
         .iter()
@@ -10711,6 +11260,28 @@ fn emit_promotion_diagnostics(
         promoted_return_lifetimes,
     );
 
+    let mut conflict_reason_stats = FxHashMap::<ConflictDemotionReason, (usize, usize)>::default();
+    for (field, reasons) in &conflict_reasons {
+        for &reason in reasons {
+            let usage_count = usage_counts.get(field).copied().unwrap_or_default();
+            let entry = conflict_reason_stats.entry(reason).or_default();
+            entry.0 += 1;
+            entry.1 += usage_count;
+        }
+    }
+    for reason in ConflictDemotionReason::ALL {
+        let (fields, usages) = conflict_reason_stats
+            .get(&reason)
+            .copied()
+            .unwrap_or_default();
+        eprintln!(
+            "[pointer-promotion] conflict reason={} fields={} usages={}",
+            reason.as_str(),
+            fields,
+            usages,
+        );
+    }
+
     if mode != "full" {
         return;
     }
@@ -10736,11 +11307,25 @@ fn emit_promotion_diagnostics(
         } else {
             "live"
         };
+        let label = field_slot_label(tcx, field);
         eprintln!(
             "[pointer-promotion] field {reason} {mutability} uses={} {}",
             usage_counts.get(&field).copied().unwrap_or_default(),
-            field_slot_label(tcx, field),
+            label,
         );
+        if let Some(reasons) = conflict_reasons.get(&field) {
+            let mut reason_names = reasons
+                .iter()
+                .map(|reason| reason.as_str())
+                .collect::<Vec<_>>();
+            reason_names.sort();
+            eprintln!(
+                "[pointer-promotion] field-conflict reasons={} uses={} {}",
+                reason_names.join(","),
+                usage_counts.get(&field).copied().unwrap_or_default(),
+                label,
+            );
+        }
     }
 
     let mut planned_returns = lifetime_plans.functions.keys().copied().collect::<Vec<_>>();
@@ -11464,6 +12049,165 @@ mod tests {
         };
 
         (input, analysis)
+    }
+
+    fn field_conflict_reason_names_for_code(code: &str) -> FxHashMap<String, Vec<&'static str>> {
+        ::utils::compilation::run_compiler_on_str(code, |tcx| {
+            let (input, analysis) = build_analysis(tcx);
+            let (sig_decs, ptr_kinds, _reason_map, _usage_subreason_map) =
+                simulate_transform_reasons(tcx, &input, &analysis);
+            let mut sig_decs = sig_decs;
+            force_test_input_raw(tcx, &mut sig_decs, "raw_local");
+            let reasons =
+                collect_field_conflict_demotion_reasons(tcx, &analysis, &sig_decs, &ptr_kinds);
+            reasons
+                .into_iter()
+                .map(|(field, reasons)| {
+                    let mut reason_names = reasons
+                        .into_iter()
+                        .map(|reason| reason.as_str())
+                        .collect::<Vec<_>>();
+                    reason_names.sort();
+                    (field_slot_label(tcx, field), reason_names)
+                })
+                .collect()
+        })
+        .unwrap()
+    }
+
+    fn force_test_input_raw(tcx: TyCtxt<'_>, sig_decs: &mut SigDecisions, name: &str) {
+        for maybe_owner in tcx.hir_crate(()).owners.iter() {
+            let Some(owner) = maybe_owner.as_owner() else {
+                continue;
+            };
+            let OwnerNode::Item(item) = owner.node() else {
+                continue;
+            };
+            if !matches!(item.kind, HirItemKind::Fn { .. }) {
+                continue;
+            }
+            if tcx.item_name(item.owner_id.def_id.to_def_id()).as_str() != name {
+                continue;
+            }
+            if let Some(sig_dec) = sig_decs.data.get_mut(&item.owner_id.def_id)
+                && !sig_dec.input_decs.is_empty()
+            {
+                sig_dec.input_decs[0] = Some(PtrKind::Raw(true));
+            }
+        }
+    }
+
+    #[test]
+    fn promotion_diagnostics_collect_all_conflict_reasons_for_field() {
+        let reasons = field_conflict_reason_names_for_code(
+            r#"
+extern "C" {
+    fn foreign(p: *mut i32);
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+    pub q: *mut i32,
+}
+
+#[repr(C)]
+pub struct Other {
+    pub r: *mut i32,
+}
+
+pub unsafe fn raw_local(p: *mut i32) {
+    foreign(p);
+}
+
+pub unsafe fn conflict(mut x: i32, mut y: i32, raw: *mut i32, owner: *mut Holder) {
+    let mut h = Holder { p: &raw mut x, q: &raw mut x };
+    let mut other = Other { r: &raw mut x };
+    *h.p = 1;
+    *h.q = 2;
+    *other.r = 3;
+    let _raw_binding: *mut i32 = h.p;
+    let _q_raw_binding: *mut i32 = h.q;
+    x = 2;
+    let _reborrow = &mut x;
+    foreign(h.p);
+    foreign(h.q);
+    raw_local(h.p);
+    let _offset = h.p.sub(1);
+    h.p = raw;
+    h.p = malloc(4) as *mut i32;
+    y = 2;
+    h.q = &raw mut y;
+    y = 3;
+    (*owner).p = h.p;
+    raw_local((*owner).p);
+}
+"#,
+        );
+        let incompatible_raw_storage_reasons = field_conflict_reason_names_for_code(
+            r#"
+#[repr(C)]
+pub struct State {
+    pub value: i32,
+}
+
+#[repr(C)]
+pub struct PrintBuf {
+    pub buffer: *mut State,
+}
+
+pub unsafe fn print_preallocated_like(buffer: *mut State) -> i32 {
+    let mut p = PrintBuf { buffer: std::ptr::null_mut::<State>() };
+    p.buffer = buffer;
+    if p.buffer.is_null() {
+        0
+    } else {
+        1
+    }
+}
+"#,
+        );
+
+        let all_reasons = reasons
+            .values()
+            .chain(incompatible_raw_storage_reasons.values())
+            .flat_map(|reasons| reasons.iter().copied())
+            .collect::<FxHashSet<_>>();
+        for expected in [
+            "active_borrow_overlap",
+            "conflicting_reborrow",
+            "local_assignment_while_borrowed",
+            "mutable_field_copy",
+            "raw_binding_from_field",
+            "raw_field_pointer_projection",
+            "raw_pointee_field_move",
+            "raw_storage_allocator",
+            "raw_storage_pointer",
+        ] {
+            assert!(
+                all_reasons.contains(expected),
+                "expected {expected} in conflict reasons: {all_reasons:?}; all reasons: {reasons:?}"
+            );
+        }
+
+        let holder_p = reasons
+            .iter()
+            .find(|(field, _)| field.ends_with("Holder.p"))
+            .map(|(_, reasons)| reasons)
+            .unwrap_or_else(|| panic!("Holder.p missing from conflict reasons: {reasons:?}"));
+        for expected in [
+            "mutable_field_copy",
+            "raw_binding_from_field",
+            "raw_field_pointer_projection",
+            "raw_pointee_field_move",
+            "raw_storage_allocator",
+        ] {
+            assert!(
+                holder_p.contains(&expected),
+                "expected {expected} in Holder.p conflict reasons: {holder_p:?}; all reasons: {reasons:?}"
+            );
+        }
     }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -836,8 +836,8 @@ pub unsafe fn clear_list(head: *mut Node) {
 }
         "#,
         &[
-            "let mut x: *mut crate::Node =",
-            "let mut y: *mut crate::Node = std::ptr::null_mut();",
+            "let mut x: *mut crate::Node<'a> =",
+            "let mut y: *mut crate::Node<'a> = std::ptr::null_mut();",
         ],
         &["Option<&crate::Node>"],
     );
@@ -1058,8 +1058,1050 @@ pub unsafe fn get_entries(map: *mut Map) -> *mut i32 {
     return (*map).entries;
 }
 "#,
-        &["pub unsafe fn get_entries(map: &crate::Map) -> *const i32"],
-        &["Option<Box<i32>>", "Option<Box<[i32]>>"],
+        &[
+            "pub unsafe fn create_map<'a>() -> Box<crate::Map<'a>>",
+            "Box::new(crate::Map { entries: None })",
+            "pub unsafe fn get_entries<'a>(map: &crate::Map<'a>) -> *const i32",
+        ],
+        &[
+            "Option<Box<i32>>",
+            "Option<Box<[i32]>>",
+            "Box<crate::Map>",
+            "&crate::Map)",
+            "entries: std::ptr::null_mut",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_generic_struct_field_synthetic_default_path() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+}
+
+#[repr(C)]
+pub struct Holder<T> {
+    pub p: *mut T,
+}
+
+pub unsafe fn create<T>() -> *mut Holder<T> {
+    let holder: *mut Holder<T> = malloc(std::mem::size_of::<Holder<T>>()) as *mut Holder<T>;
+    (*holder).p = std::ptr::null_mut();
+    return holder;
+}
+"#,
+        &[
+            "pub struct Holder<'a, T>",
+            "pub p: Option<&'a mut T>",
+            "pub unsafe fn create<'a, T>() -> Box<crate::Holder<'a, T>>",
+            "Box::new(crate::Holder { p: None })",
+        ],
+        &[
+            "crate::Holder<T> {",
+            "Box<crate::Holder<T>>",
+            "p: std::ptr::null_mut",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_mutable_struct_field_to_option_ref() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let mut h = Holder { p: &raw mut x };
+    *h.p = 7;
+    h.p = core::ptr::null_mut();
+    if h.p.is_null() {
+        return x;
+    }
+    *h.p
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i32>",
+            "Holder { p: Some(&mut x) }",
+            "h.p = None;",
+            "h.p.is_none()",
+        ],
+        &["pub p: *mut i32", "*h.p"],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_promoted_field_struct_return_type() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *const i32,
+}
+
+pub unsafe fn make(x: *const i32) -> Holder {
+    Holder { p: x }
+}
+"#,
+        &["pub struct Holder {", "pub p: *const i32", "-> Holder"],
+        &["Holder<'_", "Option<&'a i32>"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_tuple_struct_field_raw() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder(pub *mut i32);
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let h = Holder(&raw mut x);
+    *h.0 = 7;
+    x
+}
+"#,
+        &[
+            "pub struct Holder(pub *mut i32)",
+            "Holder(&raw mut (x))",
+            "*h.0 = 7",
+        ],
+        &["Holder<'_", "Option<&'a mut i32>"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_direct_freed_returned_pointer_raw() {
+    run_test(
+        r#"
+extern "C" {
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe fn id(p: *mut i32) -> *mut i32 {
+    p
+}
+
+pub unsafe fn caller(mut x: i32) {
+    free(id(&raw mut x) as *mut core::ffi::c_void);
+}
+"#,
+        &[
+            "pub unsafe fn id(mut p: *mut i32) -> *mut i32",
+            "free(id(&raw mut (x)) as *mut core::ffi::c_void)",
+        ],
+        &["pub unsafe fn id<'a>", "-> &'a mut i32"],
+    );
+}
+
+#[test]
+fn test_rewriter_updates_impl_headers_for_promoted_struct_lifetimes() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *const i32,
+}
+
+impl Copy for Holder {}
+
+impl Clone for Holder {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let h = Holder { p: &raw const x };
+    let _ = *h.p;
+    x
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "impl<'a> Copy for Holder<'a>",
+            "impl<'a> Clone for Holder<'a>",
+            "pub p: Option<&'a i32>",
+        ],
+        &["impl Copy for Holder {", "impl Clone for Holder {"],
+    );
+}
+
+#[test]
+fn test_rewriter_rewrites_promoted_field_access_inside_impl_methods() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *const i32,
+}
+
+impl Holder {
+    pub unsafe fn read(&self) -> i32 {
+        if self.p.is_null() {
+            return 0;
+        }
+        *self.p
+    }
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let h = Holder { p: &raw const x };
+    let _ = *h.p;
+    h.read()
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "impl<'a> Holder<'a>",
+            "self.p.is_none()",
+            "*(self.p.unwrap())",
+        ],
+        &["impl Holder {", "self.p.is_null()", "*self.p"],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_promoted_field_nested_in_generic_return_type() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let mut h = Holder { p: &raw mut x };
+    *h.p = 7;
+    x
+}
+
+pub unsafe fn maybe_holder() -> Option<Holder> {
+    None
+}
+"#,
+        &[
+            "pub struct Holder {",
+            "pub p: *mut i32",
+            "pub unsafe fn maybe_holder() -> Option<Holder>",
+        ],
+        &["Holder<'_", "Option<&'a mut i32>"],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_promoted_field_raw_pointer_return_type() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+extern "C" {
+    fn make_holder() -> *mut Holder;
+}
+
+pub unsafe fn touch() {
+    let h = make_holder();
+    if !(*h).p.is_null() {
+        *(*h).p = 7;
+    }
+}
+"#,
+        &["pub struct Holder {", "pub p: *mut i32", "-> *mut Holder"],
+        &["Holder<'_", "Option<&'a mut i32>"],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_c_string_field_from_offset_struct_array_call() {
+    run_test(
+        r#"
+#![feature(derive_clone_copy)]
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Record {
+    pub name: *const i8,
+}
+
+pub unsafe fn consume_c_string(s: *const i8) -> i32 {
+    if s.is_null() {
+        return 0;
+    }
+    *s.offset(1) as i32
+}
+
+pub unsafe fn force_field_promotion(mut x: i8) -> i32 {
+    let r = Record { name: &raw const x };
+    *r.name as i32
+}
+
+pub unsafe fn show(fields: *mut Record, i: isize) -> i32 {
+    consume_c_string((*fields.offset(i)).name)
+}
+"#,
+        &["pub struct Record {", "pub name: *const i8"],
+        &["Record<'_", "Option<&'a i8>"],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_c_string_field_from_impl_method_call() {
+    run_test(
+        r#"
+#![feature(derive_clone_copy)]
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Record {
+    pub name: *const i8,
+}
+
+pub unsafe fn consume_c_string(s: *const i8) -> i32 {
+    if s.is_null() {
+        return 0;
+    }
+    *s.offset(1) as i32
+}
+
+impl Record {
+    pub unsafe fn show(fields: *mut Record, i: isize) -> i32 {
+        consume_c_string((*fields.offset(i)).name)
+    }
+}
+
+pub unsafe fn force_field_promotion(mut x: i8) -> i32 {
+    let r = Record { name: &raw const x };
+    *r.name as i32
+}
+"#,
+        &[
+            "pub struct Record {",
+            "pub name: *const i8",
+            "consume_c_string(if",
+        ],
+        &["Record<'_", "Option<&'a i8>"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_direct_raw_field_call_result_raw() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn id(p: *mut i32) -> *mut i32 {
+    p
+}
+
+pub unsafe fn make(mut x: i32) -> Holder {
+    Holder { p: id(&raw mut x) }
+}
+"#,
+        &[
+            "pub struct Holder {",
+            "pub p: *mut i32",
+            "pub unsafe fn id<'a>(p: &'a mut i32) -> *mut i32",
+            "Holder { p: id((Some(&mut x)).unwrap()) }",
+        ],
+        &["Holder<'_", "-> &'a mut i32", "Option<&'a mut i32>"],
+    );
+}
+
+#[test]
+fn test_rewriter_borrows_repeated_optional_mut_arg_without_move() {
+    run_test(
+        r#"
+pub unsafe fn write(p: *mut i32) {
+    *p = 1;
+}
+
+pub unsafe fn caller(p: *mut i32) {
+    if !p.is_null() {
+        write(p);
+        write(p);
+    }
+}
+"#,
+        &[
+            "pub unsafe fn caller(mut p: Option<&mut i32>)",
+            "let p_borrowed = p.as_deref_mut().unwrap();",
+            "write(p_borrowed)",
+        ],
+        &["write((p).unwrap())"],
+    );
+}
+
+#[test]
+fn test_rewriter_reborrows_repeated_optional_mut_arg_for_optional_callee() {
+    run_test(
+        r#"
+pub unsafe fn maybe_write(p: *mut i32) {
+    if !p.is_null() {
+        *p = 1;
+    }
+}
+
+pub unsafe fn caller(p: *mut i32) {
+    if !p.is_null() {
+        maybe_write(p);
+        maybe_write(p);
+    }
+}
+"#,
+        &[
+            "pub unsafe fn maybe_write(mut p: Option<&mut i32>)",
+            "pub unsafe fn caller(mut p: Option<&mut i32>)",
+            "maybe_write((p).as_deref_mut())",
+        ],
+        &["maybe_write(p);"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_raw_cast_local_binding_raw() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Info {
+    pub x: i32,
+}
+
+pub unsafe fn touch(info: *mut Info) {
+    let q: *mut Info = info as *mut Info;
+    (*q).x = 1;
+}
+"#,
+        &[
+            "pub unsafe fn touch(mut info: &mut crate::Info)",
+            "let mut q: *mut crate::Info = (info) as *mut crate::Info;",
+        ],
+        &["let mut q: &mut crate::Info"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_raw_cast_local_call_arg_raw() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Info {
+    pub x: i32,
+}
+
+pub unsafe fn init(info: *mut Info) {
+    (*info).x = 1;
+}
+
+pub unsafe fn touch(info: *mut Info) {
+    init(info as *mut Info);
+}
+"#,
+        &[
+            "pub unsafe fn init(mut info: *mut crate::Info)",
+            "init((info) as *mut crate::Info)",
+        ],
+        &["pub unsafe fn init(mut info: &mut crate::Info)"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_raw_casted_foreign_call_input_raw() {
+    run_test(
+        r#"
+extern "C" {
+    fn strtol(s: *const core::ffi::c_char, endp: *mut *mut core::ffi::c_char, base: core::ffi::c_int) -> core::ffi::c_long;
+}
+
+pub unsafe fn parse(str: *const core::ffi::c_char) -> core::ffi::c_long {
+    let mut endp: *mut i8 = str as *mut core::ffi::c_char as *mut i8;
+    strtol(str, &raw mut endp, 10)
+}
+"#,
+        &[
+            "pub unsafe fn parse(str: *const i8)",
+            "let mut endp: *mut i8",
+            "str as *mut core::ffi::c_char as *mut i8",
+            "strtol(str, &raw mut (endp), 10)",
+        ],
+        &["str: Option<&i8>", "strtol((str)"],
+    );
+}
+
+#[test]
+fn test_rewriter_rewrites_casted_optional_ref_local_binding() {
+    run_test(
+        r#"
+pub unsafe fn read(bytes: *mut u8) -> i32 {
+    let int_ptr: *mut core::ffi::c_int = bytes as *mut core::ffi::c_int;
+    if int_ptr.is_null() {
+        return 0;
+    }
+    *int_ptr
+}
+"#,
+        &[
+            "let int_ptr: Option<&i32>",
+            "as *const i32",
+            "int_ptr.is_none()",
+        ],
+        &["bytes as *mut core::ffi::c_int"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_generic_struct_field_preserves_type_args() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder<T> {
+    pub p: *mut T,
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let mut h: Holder<i32> = Holder { p: &raw mut x };
+    *h.p = 7;
+    x
+}
+"#,
+        &[
+            "pub struct Holder<'a, T>",
+            "pub p: Option<&'a mut T>",
+            "let mut h: Holder<'_, i32> = Holder { p: Some(&mut x) };",
+        ],
+        &["Holder<i32>", "pub p: *mut T", "*h.p"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_struct_field_after_existing_lifetime_args() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder<'ctx, T> {
+    pub ctx: &'ctx T,
+    pub p: *mut T,
+}
+
+pub unsafe fn touch<'ctx>(ctx: &'ctx i32, mut x: i32) -> i32 {
+    let mut h: Holder<'ctx, i32> = Holder { ctx, p: &raw mut x };
+    *h.p = 7;
+    *h.ctx
+}
+"#,
+        &[
+            "pub struct Holder<'ctx, 'a, T>",
+            "pub p: Option<&'a mut T>",
+            "let mut h: Holder<'ctx, '_, i32> = Holder { ctx, p: Some(&mut x) };",
+        ],
+        &[
+            "Holder<'a, 'ctx",
+            "Holder<'_, 'ctx",
+            "Holder<'ctx, i32>",
+            "*h.p",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_self_referential_struct_field_pointee_lifetime() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Node {
+    pub next: *mut Node,
+    pub value: i32,
+}
+
+pub unsafe fn touch() -> i32 {
+    let mut other = Node { next: std::ptr::null_mut(), value: 1 };
+    let mut node = Node { next: &raw mut other, value: 0 };
+    (*node.next).value = 2;
+    node.value
+}
+"#,
+        &[
+            "pub struct Node<'a>",
+            "pub next: Option<&'a mut Node<'a>>",
+            "Node { next: None, value: 1 }",
+            "Node { next: Some(&mut other), value: 0 }",
+        ],
+        &["Option<&'a mut Node>", "*node.next"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_mutable_field_write_from_immutable_holder() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let h = Holder { p: &raw mut x };
+    *h.p = 7;
+    x
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i32>",
+            "let mut h = Holder { p: Some(&mut x) };",
+        ],
+        &["let h = Holder", "pub p: *mut i32", "*h.p"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_mutable_field_write_from_by_value_param() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn write(h: Holder) {
+    *h.p = 7;
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let h = Holder { p: &raw mut x };
+    write(h);
+    x
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i32>",
+            "pub unsafe fn write(mut h: Holder<'_>)",
+        ],
+        &["pub unsafe fn write(h: Holder<'_>)", "*h.p"],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_struct_field_on_active_raw_mut_reborrow() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let h = Holder { p: &raw mut x };
+    let q = &raw mut x;
+    *q = 1;
+    *h.p = 7;
+    x
+}
+"#,
+        &["pub p: *mut i32", "Holder { p: &raw mut x }", "*h.p = 7"],
+        &["Option<&'a mut i32>", "h.p.as_deref_mut"],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_mutable_struct_field_to_field_assignment_with_rhs_reuse() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut x: i32, mut y: i32) -> i32 {
+    let mut h1 = Holder { p: &raw mut x };
+    let h2 = Holder { p: &raw mut y };
+    h1.p = h2.p;
+    *h1.p = 7;
+    *h2.p = 9;
+    x
+}
+"#,
+        &["pub p: *mut i32", "h1.p = h2.p;", "*h2.p = 9"],
+        &[
+            "Option<&'a mut i32>",
+            "h1.p.as_deref_mut",
+            "h2.p.as_deref_mut",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_mutable_struct_field_literal_copy_with_rhs_reuse() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut y: i32) -> i32 {
+    let h2 = Holder { p: &raw mut y };
+    let h1 = Holder { p: h2.p };
+    *h1.p = 7;
+    *h2.p = 9;
+    y
+}
+"#,
+        &["pub p: *mut i32", "Holder { p: h2.p }", "*h2.p = 9"],
+        &[
+            "Option<&'a mut i32>",
+            "h1.p.as_deref_mut",
+            "h2.p.as_deref_mut",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_mutable_rhs_field_copied_to_shared_field() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Source {
+    pub p: *mut i32,
+}
+
+#[repr(C)]
+pub struct View {
+    pub q: *const i32,
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let src = Source { p: &raw mut x };
+    let view = View { q: src.p };
+    *src.p = 7;
+    *view.q
+}
+"#,
+        &["pub p: *mut i32", "View { q: src.p }", "*src.p = 7"],
+        &["pub p: Option<&'a mut i32>", "src.p.as_deref_mut"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_nested_struct_path_in_field_pointee_type() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Node {
+    pub value: *mut i32,
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub nodes: *const Vec<Node>,
+}
+
+pub unsafe fn set_node(mut x: i32) -> i32 {
+    let mut node = Node { value: &raw mut x };
+    *node.value = 7;
+    x
+}
+
+pub unsafe fn hold(nodes: &Vec<Node>) -> usize {
+    let holder = Holder { nodes: std::ptr::null() };
+    if holder.nodes.is_null() {
+        return nodes.len();
+    }
+    (*holder.nodes).len()
+}
+"#,
+        &[
+            "pub struct Node<'a>",
+            "pub value: Option<&'a mut i32>",
+            "pub struct Holder<'a>",
+            "pub nodes: Option<&'a Vec<Node<'a>>>",
+        ],
+        &["Vec<Node>>", "Vec<Node>"],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_multiple_mutable_struct_fields_from_same_local() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Pair {
+    pub a: *mut i32,
+    pub b: *mut i32,
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let pair = Pair { a: &raw mut x, b: &raw mut x };
+    *pair.a = 3;
+    *pair.b = 4;
+    x
+}
+"#,
+        &[
+            "pub a: *mut i32",
+            "pub b: *mut i32",
+            "Pair { a: &raw mut x, b: &raw mut x }",
+        ],
+        &["Option<&'a mut i32>", "Some(&mut x)", "as_deref_mut"],
+    );
+}
+
+#[test]
+fn test_rewriter_demotes_mixed_mutable_shared_struct_fields_from_same_local() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Pair {
+    pub a: *mut i32,
+    pub b: *const i32,
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let pair = Pair { a: &raw mut x, b: &raw const x };
+    *pair.a = 3;
+    *pair.b
+}
+"#,
+        &[
+            "pub a: *mut i32",
+            "pub b: *const i32",
+            "Pair { a: &raw mut x, b: &raw const x }",
+        ],
+        &[
+            "Option<&'a mut i32>",
+            "Option<&'b i32>",
+            "Some(&mut x)",
+            "Some(&x)",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_shared_struct_field_to_option_ref() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *const i32,
+}
+
+pub unsafe fn read(x: i32) -> i32 {
+    let h = Holder { p: &raw const x };
+    *h.p
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a i32>",
+            "Holder { p: Some(&x) }",
+            "h.p.unwrap()",
+        ],
+        &["pub p: *const i32", "*h.p"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_multiple_struct_fields_with_distinct_lifetimes() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Pair {
+    pub a: *mut i32,
+    pub b: *const i32,
+}
+
+pub unsafe fn sum(mut x: i32, y: i32) -> i32 {
+    let mut pair = Pair { a: &raw mut x, b: &raw const y };
+    *pair.a = 3;
+    *pair.a + *pair.b
+}
+"#,
+        &[
+            "pub struct Pair<'a, 'b>",
+            "pub a: Option<&'a mut i32>",
+            "pub b: Option<&'b i32>",
+            "Pair { a: Some(&mut x), b: Some(&y) }",
+        ],
+        &["pub a: *mut i32", "pub b: *const i32"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_demoted_struct_field_raw() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn conflict() -> i32 {
+    let mut x = 0;
+    let mut h = Holder { p: &raw mut x };
+    x = 1;
+    *h.p = 2;
+    x
+}
+"#,
+        &["pub p: *mut i32", "*h.p = 2"],
+        &["pub struct Holder<'a>", "Option<&'a mut i32>"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_identity_return_with_named_lifetime() {
+    run_test(
+        r#"
+pub unsafe fn id(x: *mut i32) -> *mut i32 {
+    return x;
+}
+"#,
+        &[
+            "pub unsafe fn id<'a>(x: &'a mut i32) -> &'a mut i32",
+            "return x;",
+        ],
+        &["-> *mut i32", "Option<&'a mut i32>"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_interprocedural_return_lifetime() {
+    run_test(
+        r#"
+pub unsafe fn id(x: *mut i32) -> *mut i32 {
+    x
+}
+
+pub unsafe fn wrap(y: *mut i32) -> *mut i32 {
+    id(y)
+}
+"#,
+        &[
+            "pub unsafe fn id<'a>(x: &'a mut i32) -> &'a mut i32",
+            "pub unsafe fn wrap<'a>(y: &'a mut i32) -> &'a mut i32",
+            "id(y)",
+        ],
+        &["-> *mut i32", "id((y) as *mut"],
+    );
+}
+
+#[test]
+fn test_rewriter_preserves_nullable_returned_borrow_lifetime() {
+    run_test(
+        r#"
+pub unsafe fn maybe(flag: bool, x: *mut i32) -> *mut i32 {
+    if flag { x } else { core::ptr::null_mut() }
+}
+"#,
+        &[
+            "pub unsafe fn maybe<'a>(flag: bool, mut x: Option<&'a mut i32>)",
+            "-> Option<&'a mut i32>",
+            "if flag { x } else { None }",
+            "None",
+        ],
+        &["-> &'a mut i32", "panic!()"],
+    );
+}
+
+#[test]
+fn test_rewriter_preserves_nullable_returned_borrow_through_local() {
+    run_test(
+        r#"
+pub unsafe fn maybe_local(flag: bool, x: *mut i32) -> *mut i32 {
+    let r = if flag { x } else { core::ptr::null_mut() };
+    r
+}
+"#,
+        &[
+            "pub unsafe fn maybe_local<'a>(flag: bool, mut x: Option<&'a mut i32>)",
+            "-> Option<&'a mut i32>",
+            "let mut r: Option<&mut i32> = if flag { x } else { None }",
+            "r",
+        ],
+        &["-> &'a mut i32", "panic!()"],
+    );
+}
+
+#[test]
+fn test_rewriter_preserves_nullable_returned_borrow_null_literal() {
+    run_test(
+        r#"
+pub unsafe fn maybe_zero(flag: bool, x: *mut i32) -> *mut i32 {
+    if flag { x } else { 0 as *mut i32 }
+}
+"#,
+        &[
+            "pub unsafe fn maybe_zero<'a>(flag: bool, mut x: Option<&'a mut i32>)",
+            "-> Option<&'a mut i32>",
+            "if flag { x } else { None }",
+        ],
+        &["-> &'a mut i32", "panic!()"],
+    );
+}
+
+#[test]
+fn test_rewriter_preserves_nullable_returned_input_without_null_return() {
+    run_test(
+        r#"
+pub unsafe fn pick(x: *mut i32, y: *mut i32) -> *mut i32 {
+    *y = 1;
+    if x.is_null() { y } else { x }
+}
+"#,
+        &[
+            "mut x: Option<&'a mut i32>",
+            "y: &'a mut i32",
+            "-> &'a mut i32",
+            "if x.is_none()",
+        ],
+        &["x: &'a mut i32", "if false"],
+    );
+}
+
+#[test]
+fn test_rewriter_generated_lifetime_names_skip_existing_params() {
+    run_test(
+        r#"
+pub unsafe fn pick_existing<'a>(x: &'a i32, y: *const i32) -> *const i32 {
+    y
+}
+"#,
+        &["pub unsafe fn pick_existing<'a, 'b>(x: &'a i32, y: &'b i32) -> &'b i32"],
+        &["-> *const i32"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_fn_pointer_signature_raw_with_return_relation() {
+    run_test(
+        r#"
+pub unsafe fn id(x: *mut i32) -> *mut i32 {
+    x
+}
+
+pub unsafe fn caller(mut x: i32) -> i32 {
+    let f: unsafe fn(*mut i32) -> *mut i32 = id;
+    let p = f(&mut x);
+    *p
+}
+"#,
+        &[
+            "let f: unsafe fn(*mut i32) -> *mut i32 = id",
+            "pub unsafe fn id(x: *mut i32) -> *mut i32",
+        ],
+        &["pub unsafe fn id<'a>"],
     );
 }
 
@@ -3263,7 +4305,7 @@ pub unsafe fn complexmode(
         &[
             "let mut log_msg___v: *mut i8",
             "let mut log_message: *mut i8",
-            "log_message)).unwrap() = rv___t.1",
+            "Some(&mut log_message).unwrap() = rv___t.1",
         ],
         &["let mut log_msg___v: *const i8", "let mut log_message: &"],
     );

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -1450,10 +1450,84 @@ pub unsafe fn touch(mut buf: [i32; 2]) -> i32 {
 "#,
         &[
             "pub struct Holder<'a>",
-            "pub p: Option<&'a mut i32>",
-            "std::slice::from_raw_parts_mut",
+            "pub p: &'a mut [i32]",
+            "as usize..",
         ],
-        &["pub p: *mut i32", "*h.p.offset(1) = 9;"],
+        &[
+            "pub p: Option<&'a mut i32>",
+            "pub p: *mut i32",
+            "*h.p.offset(1) = 9;",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_array_like_struct_field_to_slice() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut buf: [i32; 2]) -> i32 {
+    let h = Holder { p: buf.as_mut_ptr() };
+    *h.p.offset(1) = 9;
+    buf[1]
+}
+"#,
+        &["pub p: &'a mut [i32]", "as usize.."],
+        &[
+            "pub p: Option<&'a mut i32>",
+            "pub p: *mut i32",
+            "*h.p.offset",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_negative_offset_struct_field_to_slice_cursor() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *const i32,
+}
+
+pub unsafe fn touch(buf: [i32; 4]) -> i32 {
+    let h = Holder { p: buf.as_ptr().offset(3) };
+    *h.p.offset(-1)
+}
+"#,
+        &[
+            "pub p: crate::slice_cursor::SliceCursor<'a, i32>",
+            "crate::slice_cursor::SliceCursor::",
+            ".seek((-1) as isize)",
+        ],
+        &["pub p: Option<&'a i32>", "pub p: *const i32", "*h.p.offset"],
+    );
+}
+
+#[test]
+fn test_rewriter_reads_mutable_cursor_field_through_shared_struct_ref() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct State {
+    pub words: *mut u32,
+    pub word_index: i32,
+}
+
+pub unsafe fn load_word(s: *const State) -> u32 {
+    *(*s).words.offset((*s).word_index as isize)
+}
+"#,
+        &[
+            "pub words: crate::slice_cursor::SliceCursorMut<'a, u32>",
+            ".as_slice()",
+            ".seek(((*s).word_index as isize) as isize)",
+        ],
+        &["let mut _c = ((*s).words);", "*(*s).words.offset"],
     );
 }
 
@@ -1473,14 +1547,10 @@ pub unsafe fn load_word(s: *const State) -> u32 {
 "#,
         &[
             "pub struct State<'a>",
-            "pub words: Option<&'a u32>",
-            ".offset((*s).word_index as isize)).as_ref()",
-            ".unwrap()",
+            "pub words: crate::slice_cursor::SliceCursor<'a, u32>",
+            ".seek(((*s).word_index as isize) as isize)",
         ],
-        &[
-            "return *(((*s).words).as_deref().map_or",
-            "*(*s).words.offset",
-        ],
+        &["pub words: Option<&'a u32>", "*(*s).words.offset"],
     );
 }
 
@@ -1502,10 +1572,39 @@ pub unsafe fn cp_ptr(s: *const State) -> *const i8 {
 "#,
         &[
             "pub struct State<'a>",
-            "pub words: Option<&'a u32>",
-            "std::ptr::null::<u32>()",
+            "pub words: crate::slice_cursor::SliceCursor<'a, u32>",
+            "crate::slice_cursor::SliceCursor::from_raw_parts",
+            ".seek((-(((*s).count / 8) as isize)) as isize)",
         ],
-        &["std::ptr::null::<i8>(), |_x| _x"],
+        &[
+            "pub words: Option<&'a u32>",
+            "std::ptr::null::<i8>(), |_x| _x",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_rewrites_casted_mutable_cursor_field_from_shared_struct_ref() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct State {
+    pub words: *mut u32,
+    pub word_index: i32,
+    pub count: i32,
+}
+
+pub unsafe fn cp_ptr(s: *const State) -> *const i8 {
+    return (((*s).words.offset((*s).word_index as isize)) as *mut i8)
+        .offset(-(((*s).count / 8) as isize)) as *const i8;
+}
+"#,
+        &[
+            "pub words: crate::slice_cursor::SliceCursorMut<'a, u32>",
+            ".as_slice()",
+            ".seek((-(((*s).count / 8) as isize)) as isize)",
+        ],
+        &["}).as_mut_ptr()", "*(*s).words.offset"],
     );
 }
 
@@ -1592,10 +1691,11 @@ pub unsafe fn touch(buf: [i8; 2]) -> i32 {
 "#,
         &[
             "pub struct Holder<'a>",
-            "pub p: Option<&'a i8>",
-            "read_second(&(std::slice::from_raw_parts",
+            "pub unsafe fn read_second(p: &[i8])",
+            "pub p: &'a [i8]",
+            "read_second(h.p)",
         ],
-        &["pub p: *const i8"],
+        &["pub p: Option<&'a i8>", "pub p: *const i8"],
     );
 }
 
@@ -1621,10 +1721,14 @@ pub unsafe fn prog_fetch(p: *mut Program, out: *mut i32) {
 "#,
         &[
             "pub struct Program<'a>",
+            "pub code: &'a [i32]",
+            "code: &'a [i32]",
+            "(*p).code = (code);",
+        ],
+        &[
             "pub code: Option<&'a i32>",
             "(*p).code = (code).as_ptr().as_ref();",
         ],
-        &["(*p).code = (code).first();"],
     );
 }
 
@@ -2037,10 +2141,11 @@ pub unsafe fn show(fields: *mut Record, i: isize) -> i32 {
 "#,
         &[
             "pub struct Record<'a>",
-            "pub name: Option<&'a i8>",
-            "consume_c_string(&(std::slice::from_raw_parts",
+            "pub name: &'a [i8]",
+            "pub unsafe fn consume_c_string(s: &[i8])",
+            "consume_c_string(((fields)[(i) as isize]).name)",
         ],
-        &["pub name: *const i8"],
+        &["pub name: Option<&'a i8>", "pub name: *const i8"],
     );
 }
 
@@ -6340,8 +6445,11 @@ pub unsafe extern "C" fn bar() -> libc::c_int {
     return foo(q, 1 as libc::c_int);
 }
 "#,
-        &[".as_deref()"],
-        &["SliceCursor::new((", ").as_slice())"],
+        &[
+            "SliceCursor::new((p).as_slice())",
+            ".seek((4 as isize) as isize)",
+        ],
+        &["}).as_deref()"],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -1074,6 +1074,36 @@ pub unsafe fn get_entries(map: *mut Map) -> *mut i32 {
 }
 
 #[test]
+fn test_rewriter_promotes_struct_field_through_borrowed_struct_return() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *const i32,
+}
+
+pub unsafe fn id_holder(h: *mut Holder) -> *mut Holder {
+    h
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let mut h = Holder { p: &raw const x };
+    let r = id_holder(&raw mut h);
+    *(*r).p
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a i32>",
+            "pub unsafe fn id_holder<'a>(h: &'a mut crate::Holder<'a>)",
+            "-> &'a mut crate::Holder<'a>",
+            "Holder { p: Some(&x) }",
+        ],
+        &["pub p: *const i32", "*(*r).p"],
+    );
+}
+
+#[test]
 fn test_rewriter_promotes_generic_struct_field_synthetic_default_path() {
     run_test(
         r#"
@@ -1997,6 +2027,22 @@ pub unsafe fn id(x: *mut i32) -> *mut i32 {
 "#,
         &[
             "pub unsafe fn id<'a>(x: &'a mut i32) -> &'a mut i32",
+            "return x;",
+        ],
+        &["-> *mut i32", "Option<&'a mut i32>"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_extern_c_identity_return_with_named_lifetime() {
+    run_test(
+        r#"
+pub unsafe extern "C" fn id(x: *mut i32) -> *mut i32 {
+    return x;
+}
+"#,
+        &[
+            "pub unsafe extern \"C\" fn id<'a>(x: &'a mut i32) -> &'a mut i32",
             "return x;",
         ],
         &["-> *mut i32", "Option<&'a mut i32>"],
@@ -5694,8 +5740,11 @@ pub unsafe extern "C" fn foo(mut x: *mut libc::c_int) -> *mut libc::c_int {
     return x;
 }
 "#,
-        &["*const"],
-        &[],
+        &[
+            "pub unsafe extern \"C\" fn foo<'a>(mut x: &'a mut i32)",
+            "-> &'a mut i32",
+        ],
+        &["-> *mut libc::c_int", "*const"],
     );
 }
 
@@ -5716,8 +5765,15 @@ pub unsafe extern "C" fn bar() {
     *q = foo(&mut x);
 }
 "#,
-        &["*const"],
-        &[],
+        &[
+            "pub unsafe extern \"C\" fn foo<'a>(mut x: &'a mut i32)",
+            "-> &'a mut i32",
+            "*q = (foo((Some(&mut x)).unwrap())) as *mut i32;",
+        ],
+        &[
+            "pub unsafe extern \"C\" fn foo(mut x: *mut libc::c_int)",
+            "-> *mut libc::c_int",
+        ],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -31,6 +31,20 @@ fn run_test(code: &str, includes: &[&str], excludes: &[&str]) {
     }
 }
 
+fn run_test_with_config(code: &str, config: &Config, includes: &[&str], excludes: &[&str]) {
+    let (s, _) = rewrite_with_config(code, config);
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    for include in includes {
+        assert!(s.contains(include), "Expected to find `{include}` in:\n{s}");
+    }
+    for exclude in excludes {
+        assert!(
+            !s.contains(exclude),
+            "Expected not to find `{exclude}` in:\n{s}",
+        );
+    }
+}
+
 #[test]
 fn test_local_ptr_to_ref() {
     run_test(
@@ -6108,6 +6122,102 @@ pub unsafe extern "C" fn caller(v_info: *mut core::ffi::c_void, offset: i32, val
             "pub unsafe extern \"C\" fn set_type(mut addr: *mut u32",
             "*(addr as *mut u8).offset",
         ],
+    );
+}
+
+#[test]
+fn test_c_exposed_abi_struct_without_interface_wrapper_stays_raw() {
+    let mut config = Config::default();
+    config.c_exposed_fns.insert("parse_number".to_string());
+    run_test_with_config(
+        r#"
+#[repr(C)]
+pub struct parse_buffer {
+    pub content: *const u8,
+    pub length: usize,
+    pub offset: usize,
+    pub depth: usize,
+}
+
+#[repr(C)]
+pub struct cJSON {
+    pub valueint: i32,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn parse_number(item: *mut cJSON, input_buffer: *mut parse_buffer) -> i32 {
+    if input_buffer.is_null() || (*input_buffer).content.is_null() {
+        return 0;
+    }
+    let b = *(*input_buffer).content.offset((*input_buffer).offset as isize);
+    (*item).valueint = b as i32;
+    (*input_buffer).offset += 1;
+    return 1;
+}
+"#,
+        &config,
+        &["pub content: *const u8"],
+        &["pub struct parse_buffer<", "pub content: &'"],
+    );
+}
+
+#[test]
+fn test_c_exposed_slice_element_abi_struct_fields_stay_raw() {
+    let mut config = Config::default();
+    config.c_exposed_fns.insert("driver".to_string());
+    run_test_with_config(
+        r#"
+#[repr(C)]
+pub struct Record {
+    pub name: *const i8,
+    pub value: i32,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn driver(records: *const Record) -> i32 {
+    if records.is_null() {
+        return 0;
+    }
+    let first = records.offset(0);
+    if (*first).name.is_null() {
+        return (*first).value;
+    }
+    return *(*first).name as i32 + (*first).value;
+}
+"#,
+        &config,
+        &["pub name: *const i8"],
+        &["pub struct Record<", "pub name: Option<&", "pub name: &'"],
+    );
+}
+
+#[test]
+fn test_c_exposed_wrapped_function_does_not_freeze_non_slice_struct_param() {
+    let mut config = Config::default();
+    config
+        .c_exposed_fns
+        .insert("SPX_wots_gen_leafx1".to_string());
+    run_test_with_config(
+        r#"
+#[repr(C)]
+pub struct Info {
+    pub steps: *const u32,
+    pub leaf_addr: [u32; 8],
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SPX_wots_gen_leafx1(dest: *mut u8, info: *mut Info, len: usize) {
+    let mut i = 0usize;
+    while i < len {
+        *dest.offset(i as isize) = *(*info).steps.offset(i as isize) as u8;
+        i += 1;
+    }
+    *dest.offset(0) = (*info).leaf_addr[0] as u8;
+}
+"#,
+        &config,
+        &["pub struct Info<", "pub steps: &'"],
+        &["pub steps: *const u32"],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -6625,6 +6625,40 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     );
 }
 
+#[test]
+fn test_c_exposed_signature_struct_fields_stay_raw() {
+    let mut config = Config::default();
+    config.c_exposed_fns.insert("driver".to_string());
+    let (s, _) = rewrite_with_config(
+        r#"
+#[repr(C)]
+pub struct Record {
+    pub precision: *const i8,
+}
+
+pub unsafe fn use_str(p: *const i8) -> i8 {
+    return *p.offset(0);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn driver(fields: *const Record) -> i8 {
+    return use_str((*fields).precision);
+}
+"#,
+        &config,
+    );
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+
+    assert!(
+        s.contains("pub struct Record {\n    pub precision: *const i8,"),
+        "expected C-exposed signature struct fields to keep raw C layout:\n{s}"
+    );
+    assert!(
+        !s.contains("pub struct Record<"),
+        "expected C-exposed signature struct not to gain pointer lifetimes:\n{s}"
+    );
+}
+
 /// Raw pointer mutability cast: `p` is *mut (writes through it), `q` is *const
 /// (only compared). The comparison `p == q` requires matching types, so a cast
 /// is inserted.

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -3138,6 +3138,48 @@ pub unsafe fn init_and_clear(holder: *mut Holder) {
 }
 
 #[test]
+fn test_rewriter_keeps_dynamic_local_struct_field_free_raw() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+#[repr(C)]
+pub struct Pixel {
+    pub value: i32,
+}
+
+#[repr(C)]
+pub struct Image {
+    pub pix: *mut Pixel,
+}
+
+pub unsafe fn load(len: usize) {
+    let mut img = Image { pix: core::ptr::null_mut() };
+    img.pix = malloc(len * std::mem::size_of::<Pixel>()) as *mut Pixel;
+    free(img.pix as *mut core::ffi::c_void);
+}
+
+pub unsafe fn load_via_local(len: usize) {
+    let mut img = Image { pix: core::ptr::null_mut() };
+    let pix = malloc(len * std::mem::size_of::<Pixel>()) as *mut Pixel;
+    img.pix = pix;
+    free(img.pix as *mut core::ffi::c_void);
+}
+"#,
+        &[
+            "img.pix = malloc(len * std::mem::size_of::<Pixel>()) as *mut Pixel;",
+            "let mut pix: *mut crate::Pixel",
+            "img.pix = pix;",
+            "free(img.pix as *mut core::ffi::c_void);",
+        ],
+        &["Box::from_raw("],
+    );
+}
+
+#[test]
 fn test_rewriter_bridges_raw_array_realloc_null_root_and_free() {
     run_test(
         r#"

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -6625,40 +6625,6 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     );
 }
 
-#[test]
-fn test_c_exposed_signature_struct_fields_stay_raw() {
-    let mut config = Config::default();
-    config.c_exposed_fns.insert("driver".to_string());
-    let (s, _) = rewrite_with_config(
-        r#"
-#[repr(C)]
-pub struct Record {
-    pub precision: *const i8,
-}
-
-pub unsafe fn use_str(p: *const i8) -> i8 {
-    return *p.offset(0);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn driver(fields: *const Record) -> i8 {
-    return use_str((*fields).precision);
-}
-"#,
-        &config,
-    );
-    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-
-    assert!(
-        s.contains("pub struct Record {\n    pub precision: *const i8,"),
-        "expected C-exposed signature struct fields to keep raw C layout:\n{s}"
-    );
-    assert!(
-        !s.contains("pub struct Record<"),
-        "expected C-exposed signature struct not to gain pointer lifetimes:\n{s}"
-    );
-}
-
 /// Raw pointer mutability cast: `p` is *mut (writes through it), `q` is *const
 /// (only compared). The comparison `p == q` requires matching types, so a cast
 /// is inserted.

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -2984,10 +2984,11 @@ pub unsafe fn free_nested() {
     free(p as *mut core::ffi::c_void);
 }
 "#,
-        &["Box::into_raw(Box::new(", "Box::from_raw("],
+        &["Box::leak(Box::new(", "Box::from_raw("],
         &[
             "let mut p: *mut *mut i32 = malloc(",
             "free(p as *mut core::ffi::c_void);",
+            "Box::into_raw(",
         ],
     );
 }
@@ -3031,10 +3032,93 @@ pub unsafe fn free_one() {
     free(p as *mut core::ffi::c_void);
 }
 "#,
-        &["Box::into_raw(Box::new(", "Box::from_raw("],
+        &["Box::leak(Box::new(", "Box::from_raw("],
         &[
             "calloc(1, std::mem::size_of::<*mut i32>())",
             "free(p as *mut core::ffi::c_void);",
+            "Box::into_raw(",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_bridges_raw_scalar_typedef_sizeof_allocator_root_and_free() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+#[repr(C)]
+pub struct Node {
+    pub next: *mut NodeAlias,
+    pub value: i32,
+}
+
+pub type NodeAlias = Node;
+
+#[repr(C)]
+pub struct List {
+    pub head: *mut NodeAlias,
+}
+
+pub unsafe fn push_alias_sized(list: *mut List) {
+    let node: *mut NodeAlias =
+        malloc(std::mem::size_of::<NodeAlias>()) as *mut NodeAlias;
+    if node.is_null() {
+        return;
+    }
+    (*node).next = (*list).head;
+    (*list).head = node;
+}
+
+pub unsafe fn clear_alias_sized(list: *mut List) {
+    free((*list).head as *mut core::ffi::c_void);
+}
+"#,
+        &["Box::leak(Box::new(", "Box::from_raw("],
+        &[
+            "malloc(std::mem::size_of::<NodeAlias>())",
+            "free(p as *mut core::ffi::c_void);",
+            "Box::into_raw(",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_bridges_raw_scalar_field_allocator_root_and_free() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+#[repr(C)]
+pub struct Node {
+    pub value: i32,
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub node: *mut Node,
+}
+
+pub unsafe fn init_and_clear(holder: *mut Holder) {
+    (*holder).node = malloc(std::mem::size_of::<Node>()) as *mut Node;
+    if ((*holder).node).is_null() {
+        return;
+    }
+    (*(*holder).node).value = 7;
+    free((*holder).node as *mut core::ffi::c_void);
+}
+"#,
+        &["Box::leak(Box::new(", "Box::from_raw("],
+        &[
+            "malloc(std::mem::size_of::<Node>())",
+            "free((*holder).node as *mut core::ffi::c_void);",
+            "Box::into_raw(",
         ],
     );
 }
@@ -3059,6 +3143,33 @@ pub unsafe fn alloc_chars(len: usize) {
             "realloc(std::ptr::null_mut::<core::ffi::c_void>(), len)",
             "free(buf as *mut core::ffi::c_void);",
         ],
+    );
+}
+
+#[test]
+fn test_rewriter_box_from_raw_free_evaluates_argument_once() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+#[repr(C)]
+pub struct Node {
+    pub value: i32,
+}
+
+pub unsafe fn alloc_node() -> *mut Node {
+    malloc(std::mem::size_of::<Node>()) as *mut Node
+}
+
+pub unsafe fn cleanup() {
+    free(alloc_node() as *mut core::ffi::c_void);
+}
+"#,
+        &["let __crat_raw_free =", "Box::from_raw((__crat_raw_free)"],
+        &["Box::from_raw((alloc_node()"],
     );
 }
 
@@ -3088,10 +3199,11 @@ pub unsafe fn foo() {
     dealloc_ptr(p as *mut core::ffi::c_void);
 }
 "#,
-        &["Box::into_raw(Box::new(", "Box::from_raw("],
+        &["Box::leak(Box::new(", "Box::from_raw("],
         &[
             "alloc_zeroed(1, std::mem::size_of::<i32>())",
             "dealloc_ptr(p as *mut core::ffi::c_void);",
+            "Box::into_raw(",
         ],
     );
 }
@@ -3481,11 +3593,12 @@ pub unsafe fn helper() -> i32 {
     result
 }
 "#,
+        &["Box::leak(Box::new(", "Box::from_raw("],
         &[
             "calloc(1, std::mem::size_of::<State>())",
             "free(s as *mut core::ffi::c_void);",
+            "Box::into_raw(",
         ],
-        &["Box::into_raw(", "Box::leak("],
     );
 }
 
@@ -3517,11 +3630,12 @@ pub unsafe fn helper() -> i32 {
     0
 }
 "#,
+        &["Box::leak(Box::new(", "Box::from_raw("],
         &[
             "calloc(1, std::mem::size_of::<State>())",
             "free(result as *mut core::ffi::c_void);",
+            "Box::into_raw(",
         ],
-        &["Box::into_raw(", "Box::leak("],
     );
 }
 
@@ -3552,8 +3666,12 @@ pub unsafe fn helper() -> i32 {
     0
 }
 "#,
-        &["calloc(1, std::mem::size_of::<State>())"],
-        &["Box::into_raw(", "Box::leak("],
+        &["Box::leak(Box::new(", "Box::from_raw("],
+        &[
+            "calloc(1, std::mem::size_of::<State>())",
+            "free(state as *mut core::ffi::c_void);",
+            "Box::into_raw(",
+        ],
     );
 }
 
@@ -3587,11 +3705,12 @@ pub unsafe fn helper() -> i32 {
     0
 }
 "#,
+        &["Box::leak(Box::new(", "Box::from_raw("],
         &[
             "calloc(1, std::mem::size_of::<State>())",
             "free(s as *mut core::ffi::c_void);",
+            "Box::into_raw(",
         ],
-        &["Box::into_raw(", "Box::leak("],
     );
 }
 
@@ -3639,8 +3758,12 @@ pub unsafe fn helper() -> i32 {
     result
 }
 "#,
-        &["calloc(1, std::mem::size_of::<State>())"],
-        &["Box::into_raw(", "Box::leak("],
+        &["Box::leak(Box::new(", "Box::from_raw("],
+        &[
+            "calloc(1, std::mem::size_of::<State>())",
+            "free(s as *mut core::ffi::c_void);",
+            "Box::into_raw(",
+        ],
     );
 }
 
@@ -3683,11 +3806,11 @@ pub unsafe fn checkshift_like() -> i32 {
     result
 }
 "#,
-        &["Box::into_raw(Box::new(", "Box::from_raw("],
+        &["Box::leak(Box::new(", "Box::from_raw("],
         &[
             "malloc(std::mem::size_of::<State>())",
             "free(state as *mut core::ffi::c_void);",
-            "Box::leak(",
+            "Box::into_raw(",
         ],
     );
 }

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -1167,6 +1167,201 @@ pub unsafe fn touch(mut x: i32) -> i32 {
 }
 
 #[test]
+fn test_rewriter_removes_unneeded_generated_copy_for_mutable_struct_field() {
+    run_test(
+        r#"
+#![feature(derive_clone_copy)]
+
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+    pub tag: i32,
+}
+
+#[automatically_derived]
+impl ::core::marker::Copy for Holder {}
+
+#[automatically_derived]
+impl ::core::clone::Clone for Holder {
+    #[inline]
+    fn clone(&self) -> Holder {
+        let _: ::core::clone::AssertParamIsClone<*mut i32>;
+        let _: ::core::clone::AssertParamIsClone<i32>;
+        *self
+    }
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let mut h = Holder { p: &raw mut x, tag: 3 };
+    *h.p = 7;
+    h.p = core::ptr::null_mut();
+    h.tag
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i32>",
+            "Holder { p: Some(&mut x), tag: 3 }",
+            "h.p = None;",
+        ],
+        &[
+            "pub p: *mut i32",
+            "impl ::core::marker::Copy for Holder",
+            "impl ::core::clone::Clone for Holder",
+            "*h.p = 7",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_reborrows_mutable_promoted_field_for_shared_pointer_assignment() {
+    run_test(
+        r#"
+#![feature(derive_clone_copy)]
+
+#[repr(C)]
+pub struct Node {
+    pub value: i32,
+    pub next: *mut Node,
+}
+
+#[automatically_derived]
+impl ::core::marker::Copy for Node {}
+
+#[automatically_derived]
+impl ::core::clone::Clone for Node {
+    #[inline]
+    fn clone(&self) -> Node {
+        let _: ::core::clone::AssertParamIsClone<i32>;
+        let _: ::core::clone::AssertParamIsClone<*mut Node>;
+        *self
+    }
+}
+
+pub unsafe fn last_value(mut head: *mut Node) -> i32 {
+    if head.is_null() {
+        return 0;
+    }
+    while !(*head).next.is_null() {
+        head = (*head).next;
+    }
+    (*head).value
+}
+"#,
+        &[
+            "pub struct Node<'a>",
+            "pub next: Option<&'a mut Node<'a>>",
+            "head = ((*head.unwrap()).next).as_deref();",
+        ],
+        &[
+            "impl ::core::marker::Copy for Node",
+            "impl ::core::clone::Clone for Node",
+            "head = unsafe { ((*(head).as_deref().unwrap()).next).as_ref() };",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_preserves_generated_copy_when_struct_is_reused_after_raw_storage_move() {
+    run_test(
+        r#"
+#![feature(derive_clone_copy)]
+
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+    pub tag: i32,
+}
+
+#[automatically_derived]
+impl ::core::marker::Copy for Holder {}
+
+#[automatically_derived]
+impl ::core::clone::Clone for Holder {
+    #[inline]
+    fn clone(&self) -> Holder {
+        let _: ::core::clone::AssertParamIsClone<*mut i32>;
+        let _: ::core::clone::AssertParamIsClone<i32>;
+        *self
+    }
+}
+
+pub unsafe fn touch(mut x: i32, slot: *mut Holder) -> i32 {
+    let h = Holder { p: &raw mut x, tag: 3 };
+    *slot = h;
+    *h.p = 7;
+    h.tag
+}
+"#,
+        &[
+            "pub struct Holder {",
+            "pub p: *mut i32",
+            "impl ::core::marker::Copy for Holder",
+            "impl ::core::clone::Clone for Holder",
+            "*slot = h;",
+            "*h.p = 7",
+        ],
+        &["pub p: Option<&'a mut i32>", "Holder<'a>"],
+    );
+}
+
+#[test]
+fn test_rewriter_preserves_generated_copy_when_copy_container_depends_on_struct() {
+    run_test(
+        r#"
+#![feature(derive_clone_copy)]
+
+#[repr(C)]
+pub struct Inner {
+    pub p: *mut i32,
+}
+
+#[automatically_derived]
+impl ::core::marker::Copy for Inner {}
+
+#[automatically_derived]
+impl ::core::clone::Clone for Inner {
+    #[inline]
+    fn clone(&self) -> Inner {
+        let _: ::core::clone::AssertParamIsClone<*mut i32>;
+        *self
+    }
+}
+
+#[repr(C)]
+pub struct Outer {
+    pub inner: Inner,
+}
+
+#[automatically_derived]
+impl ::core::marker::Copy for Outer {}
+
+#[automatically_derived]
+impl ::core::clone::Clone for Outer {
+    #[inline]
+    fn clone(&self) -> Outer {
+        let _: ::core::clone::AssertParamIsClone<Inner>;
+        *self
+    }
+}
+
+pub unsafe fn touch(mut x: i32) -> i32 {
+    let inner = Inner { p: &raw mut x };
+    *inner.p = 7;
+    0
+}
+"#,
+        &[
+            "pub struct Inner {",
+            "pub p: *mut i32",
+            "impl ::core::marker::Copy for Inner",
+            "impl ::core::marker::Copy for Outer",
+        ],
+        &["pub p: Option<&'a mut i32>", "Inner<'a>"],
+    );
+}
+
+#[test]
 fn test_rewriter_demotes_promoted_field_struct_return_type() {
     run_test(
         r#"

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -167,7 +167,7 @@ pub unsafe fn foo() -> *mut i32 {
 }
 
 #[test]
-fn test_rewriter_keeps_field_stored_malloc_raw() {
+fn test_rewriter_rewrites_owned_scalar_struct_field_to_opt_box() {
     run_test(
         r#"
 extern "C" {
@@ -186,10 +186,185 @@ pub unsafe fn stash(owner: *mut Holder) {
 }
 "#,
         &[
-            "malloc(std::mem::size_of::<i32>())",
-            "(*owner).data = data;",
+            "pub data: Option<Box<i32>>",
+            "Box::from_raw((data) as *mut i32)",
         ],
-        &["Option<Box<i32>>", "Some(Box::new("],
+        &["pub data: *mut i32", "(*owner).data = data;"],
+    );
+}
+
+#[test]
+fn test_rewriter_drops_selected_owned_scalar_struct_field_free() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub data: *mut i32,
+}
+
+pub unsafe fn stash(owner: *mut Holder) {
+    let data: *mut i32 = malloc(std::mem::size_of::<i32>());
+    (*owner).data = data;
+}
+
+pub unsafe fn release(owner: *mut Holder) {
+    free((*owner).data as *mut core::ffi::c_void);
+}
+"#,
+        &["pub data: Option<Box<i32>>", "drop(((*owner).data).take())"],
+        &["free((*owner).data as *mut core::ffi::c_void);"],
+    );
+}
+
+#[test]
+fn test_rewriter_drops_nested_owned_scalar_struct_field_free() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub data: *mut i32,
+}
+
+#[repr(C)]
+pub struct Outer {
+    pub inner: Holder,
+}
+
+pub unsafe fn stash(owner: *mut Outer) {
+    (*owner).inner.data = malloc(std::mem::size_of::<i32>());
+}
+
+pub unsafe fn release(owner: *mut Outer) {
+    free((*owner).inner.data as *mut core::ffi::c_void);
+}
+"#,
+        &[
+            "pub data: Option<Box<i32>>",
+            "drop(((*owner).inner.data).take())",
+        ],
+        &["drop(((*owner).data).take())"],
+    );
+}
+
+#[test]
+fn test_rewriter_marks_local_owned_scalar_struct_field_free_mutable() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub data: *mut i32,
+}
+
+pub unsafe fn stash(owner: *mut Holder) {
+    (*owner).data = malloc(std::mem::size_of::<i32>());
+}
+
+pub unsafe fn release_local() {
+    let h = Holder { data: malloc(std::mem::size_of::<i32>()) };
+    free(h.data as *mut core::ffi::c_void);
+}
+"#,
+        &["let mut h = Holder", "drop((h.data).take())"],
+        &[
+            "let h = crate::Holder",
+            "free(h.data as *mut core::ffi::c_void);",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_unsupported_owned_scalar_struct_field_raw() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub data: *mut i32,
+}
+
+pub unsafe fn stash(owner: *mut Holder) {
+    (*owner).data = malloc(2 * std::mem::size_of::<i32>());
+}
+"#,
+        &[
+            "pub data: *mut i32",
+            "malloc(2 * std::mem::size_of::<i32>())",
+        ],
+        &["pub data: Option<&", "pub data: Option<Box<i32>>"],
+    );
+}
+
+#[test]
+fn test_rewriter_removes_generated_copy_clone_for_owned_scalar_struct_field() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Holder {
+    pub data: *mut i32,
+}
+
+pub unsafe fn stash(owner: *mut Holder) {
+    (*owner).data = malloc(std::mem::size_of::<i32>());
+}
+"#,
+        &["pub data: Option<Box<i32>>"],
+        &["impl Copy for", "impl Clone for"],
+    );
+}
+
+#[test]
+fn test_rewriter_visits_impl_for_owned_scalar_struct_field() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut i32;
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub data: *mut i32,
+}
+
+pub unsafe fn stash(owner: *mut Holder) {
+    let data: *mut i32 = malloc(std::mem::size_of::<i32>());
+    (*owner).data = data;
+}
+
+impl Holder {
+    pub unsafe fn init(&mut self) {
+        self.data = malloc(std::mem::size_of::<i32>());
+    }
+}
+"#,
+        &[
+            "pub data: Option<Box<i32>>",
+            "Box::from_raw((data) as *mut i32)",
+            "self.data = Some(Box::new(<i32 as Default>::default()));",
+        ],
+        &["pub data: *mut i32", "self.data = malloc"],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -1470,7 +1470,7 @@ pub unsafe fn caller(p: *mut i32) {
 }
 
 #[test]
-fn test_rewriter_keeps_raw_cast_local_binding_raw() {
+fn test_rewriter_rewrites_noop_cast_local_binding_to_ref() {
     run_test(
         r#"
 #[repr(C)]
@@ -1485,14 +1485,14 @@ pub unsafe fn touch(info: *mut Info) {
 "#,
         &[
             "pub unsafe fn touch(mut info: &mut crate::Info)",
-            "let mut q: *mut crate::Info = (info) as *mut crate::Info;",
+            "let mut q: &mut crate::Info = (Some(&mut *(info))).unwrap();",
         ],
-        &["let mut q: &mut crate::Info"],
+        &["let mut q: *mut crate::Info"],
     );
 }
 
 #[test]
-fn test_rewriter_keeps_raw_cast_local_call_arg_raw() {
+fn test_rewriter_rewrites_noop_cast_local_call_arg_to_ref() {
     run_test(
         r#"
 #[repr(C)]
@@ -1509,10 +1509,37 @@ pub unsafe fn touch(info: *mut Info) {
 }
 "#,
         &[
-            "pub unsafe fn init(mut info: *mut crate::Info)",
-            "init((info) as *mut crate::Info)",
+            "pub unsafe fn init(mut info: &mut crate::Info)",
+            "init((Some(&mut *(info))).unwrap());",
         ],
-        &["pub unsafe fn init(mut info: &mut crate::Info)"],
+        &["pub unsafe fn init(mut info: *mut crate::Info)"],
+    );
+}
+
+#[test]
+fn test_rewriter_does_not_demote_ref_callee_for_noop_cast_call() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct State {
+    pub h: [u32; 8],
+    pub flag: i32,
+}
+
+pub unsafe fn init(state: *mut State) {
+    (*state).h[0] = 1;
+    (*state).flag = 0;
+}
+
+pub unsafe fn caller(ctx: *mut State) {
+    init(ctx as *mut State);
+}
+"#,
+        &[
+            "pub unsafe fn init(mut state: &mut crate::State)",
+            "init((Some(&mut *(ctx))).unwrap());",
+        ],
+        &["pub unsafe fn init(mut state: *mut crate::State)"],
     );
 }
 
@@ -5053,6 +5080,74 @@ pub unsafe extern "C" fn foo() {
 "#,
         &["bytemuck::cast_slice_mut", "slice::from_mut", "as usize..]"],
         &["*mut", "as *mut"],
+    );
+}
+
+#[test]
+fn test_param_byte_cast_offset_rewrites_to_slice_bytemuck() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Info {
+    pub leaf_addr: [u32; 8],
+}
+
+pub unsafe extern "C" fn set_type(addr: *mut u32, offset: i32, value: u32) {
+    *(addr as *mut u8).offset(offset as isize) = value as u8;
+}
+
+pub unsafe extern "C" fn caller(info: *mut Info, offset: i32, value: u32) {
+    let leaf_addr: *mut u32 = (*info).leaf_addr.as_mut_ptr();
+    set_type(leaf_addr as *mut u32, offset, value);
+}
+"#,
+        &[
+            "pub unsafe extern \"C\" fn set_type(mut addr: &mut [u32]",
+            "bytemuck::cast_slice_mut::<_,",
+            "u8>(&mut (addr))",
+            "set_type((leaf_addr).as_slice_mut(), offset, value);",
+        ],
+        &[
+            "pub unsafe extern \"C\" fn set_type(mut addr: *mut u32",
+            "*(addr as *mut u8).offset",
+        ],
+    );
+}
+
+#[test]
+fn test_raw_local_noop_cast_call_does_not_demote_slice_callee() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Info {
+    pub leaf_addr: [u32; 8],
+}
+
+extern "C" {
+    fn consume(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe extern "C" fn set_type(addr: *mut u32, offset: i32, value: u32) {
+    *(addr as *mut u8).offset(offset as isize) = value as u8;
+}
+
+pub unsafe extern "C" fn caller(v_info: *mut core::ffi::c_void, offset: i32, value: u32) {
+    let info: *mut Info = v_info as *mut Info;
+    consume(info as *mut core::ffi::c_void);
+    let leaf_addr: *mut u32 = (*info).leaf_addr.as_mut_ptr();
+    set_type(leaf_addr as *mut u32, offset, value);
+}
+"#,
+        &[
+            "pub unsafe extern \"C\" fn set_type(mut addr: &mut [u32]",
+            "bytemuck::cast_slice_mut::<_,",
+            "u8>(&mut (addr))",
+            "set_type(if (leaf_addr).is_null()",
+        ],
+        &[
+            "pub unsafe extern \"C\" fn set_type(mut addr: *mut u32",
+            "*(addr as *mut u8).offset",
+        ],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -1167,6 +1167,293 @@ pub unsafe fn touch(mut x: i32) -> i32 {
 }
 
 #[test]
+fn test_rewriter_promotes_mutable_struct_field_assigned_from_raw_pointer() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut x: i32, mut buf: [i32; 1]) -> i32 {
+    let mut h = Holder { p: &raw mut x };
+    *h.p = 7;
+    h.p = buf.as_mut_ptr();
+    if !h.p.is_null() {
+        *h.p = 9;
+    }
+    x
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i32>",
+            "Holder { p: Some(&mut x) }",
+            "h.p = (buf.as_mut_ptr()).as_mut();",
+        ],
+        &[
+            "pub p: *mut i32",
+            "h.p = buf.as_mut_ptr();",
+            "unsafe { (buf.as_mut_ptr()).as_mut()",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_mutable_struct_field_zero_initializer_to_none() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut buf: [i32; 1]) -> i32 {
+    let mut h = Holder { p: 0 as *mut i32 };
+    h.p = buf.as_mut_ptr();
+    if !h.p.is_null() {
+        *h.p = 9;
+    }
+    buf[0]
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i32>",
+            "Holder { p: None }",
+            "h.p = (buf.as_mut_ptr()).as_mut();",
+        ],
+        &["(0).as_mut()", "0 as *mut i32"],
+    );
+}
+
+#[test]
+fn test_rewriter_casts_raw_rhs_assigned_to_promoted_field() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i8,
+}
+
+pub unsafe fn touch(out: *mut core::ffi::c_void) -> i8 {
+    let mut h = Holder { p: std::ptr::null_mut() };
+    let _addr = out as usize;
+    h.p = out as *mut i8;
+    if !h.p.is_null() {
+        *h.p = 9;
+    }
+    0
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i8>",
+            "h.p = (out as *mut i8).as_mut();",
+        ],
+        &[
+            "h.p = out as *mut i8;",
+            "unsafe { (out as *mut i8).as_mut()",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_field_with_offset_deref_receiver() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut buf: [i32; 2]) -> i32 {
+    let mut h = Holder { p: buf.as_mut_ptr() };
+    *h.p.offset(1) = 9;
+    buf[1]
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i32>",
+            "std::slice::from_raw_parts_mut",
+        ],
+        &["pub p: *mut i32", "*h.p.offset(1) = 9;"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_borrowed_struct_field_offset_deref_to_slice_index() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct State {
+    pub words: *const u32,
+    pub word_index: i32,
+}
+
+pub unsafe fn load_word(s: *const State) -> u32 {
+    return *(*s).words.offset((*s).word_index as isize);
+}
+"#,
+        &[
+            "pub struct State<'a>",
+            "pub words: Option<&'a u32>",
+            ".offset((*s).word_index as isize)).as_ref()",
+            ".unwrap()",
+        ],
+        &[
+            "return *(((*s).words).as_deref().map_or",
+            "*(*s).words.offset",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_rewrites_casted_promoted_field_offset_return() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct State {
+    pub words: *const u32,
+    pub word_index: i32,
+    pub count: i32,
+}
+
+pub unsafe fn cp_ptr(s: *const State) -> *const i8 {
+    return (((*s).words.offset((*s).word_index as isize)) as *const i8)
+        .offset(-(((*s).count / 8) as isize));
+}
+"#,
+        &[
+            "pub struct State<'a>",
+            "pub words: Option<&'a u32>",
+            "std::ptr::null::<u32>()",
+        ],
+        &["std::ptr::null::<i8>(), |_x| _x"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_field_passed_to_unknown_raw_call() {
+    run_test(
+        r#"
+extern "C" {
+    fn foreign(p: *mut i32);
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch() -> i32 {
+    let mut x = 0;
+    let mut h = Holder { p: &raw mut x };
+    foreign(h.p);
+    *h.p = 7;
+    x
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i32>",
+            "foreign((h.p).as_deref_mut().map_or",
+        ],
+        &["pub p: *mut i32"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_field_passed_to_local_raw_call() {
+    run_test(
+        r#"
+pub unsafe fn local_raw(p: *mut i32) {
+    extern "C" {
+        fn foreign(p: *mut i32);
+    }
+    foreign(p);
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch() -> i32 {
+    let mut x = 0;
+    let mut h = Holder { p: &raw mut x };
+    local_raw(h.p);
+    *h.p = 7;
+    x
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a mut i32>",
+            "local_raw((h.p).as_deref_mut())",
+        ],
+        &["pub p: *mut i32"],
+    );
+}
+
+#[test]
+fn test_rewriter_promotes_field_passed_to_local_slice_call() {
+    run_test(
+        r#"
+pub unsafe fn read_second(p: *const i8) -> i32 {
+    *p.offset(1) as i32
+}
+
+#[repr(C)]
+pub struct Holder {
+    pub p: *const i8,
+}
+
+pub unsafe fn touch(buf: [i8; 2]) -> i32 {
+    let h = Holder { p: buf.as_ptr() };
+    read_second(h.p)
+}
+"#,
+        &[
+            "pub struct Holder<'a>",
+            "pub p: Option<&'a i8>",
+            "read_second(&(std::slice::from_raw_parts",
+        ],
+        &["pub p: *const i8"],
+    );
+}
+
+#[test]
+fn test_rewriter_stores_slice_param_into_promoted_field_via_raw_bridge() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Program {
+    pub code: *const i32,
+    pub n: usize,
+}
+
+pub unsafe fn prog_init(p: *mut Program, code: *const i32, n: usize, out: *mut i32) {
+    (*p).code = code;
+    *out = *code.offset(0);
+    (*p).n = n;
+}
+
+pub unsafe fn prog_fetch(p: *mut Program, out: *mut i32) {
+    *out = *(*p).code.offset(0);
+}
+"#,
+        &[
+            "pub struct Program<'a>",
+            "pub code: Option<&'a i32>",
+            "(*p).code = (code).as_ptr().as_ref();",
+        ],
+        &["(*p).code = (code).first();"],
+    );
+}
+
+#[test]
 fn test_rewriter_removes_unneeded_generated_copy_for_mutable_struct_field() {
     run_test(
         r#"
@@ -1546,7 +1833,7 @@ pub unsafe fn touch() {
 }
 
 #[test]
-fn test_rewriter_demotes_c_string_field_from_offset_struct_array_call() {
+fn test_rewriter_promotes_c_string_field_from_offset_struct_array_call() {
     run_test(
         r#"
 #![feature(derive_clone_copy)]
@@ -1573,13 +1860,17 @@ pub unsafe fn show(fields: *mut Record, i: isize) -> i32 {
     consume_c_string((*fields.offset(i)).name)
 }
 "#,
-        &["pub struct Record {", "pub name: *const i8"],
-        &["Record<'_", "Option<&'a i8>"],
+        &[
+            "pub struct Record<'a>",
+            "pub name: Option<&'a i8>",
+            "consume_c_string(&(std::slice::from_raw_parts",
+        ],
+        &["pub name: *const i8"],
     );
 }
 
 #[test]
-fn test_rewriter_demotes_c_string_field_from_impl_method_call() {
+fn test_rewriter_promotes_c_string_field_from_impl_method_call() {
     run_test(
         r#"
 #![feature(derive_clone_copy)]
@@ -1609,11 +1900,12 @@ pub unsafe fn force_field_promotion(mut x: i8) -> i32 {
 }
 "#,
         &[
-            "pub struct Record {",
-            "pub name: *const i8",
-            "consume_c_string(if",
+            "pub struct Record<'a>",
+            "impl<'a> Record<'a>",
+            "pub name: Option<&'a i8>",
+            "consume_c_string(&(std::slice::from_raw_parts",
         ],
-        &["Record<'_", "Option<&'a i8>"],
+        &["pub name: *const i8"],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -189,7 +189,7 @@ pub unsafe fn stash(owner: *mut Holder) {
             "pub data: Option<Box<i32>>",
             "Box::from_raw((data) as *mut i32)",
         ],
-        &["pub data: *mut i32", "(*owner).data = data;"],
+        &["pub data: *mut i32", "(*owner).data = data;", "unsafe {"],
     );
 }
 
@@ -3169,7 +3169,7 @@ pub unsafe fn cleanup() {
 }
 "#,
         &["let __crat_raw_free =", "Box::from_raw((__crat_raw_free)"],
-        &["Box::from_raw((alloc_node()"],
+        &["Box::from_raw((alloc_node()", "unsafe {"],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -1609,6 +1609,30 @@ pub unsafe fn cp_ptr(s: *const State) -> *const i8 {
 }
 
 #[test]
+fn test_rewriter_cursor_numeric_cast_uses_bytemuck_not_raw_parts() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Pair {
+    pub a: i32,
+    pub b: i32,
+}
+
+pub unsafe fn container_from_b(i: *const i32) -> *const Pair {
+    ((i as *const i8).offset(-(4 as isize))) as *const Pair
+}
+"#,
+        &[
+            "pub unsafe fn container_from_b(i: crate::slice_cursor::SliceCursor<'_, i32>)",
+            "bytemuck::cast_slice::<_,",
+            "i8>((i).as_slice())",
+            ".seek((-(4 as isize)) as isize)",
+        ],
+        &["crate::slice_cursor::SliceCursor::from_raw_parts((i).as_ptr()"],
+    );
+}
+
+#[test]
 fn test_rewriter_promotes_field_passed_to_unknown_raw_call() {
     run_test(
         r#"


### PR DESCRIPTION
## Summary

Borrow inference now treats direct raw pointer struct fields as promotion candidates, and the rewriter can emit the struct/function lifetimes needed to use promoted fields and returned pointers as references, slices, or slice cursors.

## What Changed

- Tracks raw pointer struct fields through borrow inference and lifetime-flow summaries, including demoting fields when promotion would conflict with raw uses, by-value struct shapes, or required `Copy` semantics.
- Rewrites promoted fields to references, slices, and slice cursors, updating struct definitions, impl headers, type uses, literals, assignments, derefs, raw bridges, and call arguments.
- Rewrites returned borrowed pointers to named-lifetime references/options when lifetime flow proves the return comes from an input.
- Adds experimental owned-field rewriting for scalar owning raw fields into `Option<Box<T>>`, including selected `free` removal and generated `Copy`/`Clone` removal when safe. This path does not appear to materially reduce unsafe counts yet.
- Extends offset-sign analysis to struct fields so array-like field promotions choose `SliceCursor` only when negative offsets can reach the field.
- Adds promotion/ownership diagnostics

## Evaluation

My evaluation setting may not be the same as @Medowhill but there were some reductions:

```
Metric                       Before   After   Change
----------------------------------------------------
total                         72328   72168     -160
UseOfMutableStatic            36122   36124       +2
DerefOfRawPointer             14484   14349     -135
offset                         3551    3535      -16
from_raw_parts_mut             1554    1558       +4
from_raw_parts                  789     783       -6
as_mut                          704     705       +1
as_ref                          298     301       +3
from_raw                          1     115     +114   from replacing free during malloc/calloc reduction
free                            191      77     -114
malloc                           40      28      -12
calloc                            5       4       -1
```

I will keep investigating the remaining cases.