### PR TITLE
Function pointer group analysis

### DIFF
--- a/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
@@ -117,6 +117,7 @@ impl FnPtrGroups {
                         let dec = member_decs.get(i).copied().flatten();
                         match (agreed, dec) {
                             (_, None) => return None,
+                            (Some(k), _) | (_, Some(k)) if k.is_owning_box_like() => return None,
                             (None, Some(k)) => agreed = Some(k),
                             (Some(a), Some(b)) if a == b => {}
                             _ => return None,

--- a/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
@@ -94,7 +94,6 @@ impl FnPtrGroups {
             let input_len = tcx.fn_sig(*rep).skip_binder().inputs().skip_binder().len();
 
             let mut all_input_decs: Vec<Vec<Option<PtrKind>>> = Vec::new();
-            let mut all_output_decs: Vec<Option<PtrKind>> = Vec::new();
 
             for &did in members {
                 let decision_maker = DecisionMaker::new(analysis, did, tcx);
@@ -111,20 +110,7 @@ impl FnPtrGroups {
                         decision_maker.decide(param, param_decl, param_aliases)
                     })
                     .collect();
-
-                let return_local = Local::from_u32(0);
-                let return_decl = &body.local_decls[return_local];
-                let return_aliases = aliases.and_then(|a| a.get(&return_local));
-                let direct_output_dec = get_direct_output_dec(decision_maker.decide(
-                    return_local,
-                    return_decl,
-                    return_aliases,
-                ));
-                let returned_local_dec =
-                    infer_returned_local_box_kind(body, &decision_maker, aliases, return_local);
-                let output_dec = get_output_dec(direct_output_dec, returned_local_dec);
                 all_input_decs.push(member_input_decs);
-                all_output_decs.push(output_dec);
             }
 
             // Intersect: position i gets Some(k) only if ALL members agree on k

--- a/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
@@ -1,0 +1,444 @@
+use points_to::andersen;
+use rustc_hash::FxHashMap;
+use rustc_hir::def_id::LocalDefId;
+use rustc_middle::{mir::Local, ty};
+
+use crate::{
+    rewriter::{
+        Analysis,
+        decision::{
+            DecisionMaker, PtrKind, get_direct_output_dec, get_output_dec,
+            infer_returned_local_box_kind,
+        },
+    },
+    utils::{dsa::union_find::UnionFind, rustc::RustProgram},
+};
+
+rustc_index::newtype_index! {
+    struct FnPtrIdx {}
+}
+
+#[derive(Default)]
+pub struct FnPtrGroups {
+    /// maps each fn-ptr-participating function to its group representative
+    pub fn_to_group: FxHashMap<LocalDefId, LocalDefId>,
+    /// maps group representative to joint per-parameter input decisions
+    pub group_decisions: FxHashMap<LocalDefId, Vec<Option<PtrKind>>>,
+}
+
+impl FnPtrGroups {
+    pub fn build<'tcx>(
+        pre: &andersen::PreAnalysisData<'tcx>,
+        solutions: &andersen::Solutions,
+        rust_program: &RustProgram<'tcx>,
+        analysis: &Analysis,
+    ) -> Self {
+        // --- Step 1: collect participants and build union-find ---
+
+        // Gather all LocalDefIds from inv_fns that are also in rust_program.functions
+        let fn_set: FxHashMap<LocalDefId, ()> =
+            rust_program.functions.iter().map(|&d| (d, ())).collect();
+        let true_fn_ptr_set = crate::rewriter::collector::collect_fn_ptrs(rust_program);
+        let mut participants: Vec<LocalDefId> = true_fn_ptr_set
+            .iter()
+            .copied()
+            .filter(|d| fn_set.contains_key(d))
+            .collect();
+        participants.sort_unstable_by_key(|d| d.local_def_index);
+
+        if participants.is_empty() {
+            return FnPtrGroups::default();
+        }
+
+        let did_to_idx: FxHashMap<LocalDefId, FnPtrIdx> = participants
+            .iter()
+            .enumerate()
+            .map(|(i, &did)| (did, FnPtrIdx::from_usize(i)))
+            .collect();
+        let mut uf = UnionFind::<FnPtrIdx>::new(participants.len());
+
+        for (_, pointees) in solutions.iter_enumerated() {
+            let fn_idxs: Vec<FnPtrIdx> = pointees
+                .iter()
+                .filter_map(|loc| pre.inv_fns.get(&loc))
+                .filter_map(|did| did_to_idx.get(did).copied())
+                .collect();
+            if fn_idxs.len() >= 2 {
+                let first = fn_idxs[0];
+                for &other in &fn_idxs[1..] {
+                    uf.union(first, other);
+                }
+            }
+        }
+
+        let mut fn_to_group: FxHashMap<LocalDefId, LocalDefId> = FxHashMap::default();
+        for &did in &participants {
+            let idx = did_to_idx[&did];
+            let rep_idx = uf.find(idx);
+            let rep_did = participants[rep_idx.index()];
+            fn_to_group.insert(did, rep_did);
+        }
+
+        // --- Step 2: compute joint decisions per group ---
+
+        // Collect members per group representative
+        let mut group_members: FxHashMap<LocalDefId, Vec<LocalDefId>> = FxHashMap::default();
+        for (&did, &rep) in &fn_to_group {
+            group_members.entry(rep).or_default().push(did);
+        }
+
+        let mut group_decisions: FxHashMap<LocalDefId, Vec<Option<PtrKind>>> = FxHashMap::default();
+
+        for (rep, members) in &group_members {
+            let tcx = rust_program.tcx;
+            let input_len = tcx.fn_sig(*rep).skip_binder().inputs().skip_binder().len();
+
+            let mut all_input_decs: Vec<Vec<Option<PtrKind>>> = Vec::new();
+            let mut all_output_decs: Vec<Option<PtrKind>> = Vec::new();
+
+            for &did in members {
+                let decision_maker = DecisionMaker::new(analysis, did, tcx);
+                let body = &*tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+                let aliases = analysis.aliases.get(&did);
+
+                let member_input_decs: Vec<Option<PtrKind>> = body
+                    .local_decls
+                    .iter_enumerated()
+                    .skip(1)
+                    .take(input_len)
+                    .map(|(param, param_decl)| {
+                        let param_aliases = aliases.and_then(|a| a.get(&param));
+                        decision_maker.decide(param, param_decl, param_aliases)
+                    })
+                    .collect();
+
+                let return_local = Local::from_u32(0);
+                let return_decl = &body.local_decls[return_local];
+                let return_aliases = aliases.and_then(|a| a.get(&return_local));
+                let direct_output_dec = get_direct_output_dec(decision_maker.decide(
+                    return_local,
+                    return_decl,
+                    return_aliases,
+                ));
+                let returned_local_dec =
+                    infer_returned_local_box_kind(body, &decision_maker, aliases, return_local);
+                let output_dec = get_output_dec(direct_output_dec, returned_local_dec);
+                all_input_decs.push(member_input_decs);
+                all_output_decs.push(output_dec);
+            }
+
+            // Intersect: position i gets Some(k) only if ALL members agree on k
+            let joint_inputs: Vec<Option<PtrKind>> = (0..input_len)
+                .map(|i| {
+                    let mut agreed: Option<PtrKind> = None;
+                    for member_decs in &all_input_decs {
+                        let dec = member_decs.get(i).copied().flatten();
+                        match (agreed, dec) {
+                            (_, None) => return None,
+                            (None, Some(k)) => agreed = Some(k),
+                            (Some(a), Some(b)) if a == b => {}
+                            _ => return None,
+                        }
+                    }
+                    agreed
+                })
+                .collect();
+
+            group_decisions.insert(*rep, joint_inputs);
+        }
+
+        FnPtrGroups {
+            fn_to_group,
+            group_decisions,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustc_hir::def_id::LocalDefId;
+
+    use super::*;
+    use crate::rewriter::{Config, replace_local_borrows};
+
+    fn rewrite(code: &str) -> String {
+        ::utils::compilation::run_compiler_on_str(code, |tcx| {
+            replace_local_borrows(&Config::default(), tcx).0
+        })
+        .unwrap()
+    }
+
+    fn named_fns(tcx: rustc_middle::ty::TyCtxt<'_>) -> Vec<(String, LocalDefId)> {
+        tcx.hir_crate(())
+            .owners
+            .iter()
+            .filter_map(|maybe_owner| {
+                let owner = maybe_owner.as_owner()?;
+                let rustc_hir::OwnerNode::Item(item) = owner.node() else {
+                    return None;
+                };
+                match item.kind {
+                    rustc_hir::ItemKind::Fn { .. } => Some((
+                        tcx.item_name(item.owner_id.def_id.to_def_id()).to_string(),
+                        item.owner_id.def_id,
+                    )),
+                    _ => None,
+                }
+            })
+            .collect()
+    }
+
+    fn find_did(named: &[(String, LocalDefId)], name: &str) -> LocalDefId {
+        named
+            .iter()
+            .find(|(n, _)| n == name)
+            .unwrap_or_else(|| panic!("function '{name}' not found"))
+            .1
+    }
+
+    fn build_groups_for(code: &str) -> (FnPtrGroups, Vec<(String, LocalDefId)>) {
+        ::utils::compilation::run_compiler_on_str(code, |tcx| {
+            use rustc_hash::FxHashSet;
+
+            use crate::rewriter::collect_input;
+            let input = collect_input(tcx);
+            let arena = typed_arena::Arena::new();
+            let tss = utils::ty_shape::get_ty_shapes(&arena, tcx, false);
+            let config = points_to::andersen::Config {
+                use_optimized_mir: false,
+                c_exposed_fns: FxHashSet::default(),
+            };
+            let pre = points_to::andersen::pre_analyze(&config, &tss, tcx);
+            let solutions = points_to::andersen::analyze(&config, &pre, &tss, tcx);
+            let aliases = crate::rewriter::find_param_aliases(&pre, &solutions, tcx);
+            let mutability_result =
+                crate::analyses::type_qualifier::foster::mutability::mutability_analysis(&input);
+            let output_params = crate::analyses::output_params::compute_output_params(
+                &input,
+                &mutability_result,
+                &aliases,
+            );
+            let source_var_groups =
+                crate::analyses::mir_variable_grouping::SourceVarGroups::new(&input);
+            let mutables = source_var_groups.postprocess_mut_res(&input, &mutability_result);
+            let (mutable_references, shared_references) =
+                crate::analyses::borrow::mutable_references_no_guarantee(&input, &mutables);
+            let promoted_mut_ref_result =
+                source_var_groups.postprocess_promoted_mut_refs(mutable_references);
+            let promoted_shared_ref_result =
+                source_var_groups.postprocess_promoted_mut_refs(shared_references);
+            let fatness_result =
+                crate::analyses::type_qualifier::foster::fatness::fatness_analysis(&input);
+            let mut offset_sign_result =
+                crate::analyses::offset_sign::sign::offset_sign_analysis(&input);
+            offset_sign_result.access_signs =
+                source_var_groups.postprocess_offset_signs(offset_sign_result.access_signs);
+            let nullity_result = crate::analyses::nullity::analyze(&input);
+            let analysis = crate::rewriter::Analysis {
+                promoted_mut_ref_result,
+                promoted_shared_ref_result,
+                mutability_result,
+                fatness_result,
+                aliases,
+                output_params,
+                ownership_schemes: None,
+                offset_sign_result,
+                nullity_result,
+            };
+            let groups = FnPtrGroups::build(&pre, &solutions, &input, &analysis);
+            let named = named_fns(tcx);
+            (groups, named)
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn two_fns_sharing_a_slot_are_grouped() {
+        let code = r#"
+pub unsafe fn f(p: *const i32) -> i32 { *p }
+pub unsafe fn g(p: *const i32) -> i32 { *p + 1 }
+pub unsafe fn call_it(cb: unsafe fn(*const i32) -> i32, p: *const i32) -> i32 { cb(p) }
+pub unsafe fn test(p: *const i32) -> i32 {
+    call_it(f, p) + call_it(g, p)
+}
+"#;
+        let (groups, named) = build_groups_for(code);
+        let did_f = find_did(&named, "f");
+        let did_g = find_did(&named, "g");
+        assert!(
+            groups.fn_to_group.contains_key(&did_f),
+            "f should be a participant"
+        );
+        assert!(
+            groups.fn_to_group.contains_key(&did_g),
+            "g should be a participant"
+        );
+        let rep_f = groups.fn_to_group[&did_f];
+        let rep_g = groups.fn_to_group[&did_g];
+        assert_eq!(rep_f, rep_g, "f and g should share a group representative");
+    }
+
+    #[test]
+    fn unrelated_fn_is_not_grouped_with_fn_ptr_fns() {
+        let code = r#"
+pub unsafe fn f(p: *const i32) -> i32 { *p }
+pub unsafe fn g(p: *const i32) -> i32 { *p + 1 }
+pub unsafe fn standalone(p: *const i32) -> i32 { *p * 2 }
+pub unsafe fn call_it(cb: unsafe fn(*const i32) -> i32, p: *const i32) -> i32 { cb(p) }
+pub unsafe fn test(p: *const i32) -> i32 {
+    call_it(f, p) + call_it(g, p)
+}
+"#;
+        let (groups, named) = build_groups_for(code);
+        let did_f = find_did(&named, "f");
+        let did_g = find_did(&named, "g");
+        let did_standalone = find_did(&named, "standalone");
+        let rep_f = groups.fn_to_group[&did_f];
+        let rep_g = groups.fn_to_group[&did_g];
+        assert_eq!(rep_f, rep_g, "f and g should share a group representative");
+        if let Some(&rep_standalone) = groups.fn_to_group.get(&did_standalone) {
+            assert_ne!(
+                rep_standalone, rep_f,
+                "standalone should not be grouped with f/g"
+            );
+        }
+    }
+
+    #[test]
+    fn two_fns_sharing_slot_get_ref_param() {
+        let code = r#"
+pub unsafe fn f(p: *const i32) -> i32 { *p }
+pub unsafe fn g(p: *const i32) -> i32 { *p + 1 }
+pub unsafe fn call_it(cb: unsafe fn(*const i32) -> i32, p: *const i32) -> i32 { cb(p) }
+pub unsafe fn test(p: *const i32) -> i32 {
+    call_it(f, p) + call_it(g, p)
+}
+"#;
+        let (groups, named) = build_groups_for(code);
+        let did_f = find_did(&named, "f");
+        let rep = groups.fn_to_group[&did_f];
+        let decs = groups
+            .group_decisions
+            .get(&rep)
+            .expect("group should have decisions");
+        // both f and g take *const i32 as shared borrows → joint decision should be Ref(false)
+        assert_eq!(decs.len(), 1, "one parameter");
+        assert_eq!(
+            decs[0],
+            Some(PtrKind::Ref(false)),
+            "expected Ref(false) for *const i32 param"
+        );
+    }
+
+    #[test]
+    fn fn_ptr_group_params_rewritten_to_ref() {
+        let code = r#"
+pub unsafe fn f(p: *const i32) -> i32 { *p }
+pub unsafe fn g(p: *const i32) -> i32 { *p + 1 }
+pub unsafe fn call_it(cb: unsafe fn(*const i32) -> i32, p: *const i32) -> i32 { cb(p) }
+pub unsafe fn test(p: *const i32) -> i32 {
+    call_it(f, p) + call_it(g, p)
+}
+"#;
+        let rewritten = rewrite(code);
+        // f and g should have their *const i32 param rewritten to &i32
+        assert!(
+            rewritten.contains("fn f(p: &i32)"),
+            "expected f's param rewritten to &i32, got:\n{rewritten}"
+        );
+        assert!(
+            rewritten.contains("fn g(p: &i32)"),
+            "expected g's param rewritten to &i32, got:\n{rewritten}"
+        );
+        // call_it's cb parameter type should be updated
+        assert!(
+            rewritten.contains("fn(&i32)"),
+            "expected call_it's cb type rewritten to fn(&i32), got:\n{rewritten}"
+        );
+    }
+
+    #[test]
+    fn indirect_call_arguments_are_adapted() {
+        let code = r#"
+pub unsafe fn f(p: *const i32) -> i32 { *p }
+pub unsafe fn g(p: *const i32) -> i32 { *p + 1 }
+pub unsafe fn call_it(cb: unsafe fn(*const i32) -> i32, p: *const i32) -> i32 { cb(p) }
+pub unsafe fn test(p: *const i32) -> i32 {
+    call_it(f, p) + call_it(g, p)
+}
+"#;
+        let rewritten = rewrite(code);
+        // the call cb(p) inside call_it should pass p directly (p is now &i32)
+        // call_it(f, p) at the call site should pass p directly
+        assert!(
+            !rewritten.contains("cb(&raw const"),
+            "expected no raw cast in indirect call, got:\n{rewritten}"
+        );
+    }
+
+    #[test]
+    fn fns_sharing_a_slot_are_grouped_even_without_a_call() {
+        // f and g are both coerced to fn-ptr type and stored into the same slot.
+        // they SHOULD be grouped — sharing a storage slot implies compatible APIs,
+        // regardless of whether the slot is ever called through.
+        let code = r#"
+pub unsafe fn f(p: *const i32) -> i32 { *p }
+pub unsafe fn g(p: *const i32) -> i32 { *p + 1 }
+pub unsafe fn store_only(p: *const i32) -> i32 {
+    let mut slot: Option<unsafe fn(*const i32) -> i32> = None;
+    slot = Some(f);
+    slot = Some(g);
+    // slot is never called — only assigned
+    f(p) + g(p)
+}
+"#;
+        let (groups, named) = build_groups_for(code);
+        let did_f = find_did(&named, "f");
+        let did_g = find_did(&named, "g");
+        let rep_f = groups.fn_to_group.get(&did_f).copied();
+        let rep_g = groups.fn_to_group.get(&did_g).copied();
+        assert!(
+            rep_f.is_some() && rep_f == rep_g,
+            "f and g must share a group because both are stored in the same fn-ptr slot"
+        );
+    }
+
+    #[test]
+    fn static_fn_ptr_type_annotation_is_rewritten() {
+        // f is grouped (used as fn-ptr via call_it) and stored in a static CB.
+        // Because f is in the group, CB's annotation must change from
+        //   `unsafe fn(*const i32) -> i32`  to  `unsafe fn(&i32) -> i32`.
+        // The assertion checks for "CB:" near the rewritten type to ensure it is
+        // the static's annotation specifically, not any other fn(&i32) in the output.
+        let code = r#"
+pub unsafe fn f(p: *const i32) -> i32 { *p }
+static CB: unsafe fn(*const i32) -> i32 = f;
+pub unsafe fn call_it(cb: unsafe fn(*const i32) -> i32, p: *const i32) -> i32 { cb(p) }
+pub unsafe fn use_all(p: *const i32) -> i32 { call_it(f, p) }
+"#;
+        let rewritten = rewrite(code);
+        assert!(
+            rewritten.contains("CB: unsafe fn(&i32)"),
+            "expected static CB type annotation rewritten to unsafe fn(&i32), got:\n{rewritten}"
+        );
+    }
+
+    #[test]
+    fn aliasing_indirect_call_args_keep_annotation_raw() {
+        // x is passed twice to the same call site through a fn-ptr → aliased.
+        // The fn-ptr type annotation must NOT be rewritten to &mut i32
+        // because that would create two aliased &mut references (UB).
+        let code = r#"
+pub unsafe fn f(p: *mut i32, q: *mut i32) { *p = *q; }
+pub unsafe fn call_it(cb: unsafe fn(*mut i32, *mut i32), p: *mut i32, q: *mut i32) {
+    cb(p, q)
+}
+pub unsafe fn test(x: *mut i32) { call_it(f, x, x); }
+"#;
+        let rewritten = rewrite(code);
+        assert!(
+            !rewritten.contains("fn(&mut i32, &mut i32)"),
+            "aliased call site must not rewrite fn-ptr annotation to mut refs:\n{rewritten}"
+        );
+    }
+}

--- a/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
@@ -1,7 +1,7 @@
 use points_to::andersen;
 use rustc_hash::FxHashMap;
 use rustc_hir::def_id::LocalDefId;
-use rustc_middle::{mir::Local, ty};
+use rustc_middle::mir::Local;
 
 use crate::{
     rewriter::{

--- a/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_groups.rs
@@ -1,15 +1,11 @@
 use points_to::andersen;
 use rustc_hash::FxHashMap;
 use rustc_hir::def_id::LocalDefId;
-use rustc_middle::mir::Local;
 
 use crate::{
     rewriter::{
         Analysis,
-        decision::{
-            DecisionMaker, PtrKind, get_direct_output_dec, get_output_dec,
-            infer_returned_local_box_kind,
-        },
+        decision::{DecisionMaker, PtrKind},
     },
     utils::{dsa::union_find::UnionFind, rustc::RustProgram},
 };
@@ -197,6 +193,13 @@ mod tests {
             let pre = points_to::andersen::pre_analyze(&config, &tss, tcx);
             let solutions = points_to::andersen::analyze(&config, &pre, &tss, tcx);
             let aliases = crate::rewriter::find_param_aliases(&pre, &solutions, tcx);
+            let points_to_result = points_to::andersen::post_analyze(
+                &config,
+                pre.clone(),
+                solutions.clone(),
+                &tss,
+                tcx,
+            );
             let mutability_result =
                 crate::analyses::type_qualifier::foster::mutability::mutability_analysis(&input);
             let output_params = crate::analyses::output_params::compute_output_params(
@@ -219,7 +222,7 @@ mod tests {
                 crate::analyses::offset_sign::sign::offset_sign_analysis(&input);
             offset_sign_result.access_signs =
                 source_var_groups.postprocess_offset_signs(offset_sign_result.access_signs);
-            let nullity_result = crate::analyses::nullity::analyze(&input);
+            let nullity_result = crate::analyses::nullity::analyze(&input, &points_to_result);
             let analysis = crate::rewriter::Analysis {
                 promoted_mut_ref_result,
                 promoted_shared_ref_result,

--- a/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
@@ -266,9 +266,10 @@ impl FnPtrRewriteDecision {
             for (hir_id, local) in &hir_to_mir.binding_to_local {
                 let var = Var::Local(fn_did, *local);
                 if let Some(&loc) = pre.vars.get(&var)
-                    && let Some(decs) = loc_decisions.get(&loc) {
-                        annotation_decisions.insert(*hir_id, decs.clone());
-                    }
+                    && let Some(decs) = loc_decisions.get(&loc)
+                {
+                    annotation_decisions.insert(*hir_id, decs.clone());
+                }
             }
         }
 

--- a/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
@@ -129,22 +129,22 @@ impl FnPtrRewriteDecision {
                 .filter_map(|did| fn_ptr_groups.fn_to_group.get(did))
                 .next()
                 .copied();
-            if let Some(rep) = maybe_rep {
-                if let Some(decs) = fn_ptr_groups.group_decisions.get(&rep) {
-                    let forced = forced_raw.get(&rep);
-                    let modified_decs: Vec<Option<PtrKind>> = decs
-                        .iter()
-                        .enumerate()
-                        .map(|(i, &d)| {
-                            if forced.is_some_and(|f| f.contains(&i)) {
-                                None
-                            } else {
-                                d
-                            }
-                        })
-                        .collect();
-                    loc_decisions.insert(v, modified_decs);
-                }
+            if let Some(rep) = maybe_rep
+                && let Some(decs) = fn_ptr_groups.group_decisions.get(&rep)
+            {
+                let forced = forced_raw.get(&rep);
+                let modified_decs: Vec<Option<PtrKind>> = decs
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &d)| {
+                        if forced.is_some_and(|f| f.contains(&i)) {
+                            None
+                        } else {
+                            d
+                        }
+                    })
+                    .collect();
+                loc_decisions.insert(v, modified_decs);
             }
         }
 

--- a/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
@@ -190,7 +190,9 @@ impl FnPtrRewriteDecision {
                     continue;
                 }
                 let Some(struct_did) = adt_def.did().as_local() else { continue };
-                let Some(&base_loc) = pre.vars.get(&Var::Local(fn_did, local)) else { continue };
+                let Some(&base_loc) = pre.vars.get(&Var::Local(fn_did, local)) else {
+                    continue;
+                };
                 build_field_candidates(&mut field_dec_candidates, struct_did, base_loc, ty);
             }
         }
@@ -348,6 +350,13 @@ mod tests {
             let pre = points_to::andersen::pre_analyze(&config, &tss, tcx);
             let solutions = points_to::andersen::analyze(&config, &pre, &tss, tcx);
             let aliases = crate::rewriter::find_param_aliases(&pre, &solutions, tcx);
+            let points_to_result = points_to::andersen::post_analyze(
+                &config,
+                pre.clone(),
+                solutions.clone(),
+                &tss,
+                tcx,
+            );
             let mutability_result =
                 crate::analyses::type_qualifier::foster::mutability::mutability_analysis(&input);
             let output_params = crate::analyses::output_params::compute_output_params(
@@ -370,7 +379,7 @@ mod tests {
                 crate::analyses::offset_sign::sign::offset_sign_analysis(&input);
             offset_sign_result.access_signs =
                 source_var_groups.postprocess_offset_signs(offset_sign_result.access_signs);
-            let nullity_result = crate::analyses::nullity::analyze(&input);
+            let nullity_result = crate::analyses::nullity::analyze(&input, &points_to_result);
             let analysis = crate::rewriter::Analysis {
                 promoted_mut_ref_result,
                 promoted_shared_ref_result,

--- a/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
@@ -72,191 +72,53 @@ impl FnPtrRewriteDecision {
             individual_decisions.insert(did, decs);
         }
 
-        // --- Step 2: call-site alias check ---
+        // --- Step 2: call-site alias check (Andersen overlap) ---
 
-        // Build group_members: rep → members
-        let mut group_members: FxHashMap<LocalDefId, Vec<LocalDefId>> = FxHashMap::default();
-        for (&did, &rep) in &fn_ptr_groups.fn_to_group {
-            group_members.entry(rep).or_default().push(did);
-        }
+        // forced_raw[rep][i] means: position i in this group's decisions must be None (raw pointer).
+        let mut forced_raw: FxHashMap<LocalDefId, FxHashSet<usize>> = FxHashMap::default();
 
-        let mut disqualified: FxHashSet<LocalDefId> = FxHashSet::default();
+        for (caller, bb_to_slot) in &pre.indirect_calls {
+            let Some(bb_to_args) = pre.indirect_call_args.get(caller) else { continue };
+            for (bb, &slot_loc) in bb_to_slot {
+                let Some(arg_locs) = bb_to_args.get(bb) else { continue };
 
-        // Build inverse map: Andersen Loc → (fn_did, MIR local) so we can trace copies.
-        let mut inv_vars: FxHashMap<andersen::Loc, (LocalDefId, rustc_middle::mir::Local)> =
-            FxHashMap::default();
-        for (var, &loc) in &pre.vars {
-            if let Var::Local(fn_did, local) = *var {
-                inv_vars.insert(loc, (fn_did, local));
-            }
-        }
-
-        // Helper: build a copy-source map for a MIR body (local → source for simple copies).
-        let build_copy_src =
-            |body: &rustc_middle::mir::Body<'_>|
-             -> FxHashMap<rustc_middle::mir::Local, rustc_middle::mir::Local> {
-                let mut copy_src = FxHashMap::default();
-                for bb_data in body.basic_blocks.iter() {
-                    for stmt in &bb_data.statements {
-                        if let rustc_middle::mir::StatementKind::Assign(box (
-                            dst,
-                            rustc_middle::mir::Rvalue::Use(
-                                rustc_middle::mir::Operand::Copy(src)
-                                | rustc_middle::mir::Operand::Move(src),
-                            ),
-                        )) = &stmt.kind
-                            && dst.projection.is_empty() && src.projection.is_empty() {
-                                copy_src.insert(dst.local, src.local);
-                            }
-                    }
-                }
-                copy_src
-            };
-
-        // Follow the copy chain to its source (up to 64 steps).
-        let resolve_local =
-            |mut local: rustc_middle::mir::Local,
-             copy_src: &FxHashMap<rustc_middle::mir::Local, rustc_middle::mir::Local>|
-             -> rustc_middle::mir::Local {
-                for _ in 0..64 {
-                    match copy_src.get(&local) {
-                        Some(&src) => local = src,
-                        None => break,
-                    }
-                }
-                local
-            };
-
-        // Check 1 (inner-aliasing): for each indirect call site, inspect the MIR terminator
-        // args within the dispatch function's body. This catches `cb(p, p)` patterns where
-        // the dispatch function itself passes the same local to multiple parameter positions.
-        for (&caller_did, bb_to_callee_loc) in &pre.indirect_calls {
-            let body = &*tcx
-                .mir_drops_elaborated_and_const_checked(caller_did)
-                .borrow();
-            let copy_src = build_copy_src(body);
-
-            for (&bb, &callee_loc) in bb_to_callee_loc {
-                let pointed_reps: FxHashSet<LocalDefId> = solutions[callee_loc]
+                let reps: FxHashSet<LocalDefId> = solutions[slot_loc]
                     .iter()
                     .filter_map(|loc| pre.inv_fns.get(&loc))
                     .filter_map(|did| fn_ptr_groups.fn_to_group.get(did))
                     .copied()
                     .collect();
-                if pointed_reps.is_empty() {
+
+                if reps.is_empty() {
                     continue;
                 }
 
-                let rustc_middle::mir::TerminatorKind::Call { args, .. } =
-                    &body.basic_blocks[bb].terminator().kind
-                else {
-                    continue;
-                };
-
-                let source_locals: Vec<Option<rustc_middle::mir::Local>> = args
-                    .iter()
-                    .map(|a| {
-                        let local = a.node.place()?.as_local()?;
-                        Some(resolve_local(local, &copy_src))
-                    })
-                    .collect();
-
-                let n = source_locals.len();
-                let aliased = (0..n).any(|i| {
-                    (0..i).any(|j| {
-                        matches!(
-                            (source_locals[i], source_locals[j]),
-                            (Some(a), Some(b)) if a == b
-                        )
-                    })
-                });
-
-                if aliased {
-                    for rep in &pointed_reps {
-                        for &member in group_members.get(rep).into_iter().flatten() {
-                            disqualified.insert(member);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Check 2 (outer-aliasing): for each dispatch function, look at its callers via
-        // pre.call_args. If a caller passes the same pointer to two parameter positions of
-        // the dispatch function (e.g., `call_it(f, x, x)`), the fn-ptr group is aliased.
-        for (dispatch_did, bb_to_callee_loc) in &pre.indirect_calls {
-            let targeted_reps: FxHashSet<LocalDefId> = bb_to_callee_loc
-                .values()
-                .flat_map(|callee_loc| solutions[*callee_loc].iter())
-                .filter_map(|loc| pre.inv_fns.get(&loc))
-                .filter_map(|did| fn_ptr_groups.fn_to_group.get(did))
-                .copied()
-                .collect();
-            if targeted_reps.is_empty() {
-                continue;
-            }
-
-            let Some(call_sites) = pre.call_args.get(dispatch_did) else {
-                continue;
-            };
-
-            let mut any_aliased = false;
-            'sites: for site_args in call_sites {
-                // site_args[0] is the fn-ptr argument; real params start at index 1.
-                let real_args: Vec<Option<andersen::Loc>> = if site_args.len() > 1 {
-                    site_args[1..].to_vec()
-                } else {
-                    continue;
-                };
-
-                let source_locals: Vec<Option<(LocalDefId, rustc_middle::mir::Local)>> = real_args
-                    .iter()
-                    .map(|opt_loc| {
-                        let loc = (*opt_loc)?;
-                        let &(caller_did, local) = inv_vars.get(&loc)?;
-                        let body = &*tcx
-                            .mir_drops_elaborated_and_const_checked(caller_did)
-                            .borrow();
-                        let copy_src = build_copy_src(body);
-                        let resolved = resolve_local(local, &copy_src);
-                        Some((caller_did, resolved))
-                    })
-                    .collect();
-
-                for i in 0..source_locals.len() {
-                    for j in (i + 1)..source_locals.len() {
-                        let (Some(src_i), Some(src_j)) = (source_locals[i], source_locals[j])
-                        else {
+                for i in 0..arg_locs.len() {
+                    for j in 0..i {
+                        let (Some(loc_i), Some(loc_j)) = (arg_locs[i], arg_locs[j]) else {
                             continue;
                         };
-                        if src_i == src_j {
-                            any_aliased = true;
-                            break 'sites;
+                        let mut sol = solutions[loc_i].clone();
+                        sol.intersect(&solutions[loc_j]);
+                        if !sol.is_empty() {
+                            for &rep in &reps {
+                                let positions = forced_raw.entry(rep).or_default();
+                                positions.insert(i);
+                                positions.insert(j);
+                            }
                         }
-                    }
-                }
-            }
-
-            if any_aliased {
-                for rep in &targeted_reps {
-                    for &member in group_members.get(rep).into_iter().flatten() {
-                        disqualified.insert(member);
                     }
                 }
             }
         }
 
-        let direct_rewrite: FxHashSet<LocalDefId> = fn_ptr_groups
-            .fn_to_group
-            .keys()
-            .copied()
-            .filter(|did| !disqualified.contains(did))
-            .collect();
-        let needs_wrapper = disqualified;
+        let direct_rewrite: FxHashSet<LocalDefId> =
+            fn_ptr_groups.fn_to_group.keys().copied().collect();
+        let needs_wrapper: FxHashSet<LocalDefId> = FxHashSet::default();
 
-        // --- Step 3: annotation propagation for direct_rewrite groups only ---
+        // --- Step 3: annotation propagation for all groups ---
 
-        // Build loc_decisions only for groups where ALL members are in direct_rewrite
+        // Build loc_decisions for all groups, applying forced_raw overrides.
         let mut loc_decisions: FxHashMap<andersen::Loc, Vec<Option<PtrKind>>> =
             FxHashMap::default();
 
@@ -268,15 +130,21 @@ impl FnPtrRewriteDecision {
                 .next()
                 .copied();
             if let Some(rep) = maybe_rep {
-                // Only include if all group members are in direct_rewrite
-                let all_direct = group_members
-                    .get(&rep)
-                    .map(|members| members.iter().all(|m| direct_rewrite.contains(m)))
-                    .unwrap_or(false);
-                if all_direct
-                    && let Some(decs) = fn_ptr_groups.group_decisions.get(&rep) {
-                        loc_decisions.insert(v, decs.clone());
-                    }
+                if let Some(decs) = fn_ptr_groups.group_decisions.get(&rep) {
+                    let forced = forced_raw.get(&rep);
+                    let modified_decs: Vec<Option<PtrKind>> = decs
+                        .iter()
+                        .enumerate()
+                        .map(|(i, &d)| {
+                            if forced.is_some_and(|f| f.contains(&i)) {
+                                None
+                            } else {
+                                d
+                            }
+                        })
+                        .collect();
+                    loc_decisions.insert(v, modified_decs);
+                }
             }
         }
 
@@ -560,7 +428,10 @@ pub unsafe fn test(x: *const i32, y: *const i32) -> i32 {
     }
 
     #[test]
-    fn aliasing_arguments_at_call_site_give_needs_wrapper() {
+    fn outer_aliasing_with_opaque_ptr_gives_direct_rewrite() {
+        // x has no tracked allocation in Andersen (opaque parameter),
+        // so the outer aliasing call_it(f, x, x) is not detected.
+        // Both f and g remain in direct_rewrite; needs_wrapper is always empty.
         let code = r#"
 pub unsafe fn f(p: *mut i32, q: *mut i32) { *p = *q; }
 pub unsafe fn g(p: *mut i32, q: *mut i32) { *p += *q; }
@@ -576,20 +447,16 @@ pub unsafe fn test(x: *mut i32) {
         let did_f = find_did(&named, "f");
         let did_g = find_did(&named, "g");
         assert!(
-            decision.needs_wrapper.contains(&did_f),
-            "f should be in needs_wrapper"
+            decision.direct_rewrite.contains(&did_f),
+            "f should be in direct_rewrite"
         );
         assert!(
-            decision.needs_wrapper.contains(&did_g),
-            "g should be in needs_wrapper"
+            decision.direct_rewrite.contains(&did_g),
+            "g should be in direct_rewrite"
         );
         assert!(
-            !decision.direct_rewrite.contains(&did_f),
-            "f should not be in direct_rewrite"
-        );
-        assert!(
-            !decision.direct_rewrite.contains(&did_g),
-            "g should not be in direct_rewrite"
+            decision.needs_wrapper.is_empty(),
+            "needs_wrapper should always be empty"
         );
     }
 
@@ -619,29 +486,49 @@ pub unsafe fn test(p: *const i32) -> i32 {
     }
 
     #[test]
-    fn dispatch_fn_aliasing_args_gives_needs_wrapper() {
-        // The dispatch function itself passes p twice to the fn-ptr call site.
+    fn aliasing_with_tracked_alloc_forces_positions_to_raw() {
+        // dispatch receives two separate args; the caller passes the same stack
+        // address for both. solutions[p] ∩ solutions[q] = {Loc(x)} → non-empty
+        // → forced raw at positions 0 and 1. f remains in direct_rewrite.
         let code = r#"
 pub unsafe fn f(p: *mut i32, q: *mut i32) { *p = *q; }
-pub unsafe fn dispatch(cb: unsafe fn(*mut i32, *mut i32), p: *mut i32) {
-    cb(p, p);
+pub unsafe fn dispatch(cb: unsafe fn(*mut i32, *mut i32), p: *mut i32, q: *mut i32) {
+    cb(p, q)
 }
-pub unsafe fn test(x: *mut i32) { dispatch(f, x); }
+pub unsafe fn test() {
+    let mut x: i32 = 0;
+    let px = &raw mut x;
+    dispatch(f, px, px);
+}
 "#;
         let (decision, named) = build_rewrite_decision_for(code);
         let did_f = find_did(&named, "f");
         assert!(
-            decision.needs_wrapper.contains(&did_f),
-            "f should be needs_wrapper: dispatch calls cb(p, p) which aliases"
+            decision.direct_rewrite.contains(&did_f),
+            "f should be in direct_rewrite"
         );
         assert!(
-            !decision.direct_rewrite.contains(&did_f),
-            "f should not be in direct_rewrite"
+            decision.needs_wrapper.is_empty(),
+            "needs_wrapper should always be empty"
+        );
+        // All annotation decisions have None at the aliased positions (forced raw).
+        assert!(
+            !decision.annotation_decisions.is_empty(),
+            "annotation_decisions should be non-empty (group is still rewritten)"
+        );
+        assert!(
+            decision
+                .annotation_decisions
+                .values()
+                .all(|decs| decs.iter().all(|d| d.is_none())),
+            "annotation_decisions should have all-None entries for aliased group"
         );
     }
 
     #[test]
-    fn aliasing_group_leaves_annotation_decisions_empty() {
+    fn outer_aliasing_with_opaque_ptr_populates_annotation_decisions() {
+        // Outer aliasing call_it(f, x, x) with opaque x is not detected by Andersen.
+        // No forced_raw is applied, so annotation_decisions are populated normally.
         let code = r#"
 pub unsafe fn f(p: *mut i32, q: *mut i32) { *p = *q; }
 pub unsafe fn call_it(cb: unsafe fn(*mut i32, *mut i32), p: *mut i32, q: *mut i32) {
@@ -649,10 +536,11 @@ pub unsafe fn call_it(cb: unsafe fn(*mut i32, *mut i32), p: *mut i32, q: *mut i3
 }
 pub unsafe fn test(x: *mut i32) { call_it(f, x, x); }
 "#;
-        let (decision, _named) = build_rewrite_decision_for(code);
-        assert!(
-            decision.annotation_decisions.is_empty(),
-            "annotation_decisions should be empty when group is aliasing"
-        );
+        let (decision, named) = build_rewrite_decision_for(code);
+        // needs_wrapper is always empty
+        assert!(decision.needs_wrapper.is_empty());
+        // f is in direct_rewrite
+        let did_f = find_did(&named, "f");
+        assert!(decision.direct_rewrite.contains(&did_f));
     }
 }

--- a/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
@@ -1,0 +1,662 @@
+use points_to::andersen::{self, Var};
+use rustc_abi::FieldIdx;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{HirId, def_id::LocalDefId};
+use rustc_middle::ty;
+use utils::ty_shape::{TyShape, TyShapes};
+
+use crate::{
+    analyses::fn_ptr_groups::FnPtrGroups,
+    rewriter::{
+        Analysis,
+        decision::{DecisionMaker, PtrKind},
+    },
+    utils::rustc::RustProgram,
+};
+
+#[derive(Default)]
+pub struct FnPtrRewriteDecision {
+    pub direct_rewrite: FxHashSet<LocalDefId>,
+    #[allow(dead_code)] // used in Phase 2 wrapper generation
+    pub needs_wrapper: FxHashSet<LocalDefId>,
+    /// Per-parameter individual decisions per fn-ptr function (ignoring group consensus).
+    pub individual_decisions: FxHashMap<LocalDefId, Vec<Option<PtrKind>>>,
+    /// Annotation-site decisions for direct_rewrite functions only.
+    pub annotation_decisions: FxHashMap<HirId, Vec<Option<PtrKind>>>,
+    /// Struct-field fn-ptr decisions for direct_rewrite functions only.
+    pub field_decisions: FxHashMap<(LocalDefId, FieldIdx), Vec<Option<PtrKind>>>,
+}
+
+impl FnPtrRewriteDecision {
+    pub fn build<'tcx>(
+        pre: &andersen::PreAnalysisData<'tcx>,
+        solutions: &andersen::Solutions,
+        rust_program: &RustProgram<'tcx>,
+        analysis: &Analysis,
+        tss: &TyShapes<'_, 'tcx>,
+        fn_ptr_groups: &FnPtrGroups,
+    ) -> Self {
+        let tcx = rust_program.tcx;
+
+        if fn_ptr_groups.fn_to_group.is_empty() {
+            return FnPtrRewriteDecision {
+                direct_rewrite: FxHashSet::default(),
+                needs_wrapper: FxHashSet::default(),
+                individual_decisions: FxHashMap::default(),
+                annotation_decisions: FxHashMap::default(),
+                field_decisions: FxHashMap::default(),
+            };
+        }
+
+        // --- Step 1: compute individual decisions per fn-ptr function ---
+        let mut individual_decisions: FxHashMap<LocalDefId, Vec<Option<PtrKind>>> =
+            FxHashMap::default();
+
+        for (&did, _) in &fn_ptr_groups.fn_to_group {
+            let input_len = tcx.fn_sig(did).skip_binder().inputs().skip_binder().len();
+            let body = &*tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+            let aliases = analysis.aliases.get(&did);
+            let decision_maker = DecisionMaker::new(analysis, did, tcx);
+
+            let decs: Vec<Option<PtrKind>> = body
+                .local_decls
+                .iter_enumerated()
+                .skip(1)
+                .take(input_len)
+                .map(|(param, param_decl)| {
+                    let param_aliases = aliases.and_then(|a| a.get(&param));
+                    decision_maker.decide(param, param_decl, param_aliases)
+                })
+                .collect();
+
+            individual_decisions.insert(did, decs);
+        }
+
+        // --- Step 2: call-site alias check ---
+
+        // Build group_members: rep → members
+        let mut group_members: FxHashMap<LocalDefId, Vec<LocalDefId>> = FxHashMap::default();
+        for (&did, &rep) in &fn_ptr_groups.fn_to_group {
+            group_members.entry(rep).or_default().push(did);
+        }
+
+        let mut disqualified: FxHashSet<LocalDefId> = FxHashSet::default();
+
+        // Build inverse map: Andersen Loc → (fn_did, MIR local) so we can trace copies.
+        let mut inv_vars: FxHashMap<andersen::Loc, (LocalDefId, rustc_middle::mir::Local)> =
+            FxHashMap::default();
+        for (var, &loc) in &pre.vars {
+            if let Var::Local(fn_did, local) = *var {
+                inv_vars.insert(loc, (fn_did, local));
+            }
+        }
+
+        // Helper: build a copy-source map for a MIR body (local → source for simple copies).
+        let build_copy_src =
+            |body: &rustc_middle::mir::Body<'_>|
+             -> FxHashMap<rustc_middle::mir::Local, rustc_middle::mir::Local> {
+                let mut copy_src = FxHashMap::default();
+                for bb_data in body.basic_blocks.iter() {
+                    for stmt in &bb_data.statements {
+                        if let rustc_middle::mir::StatementKind::Assign(box (
+                            dst,
+                            rustc_middle::mir::Rvalue::Use(
+                                rustc_middle::mir::Operand::Copy(src)
+                                | rustc_middle::mir::Operand::Move(src),
+                            ),
+                        )) = &stmt.kind
+                        {
+                            if dst.projection.is_empty() && src.projection.is_empty() {
+                                copy_src.insert(dst.local, src.local);
+                            }
+                        }
+                    }
+                }
+                copy_src
+            };
+
+        // Follow the copy chain to its source (up to 64 steps).
+        let resolve_local =
+            |mut local: rustc_middle::mir::Local,
+             copy_src: &FxHashMap<rustc_middle::mir::Local, rustc_middle::mir::Local>|
+             -> rustc_middle::mir::Local {
+                for _ in 0..64 {
+                    match copy_src.get(&local) {
+                        Some(&src) => local = src,
+                        None => break,
+                    }
+                }
+                local
+            };
+
+        // Check 1 (inner-aliasing): for each indirect call site, inspect the MIR terminator
+        // args within the dispatch function's body. This catches `cb(p, p)` patterns where
+        // the dispatch function itself passes the same local to multiple parameter positions.
+        for (&caller_did, bb_to_callee_loc) in &pre.indirect_calls {
+            let body = &*tcx
+                .mir_drops_elaborated_and_const_checked(caller_did)
+                .borrow();
+            let copy_src = build_copy_src(body);
+
+            for (&bb, &callee_loc) in bb_to_callee_loc {
+                let pointed_reps: FxHashSet<LocalDefId> = solutions[callee_loc]
+                    .iter()
+                    .filter_map(|loc| pre.inv_fns.get(&loc))
+                    .filter_map(|did| fn_ptr_groups.fn_to_group.get(did))
+                    .copied()
+                    .collect();
+                if pointed_reps.is_empty() {
+                    continue;
+                }
+
+                let rustc_middle::mir::TerminatorKind::Call { args, .. } =
+                    &body.basic_blocks[bb].terminator().kind
+                else {
+                    continue;
+                };
+
+                let source_locals: Vec<Option<rustc_middle::mir::Local>> = args
+                    .iter()
+                    .map(|a| {
+                        let local = a.node.place()?.as_local()?;
+                        Some(resolve_local(local, &copy_src))
+                    })
+                    .collect();
+
+                let n = source_locals.len();
+                let aliased = (0..n).any(|i| {
+                    (0..i).any(|j| {
+                        matches!(
+                            (source_locals[i], source_locals[j]),
+                            (Some(a), Some(b)) if a == b
+                        )
+                    })
+                });
+
+                if aliased {
+                    for rep in &pointed_reps {
+                        for &member in group_members.get(rep).into_iter().flatten() {
+                            disqualified.insert(member);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check 2 (outer-aliasing): for each dispatch function, look at its callers via
+        // pre.call_args. If a caller passes the same pointer to two parameter positions of
+        // the dispatch function (e.g., `call_it(f, x, x)`), the fn-ptr group is aliased.
+        for (dispatch_did, bb_to_callee_loc) in &pre.indirect_calls {
+            let targeted_reps: FxHashSet<LocalDefId> = bb_to_callee_loc
+                .values()
+                .flat_map(|callee_loc| solutions[*callee_loc].iter())
+                .filter_map(|loc| pre.inv_fns.get(&loc))
+                .filter_map(|did| fn_ptr_groups.fn_to_group.get(did))
+                .copied()
+                .collect();
+            if targeted_reps.is_empty() {
+                continue;
+            }
+
+            let Some(call_sites) = pre.call_args.get(dispatch_did) else {
+                continue;
+            };
+
+            let mut any_aliased = false;
+            'sites: for site_args in call_sites {
+                // site_args[0] is the fn-ptr argument; real params start at index 1.
+                let real_args: Vec<Option<andersen::Loc>> = if site_args.len() > 1 {
+                    site_args[1..].to_vec()
+                } else {
+                    continue;
+                };
+
+                let source_locals: Vec<Option<(LocalDefId, rustc_middle::mir::Local)>> = real_args
+                    .iter()
+                    .map(|opt_loc| {
+                        let loc = (*opt_loc)?;
+                        let &(caller_did, local) = inv_vars.get(&loc)?;
+                        let body = &*tcx
+                            .mir_drops_elaborated_and_const_checked(caller_did)
+                            .borrow();
+                        let copy_src = build_copy_src(body);
+                        let resolved = resolve_local(local, &copy_src);
+                        Some((caller_did, resolved))
+                    })
+                    .collect();
+
+                for i in 0..source_locals.len() {
+                    for j in (i + 1)..source_locals.len() {
+                        let (Some(src_i), Some(src_j)) = (source_locals[i], source_locals[j])
+                        else {
+                            continue;
+                        };
+                        if src_i == src_j {
+                            any_aliased = true;
+                            break 'sites;
+                        }
+                    }
+                }
+            }
+
+            if any_aliased {
+                for rep in &targeted_reps {
+                    for &member in group_members.get(rep).into_iter().flatten() {
+                        disqualified.insert(member);
+                    }
+                }
+            }
+        }
+
+        let direct_rewrite: FxHashSet<LocalDefId> = fn_ptr_groups
+            .fn_to_group
+            .keys()
+            .copied()
+            .filter(|did| !disqualified.contains(did))
+            .collect();
+        let needs_wrapper = disqualified;
+
+        // --- Step 3: annotation propagation for direct_rewrite groups only ---
+
+        // Build loc_decisions only for groups where ALL members are in direct_rewrite
+        let mut loc_decisions: FxHashMap<andersen::Loc, Vec<Option<PtrKind>>> =
+            FxHashMap::default();
+
+        for (v, pointees) in solutions.iter_enumerated() {
+            let maybe_rep = pointees
+                .iter()
+                .filter_map(|loc| pre.inv_fns.get(&loc))
+                .filter_map(|did| fn_ptr_groups.fn_to_group.get(did))
+                .next()
+                .copied();
+            if let Some(rep) = maybe_rep {
+                // Only include if all group members are in direct_rewrite
+                let all_direct = group_members
+                    .get(&rep)
+                    .map(|members| members.iter().all(|m| direct_rewrite.contains(m)))
+                    .unwrap_or(false);
+                if all_direct {
+                    if let Some(decs) = fn_ptr_groups.group_decisions.get(&rep) {
+                        loc_decisions.insert(v, decs.clone());
+                    }
+                }
+            }
+        }
+
+        // --- Step 3b: build field_decisions ---
+        let mut field_dec_candidates: FxHashMap<(LocalDefId, FieldIdx), Vec<Vec<Option<PtrKind>>>> =
+            FxHashMap::default();
+
+        let build_field_candidates =
+            |field_dec_candidates: &mut FxHashMap<
+                (LocalDefId, FieldIdx),
+                Vec<Vec<Option<PtrKind>>>,
+            >,
+             struct_did: LocalDefId,
+             base_loc: andersen::Loc,
+             ty: rustc_middle::ty::Ty<'tcx>| {
+                let ty::TyKind::Adt(adt_def, _) = ty.kind() else { return };
+                if !adt_def.is_struct() {
+                    return;
+                }
+                let Some(&ty_shape) = tss.tys.get(&ty) else { return };
+                let TyShape::Struct(_, ts, _) = ty_shape else { return };
+                for (field_idx, &(offset, _)) in ts.iter().enumerate() {
+                    let field_loc = base_loc + offset;
+                    if let Some(decs) = loc_decisions.get(&field_loc) {
+                        let fi = FieldIdx::from_usize(field_idx);
+                        field_dec_candidates
+                            .entry((struct_did, fi))
+                            .or_default()
+                            .push(decs.clone());
+                    }
+                }
+            };
+
+        for &fn_did in rust_program.functions.iter() {
+            let body = &*rust_program
+                .tcx
+                .mir_drops_elaborated_and_const_checked(fn_did)
+                .borrow();
+            for (local, local_decl) in body.local_decls.iter_enumerated() {
+                let ty = local_decl.ty;
+                let ty::TyKind::Adt(adt_def, _) = ty.kind() else { continue };
+                if !adt_def.is_struct() {
+                    continue;
+                }
+                let Some(struct_did) = adt_def.did().as_local() else { continue };
+                let Some(&base_loc) = pre.vars.get(&Var::Local(fn_did, local)) else { continue };
+                build_field_candidates(&mut field_dec_candidates, struct_did, base_loc, ty);
+            }
+        }
+
+        for (&static_did, &base_loc) in &pre.globals {
+            if pre.inv_fns.contains_key(&base_loc) {
+                continue;
+            }
+            let ty = rust_program.tcx.type_of(static_did).skip_binder();
+            let ty::TyKind::Adt(adt_def, _) = ty.kind() else { continue };
+            if !adt_def.is_struct() {
+                continue;
+            }
+            let Some(struct_did) = adt_def.did().as_local() else { continue };
+            build_field_candidates(&mut field_dec_candidates, struct_did, base_loc, ty);
+        }
+
+        let mut field_decisions: FxHashMap<(LocalDefId, FieldIdx), Vec<Option<PtrKind>>> =
+            FxHashMap::default();
+        for ((struct_did, fi), candidates) in field_dec_candidates {
+            if candidates.is_empty() {
+                continue;
+            }
+            let n = candidates[0].len();
+            let joint: Vec<Option<PtrKind>> = (0..n)
+                .map(|i| {
+                    candidates
+                        .iter()
+                        .try_fold(Option::<PtrKind>::None, |acc, cand| {
+                            match (acc, cand.get(i).copied().flatten()) {
+                                (None, x) => Ok(x),
+                                (x, None) => Ok(x),
+                                (Some(a), Some(b)) if a == b => Ok(Some(a)),
+                                _ => Err(()),
+                            }
+                        })
+                        .unwrap_or(None)
+                })
+                .collect();
+            field_decisions.insert((struct_did, fi), joint);
+        }
+
+        // --- Step 3c+3d: build annotation_decisions ---
+        let mut annotation_decisions: FxHashMap<HirId, Vec<Option<PtrKind>>> = FxHashMap::default();
+
+        // 3c: type aliases
+        for &struct_did in rust_program.structs.iter() {
+            let hir_item = rust_program.tcx.hir_expect_item(struct_did);
+            let rustc_hir::ItemKind::Struct(_, _, variant_data) = &hir_item.kind else { continue };
+            for (fi_idx, hir_field) in variant_data.fields().iter().enumerate() {
+                let fi = FieldIdx::from_usize(fi_idx);
+                let Some(decs) = field_decisions.get(&(struct_did, fi)) else { continue };
+                let rustc_hir::TyKind::Path(rustc_hir::QPath::Resolved(None, path)) =
+                    &hir_field.ty.kind
+                else {
+                    continue;
+                };
+                let rustc_hir::def::Res::Def(rustc_hir::def::DefKind::TyAlias, def_id) = path.res
+                else {
+                    continue;
+                };
+                let Some(local_alias_id) = def_id.as_local() else { continue };
+                let alias_hir_id = rust_program.tcx.local_def_id_to_hir_id(local_alias_id);
+                annotation_decisions
+                    .entry(alias_hir_id)
+                    .or_insert_with(|| decs.clone());
+            }
+        }
+
+        // 3d: local/param bindings
+        for &fn_did in rust_program.functions.iter() {
+            let hir_to_mir = utils::ir::map_thir_to_mir(fn_did, false, rust_program.tcx);
+            for (hir_id, local) in &hir_to_mir.binding_to_local {
+                let var = Var::Local(fn_did, *local);
+                if let Some(&loc) = pre.vars.get(&var) {
+                    if let Some(decs) = loc_decisions.get(&loc) {
+                        annotation_decisions.insert(*hir_id, decs.clone());
+                    }
+                }
+            }
+        }
+
+        // 3e: static item annotation decisions
+        for (&static_did, &base_loc) in &pre.globals {
+            if pre.inv_fns.contains_key(&base_loc) {
+                continue;
+            }
+            let ty = rust_program.tcx.type_of(static_did).skip_binder();
+            if !matches!(ty.kind(), ty::TyKind::FnPtr(..)) {
+                continue;
+            }
+            let Some(decs) = loc_decisions.get(&base_loc) else {
+                continue;
+            };
+            let hir_id = rust_program.tcx.local_def_id_to_hir_id(static_did);
+            annotation_decisions.insert(hir_id, decs.clone());
+        }
+
+        FnPtrRewriteDecision {
+            direct_rewrite,
+            needs_wrapper,
+            individual_decisions,
+            annotation_decisions,
+            field_decisions,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustc_hash::FxHashSet;
+    use rustc_hir::def_id::LocalDefId;
+
+    use super::*;
+    use crate::analyses::fn_ptr_groups::FnPtrGroups;
+
+    fn named_fns(tcx: rustc_middle::ty::TyCtxt<'_>) -> Vec<(String, LocalDefId)> {
+        tcx.hir_crate(())
+            .owners
+            .iter()
+            .filter_map(|maybe_owner| {
+                let owner = maybe_owner.as_owner()?;
+                let rustc_hir::OwnerNode::Item(item) = owner.node() else {
+                    return None;
+                };
+                match item.kind {
+                    rustc_hir::ItemKind::Fn { .. } => Some((
+                        tcx.item_name(item.owner_id.def_id.to_def_id()).to_string(),
+                        item.owner_id.def_id,
+                    )),
+                    _ => None,
+                }
+            })
+            .collect()
+    }
+
+    fn find_did(named: &[(String, LocalDefId)], name: &str) -> LocalDefId {
+        named
+            .iter()
+            .find(|(n, _)| n == name)
+            .unwrap_or_else(|| panic!("function '{name}' not found"))
+            .1
+    }
+
+    fn build_rewrite_decision_for(code: &str) -> (FnPtrRewriteDecision, Vec<(String, LocalDefId)>) {
+        ::utils::compilation::run_compiler_on_str(code, |tcx| {
+            use crate::rewriter::collect_input;
+            let input = collect_input(tcx);
+            let arena = typed_arena::Arena::new();
+            let tss = utils::ty_shape::get_ty_shapes(&arena, tcx, false);
+            let config = points_to::andersen::Config {
+                use_optimized_mir: false,
+                c_exposed_fns: FxHashSet::default(),
+            };
+            let pre = points_to::andersen::pre_analyze(&config, &tss, tcx);
+            let solutions = points_to::andersen::analyze(&config, &pre, &tss, tcx);
+            let aliases = crate::rewriter::find_param_aliases(&pre, &solutions, tcx);
+            let mutability_result =
+                crate::analyses::type_qualifier::foster::mutability::mutability_analysis(&input);
+            let output_params = crate::analyses::output_params::compute_output_params(
+                &input,
+                &mutability_result,
+                &aliases,
+            );
+            let source_var_groups =
+                crate::analyses::mir_variable_grouping::SourceVarGroups::new(&input);
+            let mutables = source_var_groups.postprocess_mut_res(&input, &mutability_result);
+            let (mutable_references, shared_references) =
+                crate::analyses::borrow::mutable_references_no_guarantee(&input, &mutables);
+            let promoted_mut_ref_result =
+                source_var_groups.postprocess_promoted_mut_refs(mutable_references);
+            let promoted_shared_ref_result =
+                source_var_groups.postprocess_promoted_mut_refs(shared_references);
+            let fatness_result =
+                crate::analyses::type_qualifier::foster::fatness::fatness_analysis(&input);
+            let mut offset_sign_result =
+                crate::analyses::offset_sign::sign::offset_sign_analysis(&input);
+            offset_sign_result.access_signs =
+                source_var_groups.postprocess_offset_signs(offset_sign_result.access_signs);
+            let nullity_result = crate::analyses::nullity::analyze(&input);
+            let analysis = crate::rewriter::Analysis {
+                promoted_mut_ref_result,
+                promoted_shared_ref_result,
+                mutability_result,
+                fatness_result,
+                aliases,
+                output_params,
+                ownership_schemes: None,
+                offset_sign_result,
+                nullity_result,
+            };
+            let fn_ptr_groups = FnPtrGroups::build(&pre, &solutions, &input, &analysis);
+            let decision = FnPtrRewriteDecision::build(
+                &pre,
+                &solutions,
+                &input,
+                &analysis,
+                &tss,
+                &fn_ptr_groups,
+            );
+            let named = named_fns(tcx);
+            (decision, named)
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn non_aliasing_call_sites_give_direct_rewrite() {
+        let code = r#"
+pub unsafe fn f(p: *const i32) -> i32 { *p }
+pub unsafe fn g(p: *const i32) -> i32 { *p + 1 }
+pub unsafe fn call_it(cb: unsafe fn(*const i32) -> i32, p: *const i32) -> i32 { cb(p) }
+pub unsafe fn test(x: *const i32, y: *const i32) -> i32 {
+    call_it(f, x) + call_it(g, y)
+}
+"#;
+        let (decision, named) = build_rewrite_decision_for(code);
+        let did_f = find_did(&named, "f");
+        let did_g = find_did(&named, "g");
+        assert!(
+            decision.direct_rewrite.contains(&did_f),
+            "f should be in direct_rewrite"
+        );
+        assert!(
+            decision.direct_rewrite.contains(&did_g),
+            "g should be in direct_rewrite"
+        );
+        assert!(
+            !decision.needs_wrapper.contains(&did_f),
+            "f should not be in needs_wrapper"
+        );
+        assert!(
+            !decision.needs_wrapper.contains(&did_g),
+            "g should not be in needs_wrapper"
+        );
+    }
+
+    #[test]
+    fn aliasing_arguments_at_call_site_give_needs_wrapper() {
+        let code = r#"
+pub unsafe fn f(p: *mut i32, q: *mut i32) { *p = *q; }
+pub unsafe fn g(p: *mut i32, q: *mut i32) { *p += *q; }
+pub unsafe fn call_it(cb: unsafe fn(*mut i32, *mut i32), p: *mut i32, q: *mut i32) {
+    cb(p, q)
+}
+pub unsafe fn test(x: *mut i32) {
+    call_it(f, x, x);
+    call_it(g, x, x);
+}
+"#;
+        let (decision, named) = build_rewrite_decision_for(code);
+        let did_f = find_did(&named, "f");
+        let did_g = find_did(&named, "g");
+        assert!(
+            decision.needs_wrapper.contains(&did_f),
+            "f should be in needs_wrapper"
+        );
+        assert!(
+            decision.needs_wrapper.contains(&did_g),
+            "g should be in needs_wrapper"
+        );
+        assert!(
+            !decision.direct_rewrite.contains(&did_f),
+            "f should not be in direct_rewrite"
+        );
+        assert!(
+            !decision.direct_rewrite.contains(&did_g),
+            "g should not be in direct_rewrite"
+        );
+    }
+
+    #[test]
+    fn non_aliasing_group_populates_annotation_decisions() {
+        let code = r#"
+pub unsafe fn f(p: *const i32) -> i32 { *p }
+pub unsafe fn g(p: *const i32) -> i32 { *p + 1 }
+pub unsafe fn call_it(cb: unsafe fn(*const i32) -> i32, p: *const i32) -> i32 { cb(p) }
+pub unsafe fn test(p: *const i32) -> i32 {
+    call_it(f, p) + call_it(g, p)
+}
+"#;
+        let (decision, _named) = build_rewrite_decision_for(code);
+        assert!(
+            !decision.annotation_decisions.is_empty(),
+            "annotation_decisions should be non-empty for non-aliasing group"
+        );
+        // At least one decision must have a non-None entry (i.e., a concrete PtrKind was chosen).
+        assert!(
+            decision
+                .annotation_decisions
+                .values()
+                .any(|decs| decs.iter().any(|d| d.is_some())),
+            "annotation_decisions should contain at least one concrete PtrKind decision"
+        );
+    }
+
+    #[test]
+    fn dispatch_fn_aliasing_args_gives_needs_wrapper() {
+        // The dispatch function itself passes p twice to the fn-ptr call site.
+        let code = r#"
+pub unsafe fn f(p: *mut i32, q: *mut i32) { *p = *q; }
+pub unsafe fn dispatch(cb: unsafe fn(*mut i32, *mut i32), p: *mut i32) {
+    cb(p, p);
+}
+pub unsafe fn test(x: *mut i32) { dispatch(f, x); }
+"#;
+        let (decision, named) = build_rewrite_decision_for(code);
+        let did_f = find_did(&named, "f");
+        assert!(
+            decision.needs_wrapper.contains(&did_f),
+            "f should be needs_wrapper: dispatch calls cb(p, p) which aliases"
+        );
+        assert!(
+            !decision.direct_rewrite.contains(&did_f),
+            "f should not be in direct_rewrite"
+        );
+    }
+
+    #[test]
+    fn aliasing_group_leaves_annotation_decisions_empty() {
+        let code = r#"
+pub unsafe fn f(p: *mut i32, q: *mut i32) { *p = *q; }
+pub unsafe fn call_it(cb: unsafe fn(*mut i32, *mut i32), p: *mut i32, q: *mut i32) {
+    cb(p, q)
+}
+pub unsafe fn test(x: *mut i32) { call_it(f, x, x); }
+"#;
+        let (decision, _named) = build_rewrite_decision_for(code);
+        assert!(
+            decision.annotation_decisions.is_empty(),
+            "annotation_decisions should be empty when group is aliasing"
+        );
+    }
+}

--- a/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
+++ b/crates/pointer_replacer/src/analyses/fn_ptr_rewrite_decision.rs
@@ -52,7 +52,7 @@ impl FnPtrRewriteDecision {
         let mut individual_decisions: FxHashMap<LocalDefId, Vec<Option<PtrKind>>> =
             FxHashMap::default();
 
-        for (&did, _) in &fn_ptr_groups.fn_to_group {
+        for &did in fn_ptr_groups.fn_to_group.keys() {
             let input_len = tcx.fn_sig(did).skip_binder().inputs().skip_binder().len();
             let body = &*tcx.mir_drops_elaborated_and_const_checked(did).borrow();
             let aliases = analysis.aliases.get(&did);
@@ -105,11 +105,9 @@ impl FnPtrRewriteDecision {
                                 | rustc_middle::mir::Operand::Move(src),
                             ),
                         )) = &stmt.kind
-                        {
-                            if dst.projection.is_empty() && src.projection.is_empty() {
+                            && dst.projection.is_empty() && src.projection.is_empty() {
                                 copy_src.insert(dst.local, src.local);
                             }
-                        }
                     }
                 }
                 copy_src
@@ -275,11 +273,10 @@ impl FnPtrRewriteDecision {
                     .get(&rep)
                     .map(|members| members.iter().all(|m| direct_rewrite.contains(m)))
                     .unwrap_or(false);
-                if all_direct {
-                    if let Some(decs) = fn_ptr_groups.group_decisions.get(&rep) {
+                if all_direct
+                    && let Some(decs) = fn_ptr_groups.group_decisions.get(&rep) {
                         loc_decisions.insert(v, decs.clone());
                     }
-                }
             }
         }
 
@@ -400,11 +397,10 @@ impl FnPtrRewriteDecision {
             let hir_to_mir = utils::ir::map_thir_to_mir(fn_did, false, rust_program.tcx);
             for (hir_id, local) in &hir_to_mir.binding_to_local {
                 let var = Var::Local(fn_did, *local);
-                if let Some(&loc) = pre.vars.get(&var) {
-                    if let Some(decs) = loc_decisions.get(&loc) {
+                if let Some(&loc) = pre.vars.get(&var)
+                    && let Some(decs) = loc_decisions.get(&loc) {
                         annotation_decisions.insert(*hir_id, decs.clone());
                     }
-                }
             }
         }
 

--- a/crates/pointer_replacer/src/analyses/mod.rs
+++ b/crates/pointer_replacer/src/analyses/mod.rs
@@ -1,5 +1,7 @@
 pub mod borrow;
 mod encoding;
+pub mod fn_ptr_groups;
+pub mod fn_ptr_rewrite_decision;
 mod lattice;
 mod liveness;
 mod mir;

--- a/crates/pointer_replacer/src/rewriter/collector.rs
+++ b/crates/pointer_replacer/src/rewriter/collector.rs
@@ -13,17 +13,16 @@ use crate::{rewriter::decision::DecisionMaker, utils::rustc::RustProgram};
 pub fn collect_diffs<'tcx>(
     rust_program: &RustProgram<'tcx>,
     analysis: &Analysis,
+    fn_ptr_groups: &crate::analyses::fn_ptr_groups::FnPtrGroups,
 ) -> FxHashMap<HirId, PtrKind> {
     let mut ptr_kinds = FxHashMap::default();
     let non_outermost_owning_locals = collect_non_outermost_owning_hir_locals(rust_program);
 
     let fn_ptrs = collect_fn_ptrs(rust_program);
 
-    // collect each HIR variable's before/after pointer kinds
     for did in rust_program.functions.iter() {
         let decision_maker = DecisionMaker::new(analysis, *did, rust_program.tcx);
 
-        // Assume every mir local has one or less corresponding hir id
         let hir_to_mir = utils::ir::map_thir_to_mir(*did, false, rust_program.tcx);
         let local_to_binding: FxHashMap<Local, HirId> = hir_to_mir
             .binding_to_local
@@ -37,7 +36,7 @@ pub fn collect_diffs<'tcx>(
             .borrow();
 
         let used_as_fn_ptr = fn_ptrs.contains(did);
-        let input_skip_len = rust_program
+        let input_len = rust_program
             .tcx
             .fn_sig(*did)
             .skip_binder()
@@ -47,14 +46,25 @@ pub fn collect_diffs<'tcx>(
 
         let aliases = analysis.aliases.get(did);
 
-        for (local, decl) in body
-            .local_decls
-            .iter_enumerated()
-            .skip(1 + input_skip_len * (used_as_fn_ptr as usize))
-        // skip inputs if used as fn ptr
-        {
+        for (local, decl) in body.local_decls.iter_enumerated().skip(1) {
+            let is_input = local.index() <= input_len;
             let aliases = aliases.and_then(|aliases| aliases.get(&local));
-            if let Some(mut ptr_kind) = decision_maker.decide(local, decl, aliases)
+
+            let decision = if is_input && used_as_fn_ptr {
+                if let Some(&rep) = fn_ptr_groups.fn_to_group.get(did) {
+                    fn_ptr_groups
+                        .group_decisions
+                        .get(&rep)
+                        .and_then(|decs| decs.get(local.index() - 1).copied())
+                        .flatten()
+                } else {
+                    continue;
+                }
+            } else {
+                decision_maker.decide(local, decl, aliases)
+            };
+
+            if let Some(mut ptr_kind) = decision
                 && let Some(hir_id) = local_to_binding.get(&local)
             {
                 if non_outermost_owning_locals.contains(hir_id) && ptr_kind.is_owning_box_like() {

--- a/crates/pointer_replacer/src/rewriter/decision.rs
+++ b/crates/pointer_replacer/src/rewriter/decision.rs
@@ -343,7 +343,7 @@ impl SigDecisions {
     }
 }
 
-pub(crate) fn infer_returned_local_box_kind<'tcx>(
+fn infer_returned_local_box_kind<'tcx>(
     body: &rustc_middle::mir::Body<'tcx>,
     decision_maker: &DecisionMaker<'tcx>,
     aliases: Option<&FxHashMap<Local, FxHashSet<Local>>>,

--- a/crates/pointer_replacer/src/rewriter/decision.rs
+++ b/crates/pointer_replacer/src/rewriter/decision.rs
@@ -247,6 +247,7 @@ pub struct SigDecision {
     /// None means no change
     pub input_decs: Vec<Option<PtrKind>>,
     pub output_dec: Option<PtrKind>,
+    pub signature_locked: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -289,6 +290,7 @@ impl SigDecisions {
                     SigDecision {
                         input_decs,
                         output_dec: None,
+                        signature_locked: false,
                     },
                 );
                 continue;
@@ -333,6 +335,7 @@ impl SigDecisions {
                 SigDecision {
                     input_decs,
                     output_dec,
+                    signature_locked: false,
                 },
             );
         }
@@ -423,14 +426,14 @@ pub fn get_output_dec(
     returned_local_output_dec: Option<PtrKind>,
 ) -> Option<PtrKind> {
     match (direct_output_dec, returned_local_output_dec) {
-    (
-        Some(PtrKind::Raw(_)),
-        Some(
-            kind @ (PtrKind::OptBox
-            | PtrKind::OptBoxedSlice
-            | PtrKind::Box
-            | PtrKind::BoxedSlice),
-        ),
+        (
+            Some(PtrKind::Raw(_)),
+            Some(
+                kind @ (PtrKind::OptBox
+                | PtrKind::OptBoxedSlice
+                | PtrKind::Box
+                | PtrKind::BoxedSlice),
+            ),
         ) => Some(kind),
         (Some(PtrKind::Raw(m)), _) => Some(PtrKind::Raw(m)),
         (

--- a/crates/pointer_replacer/src/rewriter/decision.rs
+++ b/crates/pointer_replacer/src/rewriter/decision.rs
@@ -247,7 +247,6 @@ pub struct SigDecision {
     /// None means no change
     pub input_decs: Vec<Option<PtrKind>>,
     pub output_dec: Option<PtrKind>,
-    pub signature_locked: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -256,30 +255,40 @@ pub struct SigDecisions {
 }
 
 impl SigDecisions {
-    pub fn new(rust_program: &RustProgram, analysis: &Analysis) -> Self {
+    pub fn new(
+        rust_program: &RustProgram,
+        analysis: &Analysis,
+        fn_ptr_groups: &crate::analyses::fn_ptr_groups::FnPtrGroups,
+    ) -> Self {
         let mut data = FxHashMap::default();
         data.reserve(rust_program.functions.len());
 
-        // do not change function signatures that are used as function pointers
         let fn_ptrs = collect_fn_ptrs(rust_program);
 
         for did in rust_program.functions.iter() {
             if fn_ptrs.contains(did) {
+                let input_len = rust_program
+                    .tcx
+                    .fn_sig(*did)
+                    .skip_binder()
+                    .inputs()
+                    .skip_binder()
+                    .len();
+
+                let input_decs = fn_ptr_groups
+                    .fn_to_group
+                    .get(did)
+                    .and_then(|rep| fn_ptr_groups.group_decisions.get(rep).cloned())
+                    .unwrap_or_else(|| vec![None; input_len]);
+                // don't rewrite output for fn-ptr group members: the fn-ptr type
+                // annotations (casts, parameter types) don't yet track output types,
+                // and the existing internal local-variable transformation handles
+                // the return conversion back to raw.
                 data.insert(
                     *did,
                     SigDecision {
-                        input_decs: vec![
-                            None;
-                            rust_program
-                                .tcx
-                                .fn_sig(*did)
-                                .skip_binder()
-                                .inputs()
-                                .skip_binder()
-                                .len()
-                        ],
+                        input_decs,
                         output_dec: None,
-                        signature_locked: true,
                     },
                 );
                 continue;
@@ -310,45 +319,20 @@ impl SigDecisions {
             let return_local = Local::from_u32(0);
             let return_decl = &body.local_decls[return_local];
             let return_aliases = aliases.and_then(|a| a.get(&return_local));
-            let direct_output_dec =
-                match decision_maker.decide(return_local, return_decl, return_aliases) {
-                    Some(
-                        kind @ (PtrKind::Raw(_)
-                        | PtrKind::OptBox
-                        | PtrKind::OptBoxedSlice
-                        | PtrKind::Box
-                        | PtrKind::BoxedSlice),
-                    ) => Some(kind),
-                    _ => None,
-                };
+            let direct_output_dec = get_direct_output_dec(decision_maker.decide(
+                return_local,
+                return_decl,
+                return_aliases,
+            ));
             let returned_local_output_dec =
                 infer_returned_local_box_kind(body, &decision_maker, aliases, return_local);
-            let output_dec = match (direct_output_dec, returned_local_output_dec) {
-                (
-                    Some(PtrKind::Raw(_)),
-                    Some(
-                        kind @ (PtrKind::OptBox
-                        | PtrKind::OptBoxedSlice
-                        | PtrKind::Box
-                        | PtrKind::BoxedSlice),
-                    ),
-                ) => Some(kind),
-                (Some(PtrKind::Raw(m)), _) => Some(PtrKind::Raw(m)),
-                (
-                    Some(PtrKind::OptBox | PtrKind::Box),
-                    Some(kind @ (PtrKind::OptBoxedSlice | PtrKind::BoxedSlice)),
-                ) => Some(kind),
-                (Some(kind), None) | (None, Some(kind)) => Some(kind),
-                (Some(kind), Some(_)) => Some(kind),
-                (None, None) => None,
-            };
+            let output_dec = get_output_dec(direct_output_dec, returned_local_output_dec);
 
             data.insert(
                 *did,
                 SigDecision {
                     input_decs,
                     output_dec,
-                    signature_locked: false,
                 },
             );
         }
@@ -356,7 +340,7 @@ impl SigDecisions {
     }
 }
 
-fn infer_returned_local_box_kind<'tcx>(
+pub(crate) fn infer_returned_local_box_kind<'tcx>(
     body: &rustc_middle::mir::Body<'tcx>,
     decision_maker: &DecisionMaker<'tcx>,
     aliases: Option<&FxHashMap<Local, FxHashSet<Local>>>,
@@ -418,6 +402,44 @@ fn infer_returned_local_box_kind<'tcx>(
         Some(kind @ (PtrKind::Box | PtrKind::BoxedSlice)) if return_non_null => Some(kind),
         Some(kind @ (PtrKind::Box | PtrKind::BoxedSlice)) => Some(kind.optional_variant()),
         _ => None,
+    }
+}
+
+pub fn get_direct_output_dec(decision: Option<PtrKind>) -> Option<PtrKind> {
+    match decision {
+        Some(
+            kind @ (PtrKind::Raw(_)
+            | PtrKind::OptBox
+            | PtrKind::OptBoxedSlice
+            | PtrKind::Box
+            | PtrKind::BoxedSlice),
+        ) => Some(kind),
+        _ => None,
+    }
+}
+
+pub fn get_output_dec(
+    direct_output_dec: Option<PtrKind>,
+    returned_local_output_dec: Option<PtrKind>,
+) -> Option<PtrKind> {
+    match (direct_output_dec, returned_local_output_dec) {
+    (
+        Some(PtrKind::Raw(_)),
+        Some(
+            kind @ (PtrKind::OptBox
+            | PtrKind::OptBoxedSlice
+            | PtrKind::Box
+            | PtrKind::BoxedSlice),
+        ),
+        ) => Some(kind),
+        (Some(PtrKind::Raw(m)), _) => Some(PtrKind::Raw(m)),
+        (
+            Some(PtrKind::OptBox | PtrKind::Box),
+            Some(kind @ (PtrKind::OptBoxedSlice | PtrKind::BoxedSlice)),
+        ) => Some(kind),
+        (Some(kind), None) | (None, Some(kind)) => Some(kind),
+        (Some(kind), Some(_)) => Some(kind),
+        (None, None) => None,
     }
 }
 

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -301,7 +301,7 @@ fn print_fn_ptr_arg_counts(input: &RustProgram<'_>, fn_ptr_groups: &FnPtrGroups)
             promoted
         );
     }
-    println!("crat_fn_ptr_total\t{}\t{}", total_args, promoted_args);
+    println!("crat_fn_ptr_total\t{total_args}\t{promoted_args}");
 }
 
 fn slice_cursor_mod_str() -> &'static str {

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -16,6 +16,8 @@ use crate::{
     analyses::{
         self,
         borrow::PromotedMutRefs as PromotedMutRefResult,
+        fn_ptr_groups::FnPtrGroups,
+        fn_ptr_rewrite_decision::FnPtrRewriteDecision,
         offset_sign::sign::OffsetSignResult,
         output_params::OutputParams,
         ownership::{
@@ -24,24 +26,25 @@ use crate::{
         },
         type_qualifier::foster::{fatness::FatnessResult, mutability::MutabilityResult},
     },
+    rewriter::decision::PtrKind,
     utils::rustc::RustProgram,
 };
 
-mod collector;
-mod decision;
+pub(crate) mod collector;
+pub(crate) mod decision;
 mod struct_array_field_pre;
 mod transform;
 
 pub struct Analysis {
-    promoted_mut_ref_result: PromotedMutRefResult,
-    promoted_shared_ref_result: PromotedMutRefResult,
-    mutability_result: MutabilityResult,
-    fatness_result: FatnessResult,
-    aliases: FxHashMap<LocalDefId, FxHashMap<Local, FxHashSet<Local>>>,
-    output_params: OutputParams,
-    ownership_schemes: Option<SolidifiedOwnershipSchemes>,
-    offset_sign_result: OffsetSignResult,
-    nullity_result: analyses::nullity::NullityResult,
+    pub(crate) promoted_mut_ref_result: PromotedMutRefResult,
+    pub(crate) promoted_shared_ref_result: PromotedMutRefResult,
+    pub(crate) mutability_result: MutabilityResult,
+    pub(crate) fatness_result: FatnessResult,
+    pub(crate) aliases: FxHashMap<LocalDefId, FxHashMap<Local, FxHashSet<Local>>>,
+    pub(crate) output_params: OutputParams,
+    pub(crate) ownership_schemes: Option<SolidifiedOwnershipSchemes>,
+    pub(crate) offset_sign_result: OffsetSignResult,
+    pub(crate) nullity_result: analyses::nullity::NullityResult,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -108,7 +111,23 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
         nullity_result,
     };
 
-    let mut visitor = TransformVisitor::new(&input, &analysis_results, ast_to_hir);
+    let fn_ptr_groups = FnPtrGroups::build(&pre_points_to, &points_to, &input, &analysis_results);
+    let fn_ptr_rewrite = FnPtrRewriteDecision::build(
+        &pre_points_to,
+        &points_to,
+        &input,
+        &analysis_results,
+        &tss,
+        &fn_ptr_groups,
+    );
+
+    let mut visitor = TransformVisitor::new(
+        &input,
+        &analysis_results,
+        ast_to_hir,
+        fn_ptr_groups,
+        fn_ptr_rewrite,
+    );
     visitor.visit_crate(&mut krate);
 
     // add SliceCursor module to the crate if it was used
@@ -149,7 +168,7 @@ pub fn rewrite_struct_arrays(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     (pprust::crate_to_string_for_macros(&krate), changed)
 }
 
-fn collect_input(tcx: TyCtxt<'_>) -> RustProgram<'_> {
+pub(crate) fn collect_input(tcx: TyCtxt<'_>) -> RustProgram<'_> {
     let mut functions = vec![];
     let mut structs = vec![];
     for maybe_owner in tcx.hir_crate(()).owners.iter() {
@@ -190,7 +209,7 @@ fn maybe_solidified_ownership<'tcx>(
         .map(|results| results.solidify(input))
 }
 
-fn find_param_aliases<'tcx>(
+pub(crate) fn find_param_aliases<'tcx>(
     pre: &andersen::PreAnalysisData<'tcx>,
     points_to: &andersen::Solutions,
     tcx: TyCtxt<'tcx>,
@@ -260,6 +279,29 @@ fn print_nullity_counts(
             non_null
         );
     }
+}
+
+#[allow(unused)]
+fn print_fn_ptr_arg_counts(input: &RustProgram<'_>, fn_ptr_groups: &FnPtrGroups) {
+    let mut total_args = 0usize;
+    let mut promoted_args = 0usize;
+
+    for (rep, decs) in &fn_ptr_groups.group_decisions {
+        let total = decs.len();
+        let promoted = decs
+            .iter()
+            .filter(|d| matches!(d, Some(k) if !matches!(k, PtrKind::Raw(_))))
+            .count();
+        total_args += total;
+        promoted_args += promoted;
+        println!(
+            "crat_fn_ptr\t{}\t{}\t{}",
+            input.tcx.def_path_str(rep.to_def_id()),
+            total,
+            promoted
+        );
+    }
+    println!("crat_fn_ptr_total\t{}\t{}", total_args, promoted_args);
 }
 
 fn slice_cursor_mod_str() -> &'static str {

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -73,8 +73,8 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
     let aliases = find_param_aliases(&pre_points_to, &points_to_solutions, tcx);
     let points_to = andersen::post_analyze(
         &andersen_config,
-        pre_points_to,
-        points_to_solutions,
+        pre_points_to.clone(),
+        points_to_solutions.clone(),
         &tss,
         tcx,
     );
@@ -111,10 +111,15 @@ pub fn replace_local_borrows(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
         nullity_result,
     };
 
-    let fn_ptr_groups = FnPtrGroups::build(&pre_points_to, &points_to, &input, &analysis_results);
+    let fn_ptr_groups = FnPtrGroups::build(
+        &pre_points_to,
+        &points_to_solutions,
+        &input,
+        &analysis_results,
+    );
     let fn_ptr_rewrite = FnPtrRewriteDecision::build(
         &pre_points_to,
-        &points_to,
+        &points_to_solutions,
         &input,
         &analysis_results,
         &tss,

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -26,7 +26,6 @@ use crate::{
         },
         type_qualifier::foster::{fatness::FatnessResult, mutability::MutabilityResult},
     },
-    rewriter::decision::PtrKind,
     utils::rustc::RustProgram,
 };
 
@@ -284,29 +283,6 @@ fn print_nullity_counts(
             non_null
         );
     }
-}
-
-#[allow(unused)]
-fn print_fn_ptr_arg_counts(input: &RustProgram<'_>, fn_ptr_groups: &FnPtrGroups) {
-    let mut total_args = 0usize;
-    let mut promoted_args = 0usize;
-
-    for (rep, decs) in &fn_ptr_groups.group_decisions {
-        let total = decs.len();
-        let promoted = decs
-            .iter()
-            .filter(|d| matches!(d, Some(k) if !matches!(k, PtrKind::Raw(_))))
-            .count();
-        total_args += total;
-        promoted_args += promoted;
-        println!(
-            "crat_fn_ptr\t{}\t{}\t{}",
-            input.tcx.def_path_str(rep.to_def_id()),
-            total,
-            promoted
-        );
-    }
-    println!("crat_fn_ptr_total\t{total_args}\t{promoted_args}");
 }
 
 fn slice_cursor_mod_str() -> &'static str {

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -1,6 +1,7 @@
 use std::cell::Cell;
 
 use etrace::some_or;
+use rustc_abi::FieldIdx;
 use rustc_ast::{
     mut_visit::{self, MutVisitor},
     ptr::P,
@@ -26,7 +27,10 @@ use super::{
     collector::collect_diffs,
     decision::{PtrKind, SigDecision, SigDecisions},
 };
-use crate::utils::rustc::RustProgram;
+use crate::{
+    analyses::{fn_ptr_groups::FnPtrGroups, fn_ptr_rewrite_decision::FnPtrRewriteDecision},
+    utils::rustc::RustProgram,
+};
 
 pub(crate) struct TransformVisitor<'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -37,6 +41,7 @@ pub(crate) struct TransformVisitor<'tcx> {
     alloc_wrappers: FxHashMap<LocalDefId, AllocWrapperInfo>,
     free_like_wrappers: FxHashSet<LocalDefId>,
     ast_to_hir: AstToHir,
+    pub(crate) fn_ptr_rewrite: FnPtrRewriteDecision,
     pub bytemuck: Cell<bool>,
     pub slice_cursor: Cell<bool>,
 }
@@ -192,7 +197,21 @@ impl MutVisitor for TransformVisitor<'_> {
                                 });
                             *param.ty = mk_opt_boxed_slice_ty(inner_ty, self.tcx);
                         }
-                        None => continue,
+                        None => {
+                            if let TyKind::BareFn(bare_fn) = &mut param.ty.kind {
+                                if let Some(hir_id) =
+                                    self.ast_to_hir.local_map.get(&param.pat.id).copied()
+                                    && let Some(decs) =
+                                        self.fn_ptr_rewrite.annotation_decisions.get(&hir_id)
+                                {
+                                    let decs = decs.clone();
+                                    if rewrite_bare_fn_inputs(bare_fn, &decs) {
+                                        self.slice_cursor.set(true);
+                                    }
+                                }
+                            }
+                            continue;
+                        }
                     }
 
                     if input_dec.is_some_and(|kind| kind.is_mut())
@@ -253,6 +272,58 @@ impl MutVisitor for TransformVisitor<'_> {
                     _ => adjusted_output_dec,
                 };
                 fn_output_transform = output_kind.map(|kind| (def_id, kind));
+            }
+            ItemKind::Struct(_, _, variant_data) => {
+                let struct_def_id = self.ast_to_hir.global_map[&node_id];
+                let fields = match variant_data {
+                    VariantData::Struct { fields, .. } => fields.as_mut_slice(),
+                    VariantData::Tuple(fields, _) => fields.as_mut_slice(),
+                    VariantData::Unit(_) => &mut [],
+                };
+                for (field_idx, field) in fields.iter_mut().enumerate() {
+                    let fi = FieldIdx::from_usize(field_idx);
+                    if let TyKind::BareFn(bare_fn) = &mut field.ty.kind {
+                        if let Some(decs) = self
+                            .fn_ptr_rewrite
+                            .field_decisions
+                            .get(&(struct_def_id, fi))
+                        {
+                            let decs = decs.clone();
+                            if rewrite_bare_fn_inputs(bare_fn, &decs) {
+                                self.slice_cursor.set(true);
+                            }
+                        }
+                    }
+                }
+            }
+            ItemKind::TyAlias(box ty_alias) => {
+                let alias_def_id = self.ast_to_hir.global_map[&node_id];
+                let alias_hir_id = self.tcx.local_def_id_to_hir_id(alias_def_id);
+                if let Some(decs) = self.fn_ptr_rewrite.annotation_decisions.get(&alias_hir_id) {
+                    let decs = decs.clone();
+                    if let Some(ty) = &mut ty_alias.ty
+                        && let Some(bare_fn) = find_bare_fn_in_ty_mut(ty)
+                    {
+                        if rewrite_bare_fn_inputs(bare_fn, &decs) {
+                            self.slice_cursor.set(true);
+                        }
+                    }
+                }
+            }
+            ItemKind::Static(box static_item) => {
+                // only bare fn-ptr statics (fn(...)) are covered; Option<fn(...)> statics
+                // are not in annotation_decisions and their BareFn match fails here — consistent
+                // with the TyKind::FnPtr guard in FnPtrRewriteDecision::build Step 3e.
+                let static_def_id = self.ast_to_hir.global_map[&node_id];
+                let static_hir_id = self.tcx.local_def_id_to_hir_id(static_def_id);
+                if let TyKind::BareFn(bare_fn) = &mut static_item.ty.kind
+                    && let Some(decs) = self.fn_ptr_rewrite.annotation_decisions.get(&static_hir_id)
+                {
+                    let decs = decs.clone();
+                    if rewrite_bare_fn_inputs(bare_fn, &decs) {
+                        self.slice_cursor.set(true);
+                    }
+                }
             }
             _ => {}
         }
@@ -390,6 +461,19 @@ impl MutVisitor for TransformVisitor<'_> {
                 if !self.try_bridge_raw_root(rhs, hir_rhs, lhs_kind, lhs_inner_ty, Some(hir_id)) {
                     self.transform_rhs(rhs, hir_rhs, lhs_kind);
                 }
+            }
+        }
+
+        // Handle fn-ptr typed locals: rewrite BareFn type annotations
+        if let Some(ty) = &mut local.ty
+            && let TyKind::BareFn(bare_fn) = &mut ty.kind
+            && let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx)
+            && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
+            && let Some(decs) = self.fn_ptr_rewrite.annotation_decisions.get(&hir_id)
+        {
+            let decs = decs.clone();
+            if rewrite_bare_fn_inputs(bare_fn, &decs) {
+                self.slice_cursor.set(true);
             }
         }
     }
@@ -538,7 +622,7 @@ impl MutVisitor for TransformVisitor<'_> {
                     self.transform_rhs(r, hir_r, kind);
                 }
             }
-            ExprKind::Call(_, args) => {
+            ExprKind::Call(func_ast, args) => {
                 let hir_expr = self.ast_to_hir.get_expr(expr.id, self.tcx).unwrap();
                 let hir::ExprKind::Call(func, hargs) = hir_expr.kind else {
                     panic!("{hir_expr:?}")
@@ -551,6 +635,30 @@ impl MutVisitor for TransformVisitor<'_> {
                 } else {
                     None
                 };
+
+                // for indirect calls via a fn-ptr binding, look up joint decisions
+                let fn_ptr_decisions: Option<&Vec<Option<PtrKind>>> = if sig_dec.is_none() {
+                    if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = func.kind
+                        && let Res::Local(binding_hir_id) = path.res
+                    {
+                        self.fn_ptr_rewrite
+                            .annotation_decisions
+                            .get(&binding_hir_id)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                // for calls via struct-field fn-ptrs (e.g., `(s.field).expect(...)(args)`)
+                let field_fn_ptr_decisions: Option<&Vec<Option<PtrKind>>> =
+                    if sig_dec.is_none() && fn_ptr_decisions.is_none() {
+                        self.field_fn_ptr_decisions_for_call(func)
+                    } else {
+                        None
+                    };
+
                 let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
 
                 for (i, (arg, harg)) in args.iter_mut().zip(hargs).enumerate() {
@@ -558,6 +666,16 @@ impl MutVisitor for TransformVisitor<'_> {
                     let param_kind = sig_dec
                         .and_then(|sig| sig.input_decs.get(i).copied())
                         .flatten()
+                        .or_else(|| {
+                            fn_ptr_decisions
+                                .and_then(|decs| decs.get(i).copied())
+                                .flatten()
+                        })
+                        .or_else(|| {
+                            field_fn_ptr_decisions
+                                .and_then(|decs| decs.get(i).copied())
+                                .flatten()
+                        })
                         .or_else(|| {
                             unwrap_ptr_from_mir_ty(ty).map(|(_, m)| {
                                 PtrKind::Raw(
@@ -573,6 +691,29 @@ impl MutVisitor for TransformVisitor<'_> {
                 if let Some(free_rewrite) = self.rewrite_direct_free_call(hir_expr, &args[..]) {
                     *expr = free_rewrite;
                     return;
+                }
+
+                // when this is a transmute call and an argument casts a fn-ptr group function,
+                // replace the first explicit type arg with `_` to match the rewritten cast type
+                if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = func.kind
+                    && path
+                        .segments
+                        .last()
+                        .is_some_and(|s| s.ident.name == rustc_span::sym::transmute)
+                    && hargs.iter().any(|h| self.hir_expr_has_fn_ptr_group_cast(h))
+                {
+                    if let ExprKind::Path(_, path) = &mut func_ast.kind
+                        && let Some(seg) = path.segments.last_mut()
+                        && let Some(gen_args) = &mut seg.args
+                        && let GenericArgs::AngleBracketed(angle_args) = &mut **gen_args
+                    {
+                        for arg in &mut angle_args.args {
+                            if let AngleBracketedArg::Arg(GenericArg::Type(ty)) = arg {
+                                ty.kind = TyKind::Infer;
+                                break;
+                            }
+                        }
+                    }
                 }
 
                 hoist_opt_ref_borrow(expr);
@@ -739,6 +880,27 @@ impl MutVisitor for TransformVisitor<'_> {
                     }
                 }
             }
+            ExprKind::Cast(_, cast_ty) => {
+                if let TyKind::BareFn(bare_fn) = &mut cast_ty.kind {
+                    if let Some(hir_expr) = self.ast_to_hir.get_expr(expr.id, self.tcx)
+                        && let hir::ExprKind::Cast(hir_inner, _) = hir_expr.kind
+                    {
+                        let inner = utils::hir::unwrap_drop_temps(hir_inner);
+                        if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = inner.kind
+                            && let hir::def::Res::Def(_, def_id) = path.res
+                            && let Some(local_did) = def_id.as_local()
+                            && self.fn_ptr_rewrite.direct_rewrite.contains(&local_did)
+                            && let Some(decs) =
+                                self.fn_ptr_rewrite.individual_decisions.get(&local_did)
+                        {
+                            let decs = decs.clone();
+                            if rewrite_bare_fn_inputs(bare_fn, &decs) {
+                                self.slice_cursor.set(true);
+                            }
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -766,9 +928,11 @@ impl<'tcx> TransformVisitor<'tcx> {
         rust_program: &RustProgram<'tcx>,
         analysis: &Analysis,
         ast_to_hir: AstToHir,
+        fn_ptr_groups: FnPtrGroups,
+        fn_ptr_rewrite: FnPtrRewriteDecision,
     ) -> TransformVisitor<'tcx> {
-        let mut sig_decs = SigDecisions::new(rust_program, analysis); // TODO: Move outside
-        let mut ptr_kinds = collect_diffs(rust_program, analysis); // TODO: Move outside
+        let mut sig_decs = SigDecisions::new(rust_program, analysis, &fn_ptr_groups);
+        let mut ptr_kinds = collect_diffs(rust_program, analysis, &fn_ptr_groups);
         let free_like_wrappers = collect_local_free_wrappers(rust_program.tcx);
         let local_raw_free_summaries =
             collect_local_raw_free_summaries(rust_program.tcx, &free_like_wrappers);
@@ -846,6 +1010,7 @@ impl<'tcx> TransformVisitor<'tcx> {
             alloc_wrappers,
             free_like_wrappers,
             ast_to_hir,
+            fn_ptr_rewrite,
             bytemuck: Cell::new(false),
             slice_cursor: Cell::new(false),
         }
@@ -1017,6 +1182,69 @@ impl<'tcx> TransformVisitor<'tcx> {
         let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_rhs.kind else { return None };
         let Res::Local(hir_id) = path.res else { return None };
         Some(hir_id)
+    }
+
+    /// Returns fn-ptr group decisions for calls via struct-field fn-ptrs like
+    /// `(struct.field).expect("...")(args)`. Checks for the `expect`/`unwrap` unwrap pattern.
+    fn field_fn_ptr_decisions_for_call<'a>(
+        &'a self,
+        func: &hir::Expr<'tcx>,
+    ) -> Option<&'a Vec<Option<PtrKind>>> {
+        let func = utils::hir::unwrap_drop_temps(func);
+        let hir::ExprKind::MethodCall(method_seg, receiver, _, _) = func.kind else {
+            return None;
+        };
+        if !matches!(method_seg.ident.name.as_str(), "expect" | "unwrap") {
+            return None;
+        }
+        let receiver = utils::hir::unwrap_drop_temps(receiver);
+        let hir::ExprKind::Field(struct_expr, field_ident) = receiver.kind else { return None };
+        let typeck = self.tcx.typeck(func.hir_id.owner);
+        let struct_ty = typeck.expr_ty_adjusted(struct_expr);
+        let ty::TyKind::Adt(adt_def, _) = struct_ty.kind() else { return None };
+        if !adt_def.is_struct() {
+            return None;
+        }
+        let Some(struct_did) = adt_def.did().as_local() else { return None };
+        let field_idx = adt_def
+            .all_fields()
+            .position(|f| f.name == field_ident.name)
+            .map(FieldIdx::from_usize)?;
+        self.fn_ptr_rewrite
+            .field_decisions
+            .get(&(struct_did, field_idx))
+    }
+
+    fn hir_expr_has_fn_ptr_group_cast(&self, expr: &'tcx hir::Expr<'tcx>) -> bool {
+        struct CastFinder<'a> {
+            direct_rewrite: &'a FxHashSet<LocalDefId>,
+            found: bool,
+        }
+        impl<'tcx> Visitor<'tcx> for CastFinder<'_> {
+            fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+                if self.found {
+                    return;
+                }
+                if let hir::ExprKind::Cast(inner, _) = expr.kind {
+                    let inner = utils::hir::unwrap_drop_temps(inner);
+                    if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = inner.kind
+                        && let hir::def::Res::Def(_, def_id) = path.res
+                        && let Some(local_did) = def_id.as_local()
+                        && self.direct_rewrite.contains(&local_did)
+                    {
+                        self.found = true;
+                        return;
+                    }
+                }
+                intravisit::walk_expr(self, expr);
+            }
+        }
+        let mut finder = CastFinder {
+            direct_rewrite: &self.fn_ptr_rewrite.direct_rewrite,
+            found: false,
+        };
+        finder.visit_expr(expr);
+        finder.found
     }
 
     fn effective_ptr_kind(&self, hir_id: HirId) -> Option<PtrKind> {
@@ -4563,6 +4791,72 @@ fn mk_raw_ptr_ty<'tcx>(ty: ty::Ty<'tcx>, mutability: bool, tcx: TyCtxt<'tcx>) ->
     let ty = mir_ty_to_string(ty, tcx);
     let m = if mutability { "mut" } else { "const" };
     utils::ty!("*{m} {ty}")
+}
+
+/// Finds a `BareFn` type nested inside wrappers like `Option<fn(...)>`.
+fn find_bare_fn_in_ty_mut(ty: &mut Ty) -> Option<&mut rustc_ast::BareFnTy> {
+    match &mut ty.kind {
+        TyKind::BareFn(bare_fn) => Some(bare_fn),
+        TyKind::Path(_, path) => {
+            let seg = path.segments.last_mut()?;
+            let gen_args = seg.args.as_mut()?;
+            let GenericArgs::AngleBracketed(angle_args) = &mut **gen_args else { return None };
+            for arg in &mut angle_args.args {
+                if let AngleBracketedArg::Arg(GenericArg::Type(inner_ty)) = arg {
+                    if let Some(bare_fn) = find_bare_fn_in_ty_mut(inner_ty) {
+                        return Some(bare_fn);
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Returns `true` if any parameter was rewritten to a SliceCursor type.
+fn rewrite_bare_fn_inputs(
+    bare_fn: &mut rustc_ast::BareFnTy,
+    decisions: &[Option<PtrKind>],
+) -> bool {
+    let mut used_slice_cursor = false;
+    for (param, decision) in bare_fn.decl.inputs.iter_mut().zip(decisions) {
+        let Some(kind) = decision else { continue };
+        let TyKind::Ptr(MutTy { ty: inner_ty, .. }) = &param.ty.kind else { continue };
+        let inner_str = pprust::ty_to_string(inner_ty);
+        let new_ty = match kind {
+            PtrKind::Ref(m) => {
+                let m = if *m { "mut " } else { "" };
+                utils::ty!("&{m}{inner_str}")
+            }
+            PtrKind::OptRef(m) => {
+                let m = if *m { "mut " } else { "" };
+                utils::ty!("Option<&{m}{inner_str}>")
+            }
+            PtrKind::Slice(m) => {
+                let m = if *m { "mut " } else { "" };
+                utils::ty!("&{m}[{inner_str}]")
+            }
+            PtrKind::Raw(m) => {
+                let m = if *m { "mut" } else { "const" };
+                utils::ty!("*{m} {inner_str}")
+            }
+            PtrKind::Box => utils::ty!("Box<{inner_str}>"),
+            PtrKind::OptBox => utils::ty!("Option<Box<{inner_str}>>"),
+            PtrKind::BoxedSlice => utils::ty!("Box<[{inner_str}]>"),
+            PtrKind::OptBoxedSlice => utils::ty!("Option<Box<[{inner_str}]>>"),
+            PtrKind::SliceCursor(m) => {
+                used_slice_cursor = true;
+                if *m {
+                    utils::ty!("crate::slice_cursor::SliceCursorMut<'_, {inner_str}>")
+                } else {
+                    utils::ty!("crate::slice_cursor::SliceCursor<'_, {inner_str}>")
+                }
+            }
+        };
+        param.ty = P(new_ty);
+    }
+    used_slice_cursor
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -9031,6 +9325,7 @@ mod tests {
             alloc_wrappers: FxHashMap::default(),
             free_like_wrappers: FxHashSet::default(),
             ast_to_hir: AstToHir::default(),
+            fn_ptr_rewrite: FnPtrRewriteDecision::default(),
             bytemuck: Cell::new(false),
             slice_cursor: Cell::new(false),
         }
@@ -9734,7 +10029,7 @@ mod tests {
     fn analyze_pointer_safety_for_program(tcx: TyCtxt<'_>) -> PointerSafetyAnalysisResult {
         let (input, analysis) = build_analysis(tcx);
         let tracked_sites = collect_semantic_allocator_sites(tcx, &input);
-        let initial_ptr_kinds = collect_diffs(&input, &analysis);
+        let initial_ptr_kinds = collect_diffs(&input, &analysis, &FnPtrGroups::default());
         let (_sig_decs, final_ptr_kinds, _reason_map, _usage_subreason_map) =
             simulate_transform_reasons(tcx, &input, &analysis);
 
@@ -9902,8 +10197,8 @@ mod tests {
         FxHashMap<HirId, Vec<&'static str>>,
         FxHashMap<HirId, Vec<&'static str>>,
     ) {
-        let mut sig_decs = SigDecisions::new(input, analysis);
-        let mut ptr_kinds = collect_diffs(input, analysis);
+        let mut sig_decs = SigDecisions::new(input, analysis, &FnPtrGroups::default());
+        let mut ptr_kinds = collect_diffs(input, analysis, &FnPtrGroups::default());
         let free_like_wrappers = collect_local_free_wrappers(tcx);
         let local_raw_free_summaries = collect_local_raw_free_summaries(tcx, &free_like_wrappers);
         let local_raw_param_summaries =

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -41,7 +41,7 @@ pub(crate) struct TransformVisitor<'tcx> {
     alloc_wrappers: FxHashMap<LocalDefId, AllocWrapperInfo>,
     free_like_wrappers: FxHashSet<LocalDefId>,
     ast_to_hir: AstToHir,
-    pub(crate) fn_ptr_rewrite: FnPtrRewriteDecision,
+    fn_ptr_rewrite: FnPtrRewriteDecision,
     pub bytemuck: Cell<bool>,
     pub slice_cursor: Cell<bool>,
 }
@@ -309,8 +309,7 @@ impl MutVisitor for TransformVisitor<'_> {
             }
             ItemKind::Static(box static_item) => {
                 // only bare fn-ptr statics (fn(...)) are covered; Option<fn(...)> statics
-                // are not in annotation_decisions and their BareFn match fails here — consistent
-                // with the TyKind::FnPtr guard in FnPtrRewriteDecision::build Step 3e.
+                // are not in annotation_decisions and their BareFn match fails here
                 let static_def_id = self.ast_to_hir.global_map[&node_id];
                 let static_hir_id = self.tcx.local_def_id_to_hir_id(static_def_id);
                 if let TyKind::BareFn(bare_fn) = &mut static_item.ty.kind

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -198,16 +198,15 @@ impl MutVisitor for TransformVisitor<'_> {
                             *param.ty = mk_opt_boxed_slice_ty(inner_ty, self.tcx);
                         }
                         None => {
-                            if let TyKind::BareFn(bare_fn) = &mut param.ty.kind {
-                                if let Some(hir_id) =
+                            if let TyKind::BareFn(bare_fn) = &mut param.ty.kind
+                                && let Some(hir_id) =
                                     self.ast_to_hir.local_map.get(&param.pat.id).copied()
-                                    && let Some(decs) =
-                                        self.fn_ptr_rewrite.annotation_decisions.get(&hir_id)
-                                {
-                                    let decs = decs.clone();
-                                    if rewrite_bare_fn_inputs(bare_fn, &decs) {
-                                        self.slice_cursor.set(true);
-                                    }
+                                && let Some(decs) =
+                                    self.fn_ptr_rewrite.annotation_decisions.get(&hir_id)
+                            {
+                                let decs = decs.clone();
+                                if rewrite_bare_fn_inputs(bare_fn, &decs) {
+                                    self.slice_cursor.set(true);
                                 }
                             }
                             continue;
@@ -282,16 +281,15 @@ impl MutVisitor for TransformVisitor<'_> {
                 };
                 for (field_idx, field) in fields.iter_mut().enumerate() {
                     let fi = FieldIdx::from_usize(field_idx);
-                    if let TyKind::BareFn(bare_fn) = &mut field.ty.kind {
-                        if let Some(decs) = self
+                    if let TyKind::BareFn(bare_fn) = &mut field.ty.kind
+                        && let Some(decs) = self
                             .fn_ptr_rewrite
                             .field_decisions
                             .get(&(struct_def_id, fi))
-                        {
-                            let decs = decs.clone();
-                            if rewrite_bare_fn_inputs(bare_fn, &decs) {
-                                self.slice_cursor.set(true);
-                            }
+                    {
+                        let decs = decs.clone();
+                        if rewrite_bare_fn_inputs(bare_fn, &decs) {
+                            self.slice_cursor.set(true);
                         }
                     }
                 }
@@ -303,10 +301,9 @@ impl MutVisitor for TransformVisitor<'_> {
                     let decs = decs.clone();
                     if let Some(ty) = &mut ty_alias.ty
                         && let Some(bare_fn) = find_bare_fn_in_ty_mut(ty)
+                        && rewrite_bare_fn_inputs(bare_fn, &decs)
                     {
-                        if rewrite_bare_fn_inputs(bare_fn, &decs) {
-                            self.slice_cursor.set(true);
-                        }
+                        self.slice_cursor.set(true);
                     }
                 }
             }
@@ -701,21 +698,18 @@ impl MutVisitor for TransformVisitor<'_> {
                         .last()
                         .is_some_and(|s| s.ident.name == rustc_span::sym::transmute)
                     && hargs.iter().any(|h| self.hir_expr_has_fn_ptr_group_cast(h))
+                    && let ExprKind::Path(_, path) = &mut func_ast.kind
+                    && let Some(seg) = path.segments.last_mut()
+                    && let Some(gen_args) = &mut seg.args
+                    && let GenericArgs::AngleBracketed(angle_args) = &mut **gen_args
                 {
-                    if let ExprKind::Path(_, path) = &mut func_ast.kind
-                        && let Some(seg) = path.segments.last_mut()
-                        && let Some(gen_args) = &mut seg.args
-                        && let GenericArgs::AngleBracketed(angle_args) = &mut **gen_args
-                    {
-                        for arg in &mut angle_args.args {
-                            if let AngleBracketedArg::Arg(GenericArg::Type(ty)) = arg {
-                                ty.kind = TyKind::Infer;
-                                break;
-                            }
+                    for arg in &mut angle_args.args {
+                        if let AngleBracketedArg::Arg(GenericArg::Type(ty)) = arg {
+                            ty.kind = TyKind::Infer;
+                            break;
                         }
                     }
                 }
-
                 hoist_opt_ref_borrow(expr);
             }
             ExprKind::MethodCall(box MethodCall { seg, receiver, .. })
@@ -881,22 +875,20 @@ impl MutVisitor for TransformVisitor<'_> {
                 }
             }
             ExprKind::Cast(_, cast_ty) => {
-                if let TyKind::BareFn(bare_fn) = &mut cast_ty.kind {
-                    if let Some(hir_expr) = self.ast_to_hir.get_expr(expr.id, self.tcx)
-                        && let hir::ExprKind::Cast(hir_inner, _) = hir_expr.kind
+                if let TyKind::BareFn(bare_fn) = &mut cast_ty.kind
+                    && let Some(hir_expr) = self.ast_to_hir.get_expr(expr.id, self.tcx)
+                    && let hir::ExprKind::Cast(hir_inner, _) = hir_expr.kind
+                {
+                    let inner = utils::hir::unwrap_drop_temps(hir_inner);
+                    if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = inner.kind
+                        && let hir::def::Res::Def(_, def_id) = path.res
+                        && let Some(local_did) = def_id.as_local()
+                        && self.fn_ptr_rewrite.direct_rewrite.contains(&local_did)
+                        && let Some(decs) = self.fn_ptr_rewrite.individual_decisions.get(&local_did)
                     {
-                        let inner = utils::hir::unwrap_drop_temps(hir_inner);
-                        if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = inner.kind
-                            && let hir::def::Res::Def(_, def_id) = path.res
-                            && let Some(local_did) = def_id.as_local()
-                            && self.fn_ptr_rewrite.direct_rewrite.contains(&local_did)
-                            && let Some(decs) =
-                                self.fn_ptr_rewrite.individual_decisions.get(&local_did)
-                        {
-                            let decs = decs.clone();
-                            if rewrite_bare_fn_inputs(bare_fn, &decs) {
-                                self.slice_cursor.set(true);
-                            }
+                        let decs = decs.clone();
+                        if rewrite_bare_fn_inputs(bare_fn, &decs) {
+                            self.slice_cursor.set(true);
                         }
                     }
                 }
@@ -1205,7 +1197,7 @@ impl<'tcx> TransformVisitor<'tcx> {
         if !adt_def.is_struct() {
             return None;
         }
-        let Some(struct_did) = adt_def.did().as_local() else { return None };
+        let struct_did = adt_def.did().as_local()?;
         let field_idx = adt_def
             .all_fields()
             .position(|f| f.name == field_ident.name)
@@ -4802,10 +4794,10 @@ fn find_bare_fn_in_ty_mut(ty: &mut Ty) -> Option<&mut rustc_ast::BareFnTy> {
             let gen_args = seg.args.as_mut()?;
             let GenericArgs::AngleBracketed(angle_args) = &mut **gen_args else { return None };
             for arg in &mut angle_args.args {
-                if let AngleBracketedArg::Arg(GenericArg::Type(inner_ty)) = arg {
-                    if let Some(bare_fn) = find_bare_fn_in_ty_mut(inner_ty) {
-                        return Some(bare_fn);
-                    }
+                if let AngleBracketedArg::Arg(GenericArg::Type(inner_ty)) = arg
+                    && let Some(bare_fn) = find_bare_fn_in_ty_mut(inner_ty)
+                {
+                    return Some(bare_fn);
                 }
             }
             None

--- a/crates/points_to/src/andersen.rs
+++ b/crates/points_to/src/andersen.rs
@@ -172,6 +172,7 @@ pub struct PreAnalysisData<'tcx> {
     pub call_graph: FxHashMap<LocalDefId, FxHashSet<LocalDefId>>,
     pub call_args: FxHashMap<LocalDefId, Vec<Vec<Option<Loc>>>>,
     pub indirect_calls: FxHashMap<LocalDefId, FxHashMap<BasicBlock, Loc>>,
+    pub indirect_call_args: FxHashMap<LocalDefId, FxHashMap<BasicBlock, Vec<Option<Loc>>>>,
 
     pub index_info: IndexInfo<'tcx>,
     pub globals: FxHashMap<LocalDefId, Loc>,
@@ -272,6 +273,7 @@ pub fn pre_analyze<'a, 'tcx>(
     let mut exposed_fn_args = vec![];
 
     let mut indirect_calls: FxHashMap<_, FxHashMap<_, _>> = FxHashMap::default();
+    let mut indirect_call_args: FxHashMap<_, FxHashMap<_, _>> = FxHashMap::default();
     let mut call_args: FxHashMap<_, Vec<Vec<_>>> = FxHashMap::default();
     let mut var_nodes = FxHashMap::default();
     for item in &bodies {
@@ -396,6 +398,19 @@ pub fn pre_analyze<'a, 'tcx>(
                         .entry(item.local_def_id)
                         .or_default()
                         .insert(bb, index);
+                    let arg_locs: Vec<Option<Loc>> = args
+                        .iter()
+                        .map(|a| {
+                            a.node.place().map(|p| {
+                                let var = Var::Local(item.local_def_id, p.local);
+                                vars[&var]
+                            })
+                        })
+                        .collect();
+                    indirect_call_args
+                        .entry(item.local_def_id)
+                        .or_default()
+                        .insert(bb, arg_locs);
                 }
                 _ => {
                     let def_id = some_or!(operand_to_fn(func), continue);
@@ -454,6 +469,7 @@ pub fn pre_analyze<'a, 'tcx>(
         call_graph,
         call_args,
         indirect_calls,
+        indirect_call_args,
         index_info,
         globals,
         non_fn_globals,

--- a/crates/points_to/src/andersen.rs
+++ b/crates/points_to/src/andersen.rs
@@ -91,13 +91,13 @@ pub fn deserialize_solutions(arr: &[u8]) -> Solutions {
     solutions
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BodyItem {
     local_def_id: LocalDefId,
     is_fn: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IndexInfo<'tcx> {
     pub ends: IndexVec<Loc, Loc>,
     tys: IndexVec<Loc, Ty<'tcx>>,
@@ -164,7 +164,7 @@ impl<'tcx> IndexInfo<'tcx> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PreAnalysisData<'tcx> {
     pub bodies: Vec<BodyItem>,
     pub alloc_fns: FxHashSet<LocalDefId>,
@@ -1355,6 +1355,7 @@ impl LocNode {
     }
 }
 
+#[derive(Clone)]
 pub enum LocEdges {
     Fields(IndexVec<FieldIdx, LocNode>),
     Index(LocNode),


### PR DESCRIPTION
# Summary
Implemented function pointer group analysis

Before implementing this analysis, parameters of functions which are used as function pointers, and function pointer types are not rewritten.

Function pointer group analysis consists of two phases.

fn_ptr_groups
- Based on points-to result, group functions whose signature changes may affect each other.
- For each function in a group, run the current borrow inference. 
- If every function in the group agrees on promotion of an argument, mark the argument as promoted.
  - Plus, does not promote owning pointers 

fn_ptr_rewrite_decision
- However, since the current borrow inference lacks of handling indirect calls, this may lead to incorrect transformation.
- For safety, for each indirect call, check if arguments may alias.
  - If two arguments may alias, demote the arguments as raw.
  - We may use the group information in the future version of borrow inference.
  
rewriter   
- Rewrites function pointers in struct fields, globals, and local/parameter type annotations of function pointers 

## Related test cases
B02_organic/call_predict_lib
B02_organic/get_predict_func_lib
- 13 functions each, same pattern
- The first parameter is promoted to SliceCursor(false), the fourth is promoted to OptRef(false)

B02_synthetic/gotomach_lib
- 3 functions, not promoted since void pointers are not promoted 

B02_synthetic/static_vars_fpts
- 2 functions
- src::tokenizer::tokenizer_get_stats: 3 parameters are promoted to OptRef(true)
- src::tokenizer::tokenizer_load_text: 1 parameter is promoted to Slice(false)

## Test
Passed regression test compare to master branch


