### PR TITLE
Add return flows in sign analysis

### DIFF
--- a/crates/pointer_replacer/src/analyses/offset_sign/sign.rs
+++ b/crates/pointer_replacer/src/analyses/offset_sign/sign.rs
@@ -1217,7 +1217,12 @@ impl<'mir, 'tcx, 'a> MVisitor<'tcx> for Collector<'mir, 'tcx, 'a> {
     }
 
     fn visit_terminator(&mut self, terminator: &mir::Terminator<'tcx>, location: Location) {
-        if let TerminatorKind::Call { func, args, .. } = &terminator.kind
+        if let TerminatorKind::Call {
+            func,
+            args,
+            destination,
+            ..
+        } = &terminator.kind
             && let Operand::Constant(box constant) = func
         {
             let ty = constant.const_.ty();
@@ -1263,6 +1268,24 @@ impl<'mir, 'tcx, 'a> MVisitor<'tcx> for Collector<'mir, 'tcx, 'a> {
                             .unwrap_or(FieldNode::Local(self.def_id, place.local));
                         add_field_edge(self.field_graph, lhs, rhs);
                     }
+                }
+                // if caller destination is tainted, callee's return slot also needs cursor
+                if let Some(local_def_id) = def_id.as_local()
+                    && !contains_deref(destination)
+                    && self
+                        .graph
+                        .contains_key(&(local_def_id, Local::from_usize(0)))
+                {
+                    let ret = Local::from_usize(0);
+                    self.graph
+                        .entry((self.def_id, destination.local))
+                        .or_default()
+                        .insert((local_def_id, ret));
+
+                    let lhs = raw_pointer_field_slot(self.body, *destination)
+                        .map(FieldNode::Field)
+                        .unwrap_or(FieldNode::Local(self.def_id, destination.local));
+                    add_field_edge(self.field_graph, lhs, FieldNode::Local(local_def_id, ret));
                 }
             };
         }

--- a/crates/pointer_replacer/src/analyses/offset_sign/tests.rs
+++ b/crates/pointer_replacer/src/analyses/offset_sign/tests.rs
@@ -1026,3 +1026,44 @@ fn branch_copy_cycle_aliases_safe() {
         "copy-related aliases in guarded branch should stay non-negative for offset use"
     );
 }
+
+/// return taint: x = f(a); g(x); where g offsets its param negatively.
+/// Chain: g::p (direct) → caller::x (param prop) → f::_0 (internal MIR return slot, not assertable)
+/// → f::a (intra-body edge). The third assertion verifies the final observable hop.
+#[test]
+fn return_taint_two_hops() {
+    let map = run_analysis(
+        "
+        unsafe fn g(p: *const i32) {
+            let _ = *p.offset(-1);
+        }
+        unsafe fn f(a: *const i32) -> *const i32 {
+            a
+        }
+        pub unsafe fn caller(a: *const i32) {
+            let x = f(a);
+            g(x);
+        }
+        ",
+    );
+    assert_eq!(
+        needs_cursor(&map, "g", "p"),
+        Some(true),
+        "g::p directly offset by -1 needs cursor"
+    );
+    assert_eq!(
+        needs_cursor(&map, "caller", "x"),
+        Some(true),
+        "caller::x flows into g::p which needs cursor — existing param propagation"
+    );
+    assert_eq!(
+        needs_cursor(&map, "f", "a"),
+        Some(true),
+        "f::a tainted via return propagation: caller::x → f::_0 → f::a"
+    );
+    assert_eq!(
+        needs_cursor(&map, "caller", "a"),
+        Some(true),
+        "caller::a flows into f::a which needs cursor — propagated back via arg edge"
+    );
+}


### PR DESCRIPTION
# Summary

Add taint propagation through function returns:

* Updated the `visit_terminator` method in `Collector` to check if the caller's destination variable is tainted when handling function calls, and if so, propagate the taint to the callee's return slot and connect the appropriate nodes in the taint graph.
* Added a test for checking propagation through return

# Test

Regression test compared to master
- No changes in the number of unsafe features