### PR TITLE
Add array pointer local base analysis

### DIFF
--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -1,0 +1,2643 @@
+//! MIR raw-array local provenance graph to find base pointers.
+//!
+//! This analysis is intentionally not location-sensitive yet: each MIR local is
+//! represented by one graph node for the whole body. This may merge separate
+//! definitions of the same local and conservatively reject rewriteable regions.
+
+use std::{collections::VecDeque, fmt::Write as _, ops::Range};
+
+use points_to::andersen;
+use rustc_abi::FieldIdx;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::def_id::LocalDefId;
+use rustc_index::bit_set::DenseBitSet;
+use rustc_middle::{
+    mir::{
+        self, BasicBlock, Body, CastKind, Local, Location, Operand, Place, ProjectionElem, Rvalue,
+        StatementKind, TerminatorKind,
+    },
+    ty::{self, Ty, TyCtxt},
+};
+use rustc_mir_dataflow::Analysis;
+use rustc_span::{def_id::DefId, source_map::Spanned};
+
+use crate::{
+    analyses::{
+        liveness::MaybeLiveLocals,
+        mir_variable_grouping::SourceVarGroups,
+        type_qualifier::foster::mutability::{Mutability as PtrMut, MutabilityResult},
+    },
+    utils::rustc::RustProgram,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PfgNode {
+    Slot(SlotIdx),
+    Base(BaseId),
+    CallReturn(Location),
+    CastResult(Location),
+}
+
+impl PfgNode {
+    fn as_slot(&self) -> Option<SlotIdx> {
+        if let PfgNode::Slot(slot) = self {
+            Some(*slot)
+        } else {
+            None
+        }
+    }
+}
+
+pub type SlotIdx = usize;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum BaseId {
+    Param {
+        local: Local,
+        slot: SlotIdx,
+    },
+    LocalArray {
+        local: Local,
+    },
+    LocalScalar {
+        local: Local,
+    },
+    RawBorrow {
+        target: Option<SlotIdx>,
+        location: Location,
+    },
+    HeapAlloc {
+        location: Location,
+    },
+    OpaqueReturn {
+        location: Location,
+    },
+    IntToPtr {
+        location: Location,
+    },
+    Unknown {
+        location: Location,
+        reason: UnknownReason,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum UnknownReason {
+    NullLike,
+    ConstantPointer,
+    UnsupportedProjection,
+    UnsupportedMemoryLoad,
+    UnsupportedCall,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BaseAdmissibility {
+    DirectlyRewriteable,
+    RewriteableWithOwnershipTransform,
+    TrackOnly,
+    Reject,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BaseClassification {
+    pub base: BaseId,
+    pub admissibility: BaseAdmissibility,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PointerFlowGraph {
+    pub nodes: FxHashSet<PfgNode>,
+    pub edges: FxHashMap<PfgNode, FxHashSet<PfgNode>>,
+    pub bases: FxHashSet<BaseId>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ProvenanceResult {
+    pub reachable_bases: FxHashMap<PfgNode, FxHashSet<BaseId>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ArrayLocalProvenance {
+    pub slot_table: SlotTable,
+    #[allow(dead_code)]
+    pub graph: PointerFlowGraph,
+    pub provenance: ProvenanceResult,
+    pub base_classifications: FxHashMap<BaseId, BaseClassification>,
+}
+
+pub struct RewriteGroup {
+    #[allow(dead_code)]
+    pub base: BaseId,
+    /// MIR local that holds the base pointer.
+    pub base_local: Local,
+    /// offset of the base slot within `base_local`'s qualifier slice.
+    pub base_slot_offset: usize,
+    /// all `SlotIdx`s across any local whose unique reachable base is `base`.
+    pub members: Vec<SlotIdx>,
+    /// true when the base slot is written via direct (trackable) assignments only
+    /// while members are live; the rewriter must use index-tracking for this group.
+    pub index_tracked: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SlotTable {
+    local_slots: Vec<Range<SlotIdx>>,
+    pub slot_infos: Vec<SlotInfo>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SlotInfo {
+    pub root: Local,
+    pub path: Vec<SlotPathElem>,
+    pub depth: usize,
+    pub qualifier_key: Option<QualifierKey>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum QualifierKey {
+    Local {
+        offset: usize,
+    },
+    StructField {
+        def_id: LocalDefId,
+        field: FieldIdx,
+        offset: usize,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum SlotPathElem {
+    Pointee,
+    Field(FieldIdx),
+    Element,
+}
+
+// pre-computed assignment right-hand sides used by `array_source_for_local`
+enum AssignRhs<'tcx> {
+    // rvalue is Ref/RawPtr of this place; if place.local is an array type or
+    // has an array projection, the local is a direct array source
+    ArrayBorrow(Place<'tcx>),
+    // rvalue is Use/Cast/CopyForDeref of this local; follow it recursively
+    Follow(Local),
+}
+
+impl PointerFlowGraph {
+    fn add_node(&mut self, node: PfgNode) {
+        self.nodes.insert(node);
+    }
+
+    fn add_base(&mut self, base: BaseId) {
+        self.bases.insert(base.clone());
+        self.add_node(PfgNode::Base(base));
+    }
+
+    fn add_edge(&mut self, src: PfgNode, dst: PfgNode) {
+        self.nodes.insert(src.clone());
+        self.nodes.insert(dst.clone());
+        self.edges.entry(src).or_default().insert(dst);
+    }
+
+    fn add_base_edge(&mut self, base: BaseId, dst: PfgNode) {
+        self.add_base(base.clone());
+        self.add_edge(PfgNode::Base(base), dst);
+    }
+
+    fn add_bidirectional_edge(&mut self, a: PfgNode, b: PfgNode) {
+        self.add_edge(a.clone(), b.clone());
+        self.add_edge(b, a);
+    }
+}
+
+impl ProvenanceResult {
+    pub fn unique_base(&self, node: &PfgNode) -> Option<BaseId> {
+        let bases = self.reachable_bases.get(node)?;
+        if bases.len() == 1 {
+            bases.iter().next().cloned()
+        } else {
+            None
+        }
+    }
+
+    /// Like `unique_base`, but treats `Unknown(NullLike)` entries as transparent.
+    /// Used in `select_rewrite_groups` to include variables that are null-initialized
+    /// before being assigned from a real base (e.g. `prev = null_mut(); prev = raw;`).
+    pub fn unique_non_null_base(&self, node: &PfgNode) -> Option<BaseId> {
+        let bases = self.reachable_bases.get(node)?;
+        let mut iter = bases.iter().filter(|b| {
+            !matches!(
+                b,
+                BaseId::Unknown {
+                    reason: UnknownReason::NullLike,
+                    ..
+                }
+            )
+        });
+        let unique = iter.next()?.clone();
+        iter.next().is_none().then_some(unique)
+    }
+}
+
+#[allow(dead_code)]
+impl ArrayLocalProvenance {
+    pub fn unique_base(&self, node: &PfgNode) -> Option<BaseId> {
+        self.provenance.unique_base(node)
+    }
+
+    pub fn unique_base_of_local(&self, local: Local) -> Option<BaseId> {
+        let slot = self.slot_table.local_head_slot(local)?;
+        self.unique_base(&PfgNode::Slot(slot))
+    }
+
+    pub fn admissibility_of_base(&self, base: &BaseId) -> BaseAdmissibility {
+        self.base_classifications
+            .get(base)
+            .map(|classification| classification.admissibility.clone())
+            .unwrap_or(BaseAdmissibility::Reject)
+    }
+
+    pub fn is_potential_rewrite_base(&self, base: &BaseId) -> bool {
+        matches!(
+            self.admissibility_of_base(base),
+            BaseAdmissibility::DirectlyRewriteable
+                | BaseAdmissibility::RewriteableWithOwnershipTransform
+        )
+    }
+
+    pub fn debug_body(&self, tcx: TyCtxt<'_>, def_id: LocalDefId, body: &Body<'_>) -> String {
+        let mut out = String::new();
+        let _ = writeln!(
+            out,
+            "array local provenance for {}",
+            tcx.def_path_str(def_id.to_def_id())
+        );
+
+        for (local, decl) in body.local_decls.iter_enumerated() {
+            let Some(slot) = self.slot_table.local_head_slot(local) else {
+                continue;
+            };
+            let node = PfgNode::Slot(slot);
+            let bases = self
+                .provenance
+                .reachable_bases
+                .get(&node)
+                .cloned()
+                .unwrap_or_default();
+            let unique = self.unique_base(&node);
+            let _ = write!(out, "  {local:?}: ty = {:?}, bases = {:?}", decl.ty, bases);
+            match unique {
+                Some(base) => {
+                    let classification = self.base_classifications.get(&base);
+                    let _ = write!(out, ", unique = yes");
+                    if let Some(classification) = classification {
+                        let _ = write!(
+                            out,
+                            ", admissibility = {:?}, reason = {}",
+                            classification.admissibility, classification.reason
+                        );
+                    }
+                }
+                None => {
+                    let _ = write!(out, ", unique = no");
+                }
+            }
+            let _ = writeln!(out);
+        }
+
+        out
+    }
+}
+
+pub fn array_local_provenance_analysis(
+    input: &RustProgram<'_>,
+    alloc_fns: &FxHashSet<LocalDefId>,
+) -> FxHashMap<LocalDefId, ArrayLocalProvenance> {
+    input
+        .functions
+        .iter()
+        .map(|&def_id| {
+            let body = input
+                .tcx
+                .mir_drops_elaborated_and_const_checked(def_id)
+                .borrow();
+            (def_id, analyze_body(input.tcx, def_id, &body, alloc_fns))
+        })
+        .collect()
+}
+
+pub fn analyze_body<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    _def_id: LocalDefId,
+    body: &Body<'tcx>,
+    alloc_fns: &FxHashSet<LocalDefId>,
+) -> ArrayLocalProvenance {
+    let slot_table = SlotTable::new(body, tcx);
+    let rhs_map = build_rhs_map(body, tcx);
+    let mut collector = Collector {
+        tcx,
+        body,
+        alloc_fns,
+        slot_table: &slot_table,
+        graph: PointerFlowGraph::default(),
+        rhs_map,
+        direct_param_slots: FxHashSet::default(),
+    };
+    collector.collect();
+    let graph = collector.graph;
+    let provenance = solve_reachable_bases(&graph);
+    let base_classifications = graph
+        .bases
+        .iter()
+        .map(|base| (base.clone(), classify_base(base)))
+        .collect();
+
+    ArrayLocalProvenance {
+        slot_table,
+        graph,
+        provenance,
+        base_classifications,
+    }
+}
+
+/// Returns the pointer-type qualifier for a specific local qualifier offset.
+fn qualifier_at_local(
+    mutability_result: &MutabilityResult,
+    def_id: LocalDefId,
+    local: Local,
+    slot_offset: usize,
+) -> Option<PtrMut> {
+    mutability_result.function_body_fact(def_id, local.index(), slot_offset)
+}
+
+#[allow(dead_code)]
+fn qualifier_at_slot(
+    mutability_result: &MutabilityResult,
+    def_id: LocalDefId,
+    info: &SlotInfo,
+) -> Option<PtrMut> {
+    match info.qualifier_key {
+        Some(QualifierKey::Local { offset }) => {
+            mutability_result.function_body_fact(def_id, info.root.index(), offset)
+        }
+        Some(QualifierKey::StructField {
+            def_id: struct_def_id,
+            field,
+            offset,
+        }) => mutability_result.struct_field_fact(struct_def_id, field.index(), offset),
+        None => None,
+    }
+}
+
+fn slot_ty<'tcx>(body: &Body<'tcx>, tcx: TyCtxt<'tcx>, info: &SlotInfo) -> Option<Ty<'tcx>> {
+    let mut ty = body.local_decls[info.root].ty;
+
+    for elem in &info.path {
+        match elem {
+            SlotPathElem::Pointee => {
+                ty = ty.builtin_deref(true)?;
+            }
+            SlotPathElem::Field(field) => {
+                ty = match ty.kind() {
+                    ty::TyKind::Adt(adt_def, args) => {
+                        if !adt_def.is_struct() || adt_def.is_union() {
+                            return None;
+                        }
+                        adt_def.all_fields().nth(field.index())?.ty(tcx, args)
+                    }
+                    ty::TyKind::Tuple(tys) => tys.iter().nth(field.index())?,
+                    _ => return None,
+                };
+            }
+            SlotPathElem::Element => {
+                ty = ty.builtin_index()?;
+            }
+        }
+    }
+
+    Some(ty)
+}
+
+fn slot_is_mutable_pointer_source<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    info: &SlotInfo,
+) -> bool {
+    match slot_ty(body, tcx, info).map(Ty::kind) {
+        Some(ty::TyKind::RawPtr(_, mutability) | ty::TyKind::Ref(_, _, mutability)) => {
+            mutability.is_mut()
+        }
+        _ => false,
+    }
+}
+
+fn source_var_identity_for_slot<'tcx, S: AsRef<str>>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    local_names: &FxHashMap<Local, S>,
+    info: &SlotInfo,
+) -> Option<String> {
+    let root_name = local_names.get(&info.root)?;
+    if info.path.is_empty() {
+        return Some(root_name.as_ref().to_string());
+    }
+
+    let mut ty = body.local_decls[info.root].ty;
+    let mut identity = root_name.as_ref().to_string();
+    let mut saw_named_field = false;
+
+    for elem in &info.path {
+        match elem {
+            SlotPathElem::Pointee => {
+                ty = ty.builtin_deref(true)?;
+            }
+            SlotPathElem::Field(field) => {
+                let (field_name, field_ty) = named_struct_field(tcx, ty, *field)?;
+                identity.push('.');
+                identity.push_str(&field_name);
+                ty = field_ty;
+                saw_named_field = true;
+            }
+            SlotPathElem::Element => return None,
+        }
+    }
+
+    saw_named_field.then_some(identity)
+}
+
+fn named_struct_field<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: Ty<'tcx>,
+    field: FieldIdx,
+) -> Option<(String, Ty<'tcx>)> {
+    let ty::TyKind::Adt(adt_def, args) = ty.kind() else {
+        return None;
+    };
+    if !adt_def.is_struct() || adt_def.is_union() {
+        return None;
+    }
+
+    let field_def = adt_def.all_fields().nth(field.index())?;
+    let field_name = field_def.name.as_str();
+    if field_name.parse::<usize>().is_ok() {
+        return None;
+    }
+
+    Some((field_name.to_string(), field_def.ty(tcx, args)))
+}
+
+/// Selects groups of slots eligible for rewriting from a single function body.
+///
+/// A group is selected when:
+/// 1. The base has `DirectlyRewriteable` admissibility.
+/// 2. The base storage is stable for the lifetime of all non-base group members:
+///    - LocalArray and LocalScalar bases are considered stable stack objects.
+///    - RawBorrow bases use the existing pointer mutability qualifier check.
+///    - Param bases are rejected only if their storage may be written while a
+///      non-base group member is live after that write.
+/// 3. The group contains either ≥ 2 distinct mutable pointer source-variable
+///    identities, or ≥ 1 mutable AND ≥ 1 immutable identity (allowing *const
+///    aliases to participate). Direct locals and named struct-field slots count;
+///    unnamed temporaries, tuple fields, arrays, and unions do not.
+pub struct RewriteSelectionContext<'a, 'tcx> {
+    pub tcx: TyCtxt<'tcx>,
+    pub points_to: &'a andersen::AnalysisResult,
+}
+
+pub fn select_rewrite_groups<'a, 'tcx>(
+    provenance: &ArrayLocalProvenance,
+    body: &Body<'tcx>,
+    mutability_result: &MutabilityResult,
+    def_id: LocalDefId,
+    context: RewriteSelectionContext<'a, 'tcx>,
+) -> Vec<RewriteGroup> {
+    let mut groups = vec![];
+    let live_after = compute_live_after_by_location(context.tcx, body);
+
+    // build local → source-variable name from VarDebugInfo
+    let mut local_name: FxHashMap<Local, &str> = FxHashMap::default();
+    for dbg in &body.var_debug_info {
+        if let mir::VarDebugInfoContents::Place(place) = &dbg.value
+            && let Some(local) = place.as_local()
+        {
+            local_name.entry(local).or_insert(dbg.name.as_str());
+        }
+    }
+
+    for (base, classification) in &provenance.base_classifications {
+        if classification.admissibility != BaseAdmissibility::DirectlyRewriteable {
+            continue;
+        }
+
+        let Some((base_local, base_slot_offset)) = base_local_of_base(base, &provenance.slot_table)
+        else {
+            continue;
+        };
+
+        // collect all slots whose unique reachable base is this base
+        let members: Vec<SlotIdx> = provenance
+            .slot_table
+            .slot_infos
+            .iter()
+            .enumerate()
+            .filter_map(|(slot_idx, _)| {
+                let node = PfgNode::Slot(slot_idx);
+                if provenance.provenance.unique_non_null_base(&node).as_ref() == Some(base) {
+                    Some(slot_idx)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        // condition 3: either ≥ 2 distinct mutable pointer source-variable identities,
+        // or ≥ 1 mutable AND ≥ 1 immutable — lets *const aliases participate.
+        // additionally, those qualifying members must be simultaneously live at some
+        // MIR location; non-overlapping live ranges imply no borrow conflict and the
+        // pointers can be promoted independently.
+        let mut mut_source_vars: FxHashSet<String> = FxHashSet::default();
+        let mut has_any_imm = false;
+        let mut member_roots: FxHashSet<Local> = FxHashSet::default();
+        let mut local_mut_roots: FxHashSet<Local> = FxHashSet::default();
+        let mut local_imm_roots: FxHashSet<Local> = FxHashSet::default();
+        for &slot_idx in &members {
+            let info = &provenance.slot_table.slot_infos[slot_idx];
+            if local_name.contains_key(&info.root) {
+                member_roots.insert(info.root);
+            }
+            if let Some(name) = source_var_identity_for_slot(context.tcx, body, &local_name, info) {
+                if slot_is_mutable_pointer_source(body, context.tcx, info) {
+                    mut_source_vars.insert(name);
+                    local_mut_roots.insert(info.root);
+                } else {
+                    has_any_imm = true;
+                    local_imm_roots.insert(info.root);
+                }
+            }
+        }
+        // fast global pre-filter: if no named mutable identity exists at all,
+        // the liveness check below cannot pass either.
+        let has_multi_mut = mut_source_vars.len() >= 2;
+        let has_mixed = !mut_source_vars.is_empty() && has_any_imm;
+        if !has_multi_mut && !has_mixed {
+            continue;
+        }
+        // simultaneous-liveness gate: require at least one MIR location where the
+        // mutability condition holds for the subset of member locals that are live there.
+        // `live_after` tracks MIR locals (not slots), so a struct root being live means
+        // all its fields are considered potentially live — a sound over-approximation.
+        let has_conflict = live_after.values().any(|live| {
+            let live_mut_count = local_mut_roots
+                .iter()
+                .filter(|l| live.contains(**l))
+                .count();
+            if live_mut_count >= 2 {
+                return true;
+            }
+            if live_mut_count >= 1 {
+                return local_imm_roots.iter().any(|l| live.contains(*l));
+            }
+            false
+        });
+        if !has_conflict {
+            continue;
+        }
+
+        // condition 2: the base variable binding must be stable for selection
+        let stability_context = BaseStabilityContext {
+            provenance,
+            body,
+            mutability_result,
+            def_id,
+            live_after: &live_after,
+            tcx: context.tcx,
+            points_to: context.points_to,
+        };
+        let stability = is_base_stable_for_selection(
+            base,
+            base_local,
+            base_slot_offset,
+            &members,
+            &member_roots,
+            &stability_context,
+        );
+        let index_tracked = match stability {
+            SelectionStability::Stable => false,
+            SelectionStability::IndexTracked => true,
+            SelectionStability::Unstable => continue,
+        };
+
+        groups.push(RewriteGroup {
+            base: base.clone(),
+            base_local,
+            base_slot_offset,
+            members,
+            index_tracked,
+        });
+    }
+
+    groups
+}
+
+fn compute_live_after_by_location<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+) -> FxHashMap<Location, DenseBitSet<Local>> {
+    let mut cursor = MaybeLiveLocals
+        .iterate_to_fixpoint(tcx, body, None)
+        .into_results_cursor(body);
+    let mut live_after = FxHashMap::default();
+
+    for (block, block_data) in body.basic_blocks.iter_enumerated() {
+        for statement_index in 0..block_data.statements.len() {
+            let location = Location {
+                block,
+                statement_index,
+            };
+            cursor.seek_after_primary_effect(location);
+            live_after.insert(location, cursor.get().clone());
+        }
+
+        if block_data.terminator.is_some() {
+            let location = Location {
+                block,
+                statement_index: block_data.statements.len(),
+            };
+            cursor.seek_after_primary_effect(location);
+            live_after.insert(location, cursor.get().clone());
+        }
+    }
+
+    live_after
+}
+
+enum SelectionStability {
+    /// no mutation concern — select normally with `index_tracked = false`.
+    Stable,
+    /// base slot written only via direct (trackable) assignments while members live
+    /// — select with `index_tracked = true`.
+    IndexTracked,
+    /// aliased or call-based writes present — reject.
+    Unstable,
+}
+
+struct BaseStabilityContext<'a, 'tcx> {
+    provenance: &'a ArrayLocalProvenance,
+    body: &'a Body<'tcx>,
+    mutability_result: &'a MutabilityResult,
+    def_id: LocalDefId,
+    live_after: &'a FxHashMap<Location, DenseBitSet<Local>>,
+    tcx: TyCtxt<'tcx>,
+    points_to: &'a andersen::AnalysisResult,
+}
+
+fn is_base_stable_for_selection(
+    base: &BaseId,
+    base_local: Local,
+    base_slot_offset: usize,
+    members: &[SlotIdx],
+    member_roots: &FxHashSet<Local>,
+    context: &BaseStabilityContext<'_, '_>,
+) -> SelectionStability {
+    match base {
+        BaseId::LocalArray { .. } | BaseId::LocalScalar { .. } => SelectionStability::Stable,
+        BaseId::RawBorrow { .. } => {
+            if qualifier_at_local(
+                context.mutability_result,
+                context.def_id,
+                base_local,
+                base_slot_offset,
+            ) != Some(PtrMut::Mut)
+            {
+                SelectionStability::Stable
+            } else {
+                SelectionStability::Unstable
+            }
+        }
+        BaseId::Param { slot, .. } => {
+            is_param_base_stable_for_selection(base_local, *slot, members, member_roots, context)
+        }
+        _ => SelectionStability::Unstable,
+    }
+}
+
+fn is_param_base_stable_for_selection(
+    base_local: Local,
+    base_slot: SlotIdx,
+    members: &[SlotIdx],
+    member_roots: &FxHashSet<Local>,
+    context: &BaseStabilityContext<'_, '_>,
+) -> SelectionStability {
+    let dependent_locals =
+        dependent_member_locals(members, member_roots, context.provenance, base_local);
+    if dependent_locals.is_empty() {
+        return SelectionStability::Stable;
+    }
+
+    let base_path_contains_pointee = slot_path_contains_pointee(context.provenance, base_slot);
+
+    let locs = param_base_storage_locs(
+        context.points_to,
+        context.def_id,
+        base_local,
+        base_slot,
+        context.provenance,
+    );
+    let base_locs = if base_path_contains_pointee && locs.as_ref().is_none_or(FxHashSet::is_empty) {
+        None
+    } else {
+        locs
+    };
+
+    let mut has_direct_write = false;
+
+    for (block, block_data) in context.body.basic_blocks.iter_enumerated() {
+        for statement_index in 0..block_data.statements.len() {
+            let location = Location {
+                block,
+                statement_index,
+            };
+            let any_member_live = context
+                .live_after
+                .get(&location)
+                .is_some_and(|live| dependent_locals.iter().any(|local| live.contains(*local)));
+            if any_member_live {
+                let is_direct = direct_write_overlaps_slot(
+                    context.body,
+                    context.tcx,
+                    context.provenance,
+                    location,
+                    base_slot,
+                );
+                if is_direct {
+                    has_direct_write = true;
+                } else {
+                    // only run alias/call sub-checks when the direct check did not
+                    // already account for the write; Andersen's all_writes includes
+                    // return-value assignments so it would double-count direct writes.
+                    let is_alias = base_locs.as_ref().is_some_and(|base_locs| {
+                        location_writes_base_storage(
+                            context.points_to,
+                            context.def_id,
+                            location,
+                            base_locs,
+                        )
+                    });
+                    let is_call = base_locs.as_ref().is_some_and(|base_locs| {
+                        call_may_write_base_storage(
+                            context.points_to,
+                            context.body,
+                            context.tcx,
+                            context.provenance,
+                            context.def_id,
+                            location,
+                            base_locs,
+                        )
+                    });
+                    if is_alias || is_call {
+                        return SelectionStability::Unstable;
+                    }
+                }
+            }
+        }
+
+        if block_data.terminator.is_some() {
+            let location = Location {
+                block,
+                statement_index: block_data.statements.len(),
+            };
+            let any_member_live = context
+                .live_after
+                .get(&location)
+                .is_some_and(|live| dependent_locals.iter().any(|local| live.contains(*local)));
+            if any_member_live {
+                let is_direct = direct_write_overlaps_slot(
+                    context.body,
+                    context.tcx,
+                    context.provenance,
+                    location,
+                    base_slot,
+                );
+                if is_direct {
+                    has_direct_write = true;
+                } else {
+                    let is_alias = base_locs.as_ref().is_some_and(|base_locs| {
+                        location_writes_base_storage(
+                            context.points_to,
+                            context.def_id,
+                            location,
+                            base_locs,
+                        )
+                    });
+                    let is_call = base_locs.as_ref().is_some_and(|base_locs| {
+                        call_may_write_base_storage(
+                            context.points_to,
+                            context.body,
+                            context.tcx,
+                            context.provenance,
+                            context.def_id,
+                            location,
+                            base_locs,
+                        )
+                    });
+                    if is_alias || is_call {
+                        return SelectionStability::Unstable;
+                    }
+                }
+            }
+        }
+    }
+
+    if has_direct_write {
+        SelectionStability::IndexTracked
+    } else {
+        SelectionStability::Stable
+    }
+}
+
+fn slot_path_contains_pointee(provenance: &ArrayLocalProvenance, slot: SlotIdx) -> bool {
+    provenance
+        .slot_table
+        .slot_infos
+        .get(slot)
+        .is_some_and(|info| info.path.contains(&SlotPathElem::Pointee))
+}
+
+fn param_base_storage_locs(
+    points_to: &andersen::AnalysisResult,
+    def_id: LocalDefId,
+    local: Local,
+    slot: SlotIdx,
+    provenance: &ArrayLocalProvenance,
+) -> Option<FxHashSet<andersen::Loc>> {
+    let info = provenance.slot_table.slot_infos.get(slot)?;
+    let mut nodes = FxHashSet::default();
+    nodes.insert(*points_to.var_nodes.get(&(def_id, local))?);
+
+    for elem in &info.path {
+        let mut next_nodes = FxHashSet::default();
+        match elem {
+            SlotPathElem::Pointee => {
+                for node in &nodes {
+                    for loc in points_to.solutions[node.index].iter() {
+                        next_nodes.insert(andersen::LocNode {
+                            prefix: 0,
+                            index: loc,
+                        });
+                    }
+                }
+            }
+            SlotPathElem::Element => {
+                for node in &nodes {
+                    let andersen::LocEdges::Index(succ) = points_to.graph.get(node)? else {
+                        return None;
+                    };
+                    next_nodes.insert(*succ);
+                }
+            }
+            SlotPathElem::Field(field) => {
+                for node in &nodes {
+                    let andersen::LocEdges::Fields(succs) = points_to.graph.get(node)? else {
+                        return None;
+                    };
+                    next_nodes.insert(*succs.get(*field)?);
+                }
+            }
+        }
+        if next_nodes.is_empty() {
+            return None;
+        }
+        nodes = next_nodes;
+    }
+
+    Some(nodes.into_iter().map(|node| node.index).collect())
+}
+
+fn location_writes_base_storage(
+    points_to: &andersen::AnalysisResult,
+    def_id: LocalDefId,
+    location: Location,
+    base_locs: &FxHashSet<andersen::Loc>,
+) -> bool {
+    points_to
+        .all_writes
+        .get(&def_id)
+        .and_then(|writes| writes.get(&location))
+        .is_some_and(|writes| base_locs.iter().any(|base_loc| writes.contains(*base_loc)))
+}
+
+fn call_may_write_base_storage<'tcx>(
+    points_to: &andersen::AnalysisResult,
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    provenance: &ArrayLocalProvenance,
+    def_id: LocalDefId,
+    location: Location,
+    base_locs: &FxHashSet<andersen::Loc>,
+) -> bool {
+    let block_data = &body.basic_blocks[location.block];
+    if location.statement_index != block_data.statements.len() {
+        return false;
+    }
+    let Some(terminator) = &block_data.terminator else {
+        return false;
+    };
+    let TerminatorKind::Call { func, args, .. } = &terminator.kind else {
+        return false;
+    };
+    if call_name(tcx, func)
+        .as_ref()
+        .is_some_and(|(def_id, name)| call_no_writes(tcx, *def_id, name))
+    {
+        return false;
+    }
+
+    args.iter().any(|arg| {
+        let Some(place) = operand_place(&arg.node) else {
+            return false;
+        };
+        let arg_ty = place.ty(body, tcx).ty;
+        match place_value_points_to_locs(points_to, def_id, place) {
+            Some(arg_locs)
+                if arg_locs.iter().any(|arg_loc| {
+                    loc_range_overlaps_base_locs(points_to, *arg_loc, base_locs)
+                }) =>
+            {
+                return true;
+            }
+            Some(_) => {}
+            None if arg_ty.builtin_deref(true).is_some() => return true,
+            None => {}
+        }
+
+        arg_ty.builtin_deref(true).is_none()
+            && count_slots(arg_ty, tcx, &mut FxHashSet::default()) > 0
+            && aggregate_arg_may_write_base_storage(
+                points_to, body, tcx, provenance, def_id, place, base_locs,
+            )
+    })
+}
+
+fn aggregate_arg_may_write_base_storage<'tcx>(
+    points_to: &andersen::AnalysisResult,
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    provenance: &ArrayLocalProvenance,
+    def_id: LocalDefId,
+    place: Place<'tcx>,
+    base_locs: &FxHashSet<andersen::Loc>,
+) -> bool {
+    let Some(place_path) = slot_path_from_place(place) else {
+        return true;
+    };
+    let Some(slots) = provenance.slot_table.place_slots(place, body, tcx) else {
+        return true;
+    };
+
+    for slot in slots {
+        let Some(info) = provenance.slot_table.slot_infos.get(slot) else {
+            return true;
+        };
+        let Some(relative_path) = info.path.strip_prefix(place_path.as_slice()) else {
+            return true;
+        };
+        if relative_path.contains(&SlotPathElem::Pointee) {
+            continue;
+        }
+
+        let Some(arg_locs) = slot_value_points_to_locs(points_to, def_id, info) else {
+            return true;
+        };
+        if arg_locs
+            .iter()
+            .any(|arg_loc| loc_range_overlaps_base_locs(points_to, *arg_loc, base_locs))
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn slot_path_from_place<'tcx>(place: Place<'tcx>) -> Option<Vec<SlotPathElem>> {
+    place
+        .projection
+        .iter()
+        .map(|elem| match elem {
+            ProjectionElem::Deref => Some(SlotPathElem::Pointee),
+            ProjectionElem::Field(field, _) => Some(SlotPathElem::Field(field)),
+            ProjectionElem::Index(_)
+            | ProjectionElem::ConstantIndex { .. }
+            | ProjectionElem::Subslice { .. } => Some(SlotPathElem::Element),
+            _ => None,
+        })
+        .collect()
+}
+
+fn loc_range_overlaps_base_locs(
+    points_to: &andersen::AnalysisResult,
+    arg_loc: andersen::Loc,
+    base_locs: &FxHashSet<andersen::Loc>,
+) -> bool {
+    let end = points_to.ends[arg_loc];
+    base_locs
+        .iter()
+        .any(|base_loc| arg_loc <= *base_loc && *base_loc <= end)
+}
+
+fn place_value_points_to_locs<'tcx>(
+    points_to: &andersen::AnalysisResult,
+    def_id: LocalDefId,
+    place: Place<'tcx>,
+) -> Option<FxHashSet<andersen::Loc>> {
+    let nodes = points_to_nodes_for_place(points_to, def_id, place)?;
+    let mut locs = FxHashSet::default();
+    for node in nodes {
+        locs.extend(points_to.solutions[node.index].iter());
+    }
+    Some(locs)
+}
+
+fn slot_value_points_to_locs(
+    points_to: &andersen::AnalysisResult,
+    def_id: LocalDefId,
+    info: &SlotInfo,
+) -> Option<FxHashSet<andersen::Loc>> {
+    let nodes = points_to_nodes_for_slot_path(points_to, def_id, info.root, &info.path)?;
+    let mut locs = FxHashSet::default();
+    for node in nodes {
+        locs.extend(points_to.solutions[node.index].iter());
+    }
+    Some(locs)
+}
+
+fn points_to_nodes_for_place<'tcx>(
+    points_to: &andersen::AnalysisResult,
+    def_id: LocalDefId,
+    place: Place<'tcx>,
+) -> Option<FxHashSet<andersen::LocNode>> {
+    let path = slot_path_from_place(place)?;
+    points_to_nodes_for_slot_path(points_to, def_id, place.local, &path)
+}
+
+fn points_to_nodes_for_slot_path(
+    points_to: &andersen::AnalysisResult,
+    def_id: LocalDefId,
+    root: Local,
+    path: &[SlotPathElem],
+) -> Option<FxHashSet<andersen::LocNode>> {
+    let mut nodes = FxHashSet::default();
+    nodes.insert(*points_to.var_nodes.get(&(def_id, root))?);
+
+    for elem in path {
+        let mut next_nodes = FxHashSet::default();
+        match elem {
+            SlotPathElem::Pointee => {
+                for node in &nodes {
+                    for loc in points_to.solutions[node.index].iter() {
+                        next_nodes.insert(andersen::LocNode {
+                            prefix: 0,
+                            index: loc,
+                        });
+                    }
+                }
+            }
+            SlotPathElem::Field(field) => {
+                for node in &nodes {
+                    let andersen::LocEdges::Fields(succs) = points_to.graph.get(node)? else {
+                        return None;
+                    };
+                    next_nodes.insert(*succs.get(*field)?);
+                }
+            }
+            SlotPathElem::Element => {
+                for node in &nodes {
+                    let andersen::LocEdges::Index(succ) = points_to.graph.get(node)? else {
+                        return None;
+                    };
+                    next_nodes.insert(*succ);
+                }
+            }
+        }
+        if next_nodes.is_empty() {
+            return None;
+        }
+        nodes = next_nodes;
+    }
+
+    Some(nodes)
+}
+
+fn written_place_at<'tcx>(body: &Body<'tcx>, location: Location) -> Option<Place<'tcx>> {
+    let block_data = &body.basic_blocks[location.block];
+    if let Some(statement) = block_data.statements.get(location.statement_index) {
+        if let StatementKind::Assign(box (place, _)) = &statement.kind {
+            return Some(*place);
+        }
+        return None;
+    }
+
+    if location.statement_index == block_data.statements.len()
+        && let Some(terminator) = &block_data.terminator
+        && let TerminatorKind::Call { destination, .. } = terminator.kind
+    {
+        return Some(destination);
+    }
+
+    None
+}
+
+fn direct_write_overlaps_slot<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    provenance: &ArrayLocalProvenance,
+    location: Location,
+    base_slot: SlotIdx,
+) -> bool {
+    let Some(place) = written_place_at(body, location) else {
+        return false;
+    };
+    provenance
+        .slot_table
+        .place_slots(place, body, tcx)
+        .is_some_and(|slots| slots.contains(&base_slot))
+}
+
+fn dependent_member_locals(
+    members: &[SlotIdx],
+    member_roots: &FxHashSet<Local>,
+    provenance: &ArrayLocalProvenance,
+    base_local: Local,
+) -> FxHashSet<Local> {
+    members
+        .iter()
+        .filter_map(|slot| provenance.slot_table.slot_infos.get(*slot))
+        .map(|info| info.root)
+        .filter(|local| member_roots.contains(local))
+        .filter(|local| *local != base_local)
+        .collect()
+}
+
+#[allow(dead_code)]
+fn base_slot_info<'a>(
+    provenance: &'a ArrayLocalProvenance,
+    group: &RewriteGroup,
+) -> Option<&'a SlotInfo> {
+    let slots = provenance.slot_table.local_slots(group.base_local);
+    let base_slot = slots.start.checked_add(group.base_slot_offset)?;
+    if base_slot >= slots.end {
+        return None;
+    }
+    provenance.slot_table.slot_infos.get(base_slot)
+}
+
+#[allow(dead_code)]
+pub fn debug_rewrite_groups<'tcx>(
+    groups: &[RewriteGroup],
+    body: &Body<'tcx>,
+    provenance: &ArrayLocalProvenance,
+    mutability_result: &MutabilityResult,
+    def_id: LocalDefId,
+    tcx: TyCtxt<'tcx>,
+    source_var_groups: Option<&SourceVarGroups>,
+) -> String {
+    // build a map from Local → first debug name found (direct locals only)
+    let mut local_names: FxHashMap<Local, &str> = FxHashMap::default();
+    for info in &body.var_debug_info {
+        if let mir::VarDebugInfoContents::Place(place) = &info.value
+            && let Some(local) = place.as_local()
+        {
+            local_names.entry(local).or_insert(info.name.as_str());
+        }
+    }
+
+    // build a reverse map (root, path) → slot_idx for projection-based name lookup
+    let mut slot_by_place: FxHashMap<(Local, Vec<SlotPathElem>), SlotIdx> = FxHashMap::default();
+    for (slot_idx, info) in provenance.slot_table.slot_infos.iter().enumerate() {
+        slot_by_place
+            .entry((info.root, info.path.clone()))
+            .or_insert(slot_idx);
+    }
+
+    // extend with names from projection-based var_debug_info entries
+    let mut slot_names: FxHashMap<SlotIdx, &str> = FxHashMap::default();
+    for dbg in &body.var_debug_info {
+        if let mir::VarDebugInfoContents::Place(place) = &dbg.value {
+            let path: Option<Vec<SlotPathElem>> = place
+                .projection
+                .iter()
+                .map(|elem| match elem {
+                    ProjectionElem::Deref => Some(SlotPathElem::Pointee),
+                    ProjectionElem::Field(f, _) => Some(SlotPathElem::Field(f)),
+                    _ => None,
+                })
+                .collect();
+            if let Some(path) = path
+                && let Some(&slot_idx) = slot_by_place.get(&(place.local, path))
+            {
+                slot_names.entry(slot_idx).or_insert(dbg.name.as_str());
+            }
+        }
+    }
+
+    let mut grouped_local_names: FxHashMap<Local, &str> = FxHashMap::default();
+    if let Some(source_var_groups) = source_var_groups {
+        let local_count = body.local_decls.len();
+        for target_index in 0..local_count {
+            let target = Local::from_usize(target_index);
+            let mut promoted = DenseBitSet::new_empty(local_count);
+            for index in 0..local_count {
+                if index != target_index {
+                    promoted.insert(Local::from_usize(index));
+                }
+            }
+
+            let mut promoted_by_fn = FxHashMap::default();
+            promoted_by_fn.insert(def_id, promoted);
+            let postprocessed = source_var_groups.postprocess_promoted_mut_refs(promoted_by_fn);
+            let Some(group_complete_locals) = postprocessed.get(&def_id) else {
+                continue;
+            };
+            for (&source_local, &name) in &local_names {
+                if !group_complete_locals.contains(source_local) {
+                    grouped_local_names.entry(target).or_insert(name);
+                    break;
+                }
+            }
+        }
+    }
+
+    let local_label = |local: Local| -> String {
+        match local_names.get(&local) {
+            Some(name) => format!("{local:?} \"{name}\""),
+            None => grouped_local_names
+                .get(&local)
+                .map(|name| format!("{local:?} \"{name}\""))
+                .unwrap_or_else(|| format!("{local:?}")),
+        }
+    };
+
+    let slot_label = |local: Local, slot_idx: SlotIdx| -> String {
+        if let Some(name) = slot_names.get(&slot_idx) {
+            return format!("{local:?} \"{name}\"");
+        }
+        let info = &provenance.slot_table.slot_infos[slot_idx];
+        if let Some(name) = source_var_identity_for_slot(tcx, body, &local_names, info) {
+            return format!("{local:?} \"{name}\"");
+        }
+        local_label(local)
+    };
+
+    let ptr_mut_label = |local: Local, offset: usize| -> &'static str {
+        match qualifier_at_local(mutability_result, def_id, local, offset) {
+            Some(PtrMut::Mut) => "*mut",
+            Some(PtrMut::Imm) => "*const",
+            None => "?",
+        }
+    };
+
+    let path_label = |slot_idx: SlotIdx| -> String {
+        let info = &provenance.slot_table.slot_infos[slot_idx];
+        if info.path.is_empty() {
+            return String::new();
+        }
+        let parts: Vec<String> = info
+            .path
+            .iter()
+            .map(|elem| match elem {
+                SlotPathElem::Pointee => "Pointee".to_string(),
+                SlotPathElem::Field(f) => format!("Field({})", f.index()),
+                SlotPathElem::Element => "Element".to_string(),
+            })
+            .collect();
+        format!("[{}]", parts.join(", "))
+    };
+
+    let mut out = String::new();
+    for group in groups {
+        let base_label = base_slot_info(provenance, group)
+            .and_then(|info| source_var_identity_for_slot(tcx, body, &local_names, info))
+            .map(|name| format!("{:?} \"{name}\"", group.base_local))
+            .unwrap_or_else(|| local_label(group.base_local));
+        let var_mut = if body.local_decls[group.base_local].mutability == mir::Mutability::Mut {
+            "mut"
+        } else {
+            "let"
+        };
+        let ptr_mut = ptr_mut_label(group.base_local, group.base_slot_offset);
+        let _ = writeln!(
+            out,
+            "  group base: {} [{var_mut}] offset={} ({ptr_mut}) base={:?}",
+            base_label, group.base_slot_offset, group.base,
+        );
+        for &slot_idx in &group.members {
+            let info = &provenance.slot_table.slot_infos[slot_idx];
+            let pm = match qualifier_at_slot(mutability_result, def_id, info) {
+                Some(PtrMut::Mut) => "*mut",
+                Some(PtrMut::Imm) => "*const",
+                None => "?",
+            };
+            let _ = writeln!(
+                out,
+                "    member: slot {slot_idx} → {} {} ({pm})",
+                slot_label(info.root, slot_idx),
+                path_label(slot_idx),
+            );
+        }
+    }
+    out
+}
+
+fn build_rhs_map<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> FxHashMap<Local, Vec<AssignRhs<'tcx>>> {
+    let mut map: FxHashMap<Local, Vec<AssignRhs<'tcx>>> = FxHashMap::default();
+    for block_data in body.basic_blocks.iter() {
+        for statement in &block_data.statements {
+            let StatementKind::Assign(box (lhs, rvalue)) = &statement.kind else {
+                continue;
+            };
+            let Some(local) = lhs.as_local() else { continue };
+            match rvalue {
+                Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) => {
+                    map.entry(local)
+                        .or_default()
+                        .push(AssignRhs::ArrayBorrow(*place));
+                }
+                Rvalue::Use(Operand::Copy(place) | Operand::Move(place))
+                | Rvalue::Cast(_, Operand::Copy(place) | Operand::Move(place), _)
+                | Rvalue::CopyForDeref(place) => {
+                    map.entry(local)
+                        .or_default()
+                        .push(AssignRhs::Follow(place.local));
+                }
+                _ => {}
+            }
+        }
+
+        // for pointer-arithmetic and as_ptr/as_mut_ptr call terminators, record the
+        // first argument as a Follow entry so that array_source_for_local can trace
+        // back through chains like:  _tmp3 = offset(_tmp2, i)
+        //                            _tmp2 = as_mut_ptr(move _tmp1)
+        //                            _tmp1 = &mut (*arr).data   ← ArrayBorrow already recorded
+        let Some(terminator) = &block_data.terminator else { continue };
+        let TerminatorKind::Call {
+            func,
+            args,
+            destination,
+            ..
+        } = &terminator.kind
+        else {
+            continue;
+        };
+        let Some(dest_local) = destination.as_local() else {
+            continue;
+        };
+        if let Some((_, name)) = call_name(tcx, func)
+            && (is_pointer_arithmetic(&name) || is_as_ptr(&name))
+            && let Some(arg) = args.first()
+            && let Some(place) = operand_place(&arg.node)
+        {
+            map.entry(dest_local)
+                .or_default()
+                .push(AssignRhs::Follow(place.local));
+        }
+    }
+    map
+}
+
+impl SlotTable {
+    fn new<'tcx>(body: &Body<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
+        let mut local_slots = Vec::with_capacity(body.local_decls.len());
+        let mut slot_infos = vec![];
+
+        for (local, decl) in body.local_decls.iter_enumerated() {
+            let start = slot_infos.len();
+            collect_slot_infos(
+                local,
+                decl.ty,
+                tcx,
+                &mut vec![],
+                0,
+                &mut QualifierContext::Local { next_offset: 0 },
+                &mut FxHashSet::default(),
+                &mut slot_infos,
+            );
+            let end = slot_infos.len();
+            local_slots.push(start..end);
+        }
+
+        Self {
+            local_slots,
+            slot_infos,
+        }
+    }
+
+    fn local_slots(&self, local: Local) -> Range<SlotIdx> {
+        self.local_slots[local.index()].clone()
+    }
+
+    fn local_head_slot(&self, local: Local) -> Option<SlotIdx> {
+        self.local_slots(local).next()
+    }
+
+    fn place_slots<'tcx>(
+        &self,
+        place: Place<'tcx>,
+        body: &Body<'tcx>,
+        tcx: TyCtxt<'tcx>,
+    ) -> Option<Range<SlotIdx>> {
+        let mut offset = 0;
+        let mut base_ty = body.local_decls[place.local].ty;
+
+        for elem in place.projection {
+            match elem {
+                ProjectionElem::Deref => {
+                    base_ty = base_ty.builtin_deref(true)?;
+                    offset += 1;
+                }
+                ProjectionElem::Field(field, ty) => {
+                    offset += field_slot_offset(base_ty, field, tcx)?;
+                    base_ty = ty;
+                }
+                ProjectionElem::Index(_) | ProjectionElem::ConstantIndex { .. } => {
+                    base_ty = base_ty.builtin_index()?;
+                }
+                _ => return None,
+            }
+        }
+
+        let local_slots = self.local_slots(place.local);
+        let width = count_slots(base_ty, tcx, &mut FxHashSet::default());
+        let start = local_slots.start + offset;
+        let end = start + width;
+        if end <= local_slots.end {
+            Some(start..end)
+        } else {
+            None
+        }
+    }
+
+    fn place_head_slot<'tcx>(
+        &self,
+        place: Place<'tcx>,
+        body: &Body<'tcx>,
+        tcx: TyCtxt<'tcx>,
+    ) -> Option<SlotIdx> {
+        if !place.ty(body, tcx).ty.is_raw_ptr() {
+            return None;
+        }
+
+        self.place_slots(place, body, tcx)?.next()
+    }
+}
+
+struct Collector<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    body: &'a Body<'tcx>,
+    alloc_fns: &'a FxHashSet<LocalDefId>,
+    slot_table: &'a SlotTable,
+    graph: PointerFlowGraph,
+    rhs_map: FxHashMap<Local, Vec<AssignRhs<'tcx>>>,
+    direct_param_slots: FxHashSet<SlotIdx>,
+}
+
+impl<'tcx> Collector<'_, 'tcx> {
+    fn collect(&mut self) {
+        for arg in self.body.args_iter() {
+            for slot in self.slot_table.local_slots(arg) {
+                self.direct_param_slots.insert(slot);
+                self.graph
+                    .add_base_edge(BaseId::Param { local: arg, slot }, PfgNode::Slot(slot));
+            }
+        }
+
+        for (block, block_data) in self.body.basic_blocks.iter_enumerated() {
+            for (statement_index, statement) in block_data.statements.iter().enumerate() {
+                let location = Location {
+                    block,
+                    statement_index,
+                };
+                self.collect_statement(statement, location);
+            }
+            let location = Location {
+                block,
+                statement_index: block_data.statements.len(),
+            };
+            self.collect_terminator(block, location);
+        }
+    }
+
+    fn collect_statement(&mut self, statement: &mir::Statement<'tcx>, location: Location) {
+        let StatementKind::Assign(box (lhs, rvalue)) = &statement.kind else {
+            return;
+        };
+        // iterate all pointer slots in the destination via place_slots; no longer
+        // restricted to destinations whose top-level type is itself a raw pointer
+        let Some(dst_slots) = self.slot_table.place_slots(*lhs, self.body, self.tcx) else {
+            return;
+        };
+        if dst_slots.is_empty() {
+            return;
+        }
+        let dst = PfgNode::Slot(dst_slots.start);
+
+        match rvalue {
+            Rvalue::Use(operand) => {
+                // slot pairing: head slot (i=0) gets a unidirectional add_edge;
+                // tail slots (i>0) get add_bidirectional_edge so that pointer
+                // fields nested inside the source/destination stay linked in
+                // both directions (copy does not establish ownership).
+                match operand {
+                    Operand::Copy(src_place) | Operand::Move(src_place) => {
+                        if let Some(src_slots) =
+                            self.slot_table.place_slots(*src_place, self.body, self.tcx)
+                        {
+                            for (i, (src_slot, dst_slot)) in
+                                src_slots.zip(dst_slots.clone()).enumerate()
+                            {
+                                let src_node = PfgNode::Slot(src_slot);
+                                let dst_node = PfgNode::Slot(dst_slot);
+                                if i == 0 {
+                                    self.graph.add_edge(src_node, dst_node);
+                                } else {
+                                    // propagate direct-param status across bidirectional copy
+                                    // edges so that UML suppression in add_unknown_pointee_slots
+                                    // also covers slots of param copies
+                                    if self.direct_param_slots.contains(&src_slot) {
+                                        self.direct_param_slots.insert(dst_slot);
+                                    } else if self.direct_param_slots.contains(&dst_slot) {
+                                        self.direct_param_slots.insert(src_slot);
+                                    }
+                                    self.graph.add_bidirectional_edge(src_node, dst_node);
+                                }
+                            }
+                        } else {
+                            self.graph.add_base_edge(
+                                BaseId::Unknown {
+                                    location,
+                                    reason: UnknownReason::UnsupportedProjection,
+                                },
+                                dst,
+                            );
+                        }
+                    }
+                    Operand::Constant(_) => {
+                        self.collect_operand_flow(operand, dst, location);
+                    }
+                }
+            }
+            Rvalue::CopyForDeref(place) => {
+                // when the source can be resolved, collect_place_flow links tail
+                // slots via link_tail_slots (bidirectional); only when it cannot be
+                // resolved does slot[0] get Unknown and tail slots need it too.
+                if self.source_node(*place).is_none() {
+                    for slot in dst_slots.clone().skip(1) {
+                        self.graph.add_base_edge(
+                            BaseId::Unknown {
+                                location,
+                                reason: UnknownReason::UnsupportedProjection,
+                            },
+                            PfgNode::Slot(slot),
+                        );
+                    }
+                }
+                self.collect_place_flow(*place, dst, true, location);
+            }
+            Rvalue::Cast(kind, operand, _) => {
+                self.collect_cast(*kind, operand, dst, location);
+                // collect_cast only models slot[0]; emit Unknown conservatively for
+                // any nested pointer slots in the destination (e.g. *mut *mut T)
+                for slot in dst_slots.clone().skip(1) {
+                    self.graph.add_base_edge(
+                        BaseId::Unknown {
+                            location,
+                            reason: UnknownReason::UnsupportedProjection,
+                        },
+                        PfgNode::Slot(slot),
+                    );
+                }
+            }
+            Rvalue::RawPtr(_, place) => {
+                self.collect_raw_borrow_flow(*lhs, *place, dst.clone(), &dst_slots, location);
+            }
+            Rvalue::Ref(_, _, place) => {
+                self.collect_raw_borrow_flow(*lhs, *place, dst.clone(), &dst_slots, location);
+            }
+            _ => {
+                // only emit a conservative Unknown edge when the rvalue is itself
+                // a raw-pointer value we do not specifically handle.  Non-pointer
+                // rvalues (e.g. Aggregate/Repeat used to initialise structs or
+                // arrays that contain pointer fields) must not pollute those slots.
+                if rvalue.ty(self.body, self.tcx).is_raw_ptr() {
+                    self.graph.add_base_edge(
+                        BaseId::Unknown {
+                            location,
+                            reason: UnknownReason::UnsupportedProjection,
+                        },
+                        dst,
+                    );
+                }
+            }
+        }
+    }
+
+    fn collect_terminator(&mut self, block: BasicBlock, location: Location) {
+        let terminator = self.body.basic_blocks[block].terminator();
+        let TerminatorKind::Call {
+            func,
+            args,
+            destination,
+            ..
+        } = &terminator.kind
+        else {
+            return;
+        };
+
+        let call = call_name(self.tcx, func);
+
+        if !call
+            .as_ref()
+            .is_some_and(|(def_id, name)| call_no_writes(self.tcx, *def_id, name))
+        {
+            // a *mut *mut T argument lets the callee overwrite the pointed-to
+            // pointer through the double-pointer, changing its base in the caller
+            for arg in args.iter() {
+                if let Some(place) = operand_place(&arg.node) {
+                    let arg_ty = place.ty(self.body, self.tcx).ty;
+                    if let Some(inner) = arg_ty.builtin_deref(true)
+                        && count_slots(inner, self.tcx, &mut FxHashSet::default()) > 0
+                    {
+                        self.add_unknown_pointee_slots(place, location);
+                    }
+                }
+            }
+        }
+
+        if let Some((def_id, name)) = call {
+            if is_pointer_arithmetic(&name) {
+                let Some(dst) = self.destination_node(*destination, location) else {
+                    return;
+                };
+                if let Some(arg) = args.first() {
+                    self.collect_operand_head_flow(&arg.node, dst, location);
+                } else {
+                    self.graph.add_base_edge(
+                        BaseId::Unknown {
+                            location,
+                            reason: UnknownReason::UnsupportedCall,
+                        },
+                        dst,
+                    );
+                }
+                return;
+            }
+
+            if call_propagates_first_arg(self.tcx, def_id, &name, args, *destination, self.body) {
+                let Some(dst) = self.destination_node(*destination, location) else {
+                    return;
+                };
+                if let Some(arg) = args.first() {
+                    self.collect_operand_head_flow(&arg.node, dst, location);
+                } else {
+                    self.graph.add_base_edge(
+                        BaseId::Unknown {
+                            location,
+                            reason: UnknownReason::UnsupportedCall,
+                        },
+                        dst,
+                    );
+                }
+                return;
+            }
+
+            if is_as_ptr(&name)
+                && let Some(arg) = args.first()
+                && let Some(place) = operand_place(&arg.node)
+            {
+                if let Some(dst) = self.destination_node(*destination, location) {
+                    if let Some(base) = self.local_array_base_from_place(place, location) {
+                        self.graph.add_base_edge(base, dst);
+                    } else if self.source_node(place).is_some() {
+                        self.collect_place_flow(place, dst, false, location);
+                    } else {
+                        let base = self.base_for_raw_borrow(place, location);
+                        self.graph.add_base_edge(base, dst);
+                    }
+                }
+                return;
+            }
+
+            if is_heap_alloc_call(self.tcx, def_id, &name, self.alloc_fns) {
+                let Some(dst) = self.destination_node(*destination, location) else {
+                    return;
+                };
+                let return_node = PfgNode::CallReturn(location);
+                self.graph
+                    .add_base_edge(BaseId::HeapAlloc { location }, return_node.clone());
+                self.graph.add_edge(return_node, dst.clone());
+                self.add_unknown_pointee_slots(*destination, location);
+                return;
+            }
+
+            if is_null_ptr_call(self.tcx, def_id, &name) {
+                if let Some(dst) = self.destination_node(*destination, location) {
+                    self.graph.add_base_edge(
+                        BaseId::Unknown {
+                            location,
+                            reason: UnknownReason::NullLike,
+                        },
+                        dst,
+                    );
+                }
+                return;
+            }
+        }
+
+        // generic: one CallReturn node with an add_edge to every slot in the destination range
+        let return_node = PfgNode::CallReturn(location);
+        self.graph
+            .add_base_edge(BaseId::OpaqueReturn { location }, return_node.clone());
+        if let Some(slots) = self
+            .slot_table
+            .place_slots(*destination, self.body, self.tcx)
+        {
+            for slot in slots {
+                self.graph
+                    .add_edge(return_node.clone(), PfgNode::Slot(slot));
+            }
+        }
+        self.add_unknown_pointee_slots(*destination, location);
+    }
+
+    fn collect_cast(
+        &mut self,
+        kind: CastKind,
+        operand: &Operand<'tcx>,
+        dst: PfgNode,
+        location: Location,
+    ) {
+        match kind {
+            CastKind::PointerWithExposedProvenance => {
+                // `0 as *mut T` is a null pointer sentinel — treat as NullLike so that
+                // variables null-initialized via integer cast can participate in groups.
+                if is_zero_int_operand(operand, self.tcx) {
+                    self.graph.add_base_edge(
+                        BaseId::Unknown {
+                            location,
+                            reason: UnknownReason::NullLike,
+                        },
+                        dst,
+                    );
+                } else {
+                    let cast_node = PfgNode::CastResult(location);
+                    self.graph
+                        .add_base_edge(BaseId::IntToPtr { location }, cast_node.clone());
+                    self.graph.add_edge(cast_node, dst);
+                }
+            }
+            CastKind::PointerCoercion(ty::adjustment::PointerCoercion::ArrayToPointer, _) => {
+                if let Some(place) = operand_place(operand)
+                    && let Some(base) = self.local_array_base_from_place(place, location)
+                {
+                    let cast_node = PfgNode::CastResult(location);
+                    self.graph.add_base_edge(base, cast_node.clone());
+                    self.graph.add_edge(cast_node, dst);
+                } else {
+                    self.graph.add_base_edge(
+                        BaseId::Unknown {
+                            location,
+                            reason: UnknownReason::UnsupportedProjection,
+                        },
+                        dst,
+                    );
+                }
+            }
+            CastKind::PtrToPtr
+            | CastKind::PointerCoercion(ty::adjustment::PointerCoercion::MutToConstPointer, _)
+            | CastKind::PointerCoercion(ty::adjustment::PointerCoercion::Unsize, _) => {
+                self.collect_operand_head_flow(operand, dst, location);
+            }
+            _ => {
+                if operand.constant().is_some() {
+                    self.graph.add_base_edge(
+                        BaseId::Unknown {
+                            location,
+                            reason: UnknownReason::ConstantPointer,
+                        },
+                        dst,
+                    );
+                } else {
+                    self.collect_operand_head_flow(operand, dst, location);
+                }
+            }
+        }
+    }
+
+    fn collect_operand_flow(&mut self, operand: &Operand<'tcx>, dst: PfgNode, location: Location) {
+        match operand {
+            Operand::Copy(place) | Operand::Move(place) => {
+                self.collect_place_flow(*place, dst, true, location);
+            }
+            Operand::Constant(_) => {
+                if is_empty_array_ref_ty(operand.ty(self.body, self.tcx), self.tcx) {
+                    return;
+                }
+                self.graph.add_base_edge(
+                    BaseId::Unknown {
+                        location,
+                        reason: UnknownReason::NullLike,
+                    },
+                    dst,
+                );
+            }
+        }
+    }
+
+    fn collect_operand_head_flow(
+        &mut self,
+        operand: &Operand<'tcx>,
+        dst: PfgNode,
+        location: Location,
+    ) {
+        match operand {
+            Operand::Copy(place) | Operand::Move(place) => {
+                self.collect_place_flow(*place, dst, false, location);
+            }
+            Operand::Constant(_) => {
+                if is_empty_array_ref_ty(operand.ty(self.body, self.tcx), self.tcx) {
+                    return;
+                }
+                self.graph.add_base_edge(
+                    BaseId::Unknown {
+                        location,
+                        reason: UnknownReason::NullLike,
+                    },
+                    dst,
+                );
+            }
+        }
+    }
+
+    fn collect_place_flow(
+        &mut self,
+        place: Place<'tcx>,
+        dst: PfgNode,
+        link_tail_slots: bool,
+        location: Location,
+    ) {
+        if let Some(src) = self.source_node(place) {
+            self.graph.add_edge(src.clone(), dst.clone());
+            if link_tail_slots {
+                self.link_tail_slots(place, dst);
+            }
+        } else {
+            self.graph.add_base_edge(
+                BaseId::Unknown {
+                    location,
+                    reason: UnknownReason::UnsupportedProjection,
+                },
+                dst,
+            );
+        }
+    }
+
+    /// Range-based helper for source places.
+    ///
+    /// Returns the full `Range<SlotIdx>` covering all pointer slots in `place`.
+    /// Returns `None` when the projection is unsupported or the place has no
+    /// pointer slots (i.e. the slot range would be empty).
+    fn source_slots(&self, place: Place<'tcx>) -> Option<Range<SlotIdx>> {
+        let slots = self.slot_table.place_slots(place, self.body, self.tcx)?;
+        if slots.is_empty() { None } else { Some(slots) }
+    }
+
+    /// Range-based helper for destination places.
+    ///
+    /// Returns the full `Range<SlotIdx>` covering all pointer slots in `place`.
+    /// Returns `None` when the projection is unsupported or the place has no
+    /// pointer slots (i.e. the slot range would be empty).
+    fn destination_slots(&self, place: Place<'tcx>) -> Option<Range<SlotIdx>> {
+        let slots = self.slot_table.place_slots(place, self.body, self.tcx)?;
+        if slots.is_empty() { None } else { Some(slots) }
+    }
+
+    /// Returns the head `PfgNode` for `place` by looking up the first slot via
+    /// `source_slots`.  Unlike `place_head_slot`, this is not restricted to
+    /// places whose top-level type is a raw pointer: it works for any place
+    /// whose slot range is non-empty (e.g. a struct that contains pointer fields).
+    fn source_node(&self, place: Place<'tcx>) -> Option<PfgNode> {
+        self.source_slots(place)?.next().map(PfgNode::Slot)
+    }
+
+    /// Returns the head `PfgNode` (first slot in the slot range) for `place`
+    /// by delegating to `destination_slots`.
+    /// When the slot range is empty or the projection is unsupported,
+    /// inserts an `Unknown` base into the graph and returns `None`.
+    fn destination_node(&mut self, place: Place<'tcx>, location: Location) -> Option<PfgNode> {
+        if let Some(mut slots) = self.destination_slots(place) {
+            slots.next().map(PfgNode::Slot)
+        } else {
+            self.graph.add_base(BaseId::Unknown {
+                location,
+                reason: UnknownReason::UnsupportedProjection,
+            });
+            None
+        }
+    }
+
+    fn add_unknown_pointee_slots(&mut self, place: Place<'tcx>, location: Location) {
+        let Some(slots) = self.slot_table.place_slots(place, self.body, self.tcx) else {
+            return;
+        };
+        // Only mark true pointee slots (depth > 0) as unknown; sibling field
+        // slots in a struct destination (depth = 0) are NOT pointees and must
+        // not be polluted here — their provenance comes from the call itself.
+        for slot in slots.skip(1) {
+            if self.slot_table.slot_infos[slot].depth == 0 {
+                continue;
+            }
+            if self.direct_param_slots.contains(&slot) {
+                continue;
+            }
+            self.graph.add_base_edge(
+                BaseId::Unknown {
+                    location,
+                    reason: UnknownReason::UnsupportedMemoryLoad,
+                },
+                PfgNode::Slot(slot),
+            );
+        }
+    }
+
+    fn collect_address_links(
+        &mut self,
+        destination: Place<'tcx>,
+        borrowed: Place<'tcx>,
+        _location: Location,
+    ) {
+        let Some(borrowed_slots) = self.slot_table.place_slots(borrowed, self.body, self.tcx)
+        else {
+            return;
+        };
+        let Some(pointee_slots) = self
+            .slot_table
+            .place_slots(destination, self.body, self.tcx)
+            .map(|slots| slots.start + 1..slots.end)
+        else {
+            return;
+        };
+
+        for (borrowed_slot, pointee_slot) in borrowed_slots.zip(pointee_slots) {
+            self.graph
+                .add_bidirectional_edge(PfgNode::Slot(borrowed_slot), PfgNode::Slot(pointee_slot));
+        }
+    }
+
+    /// Shared implementation for `Rvalue::Ref` and `Rvalue::RawPtr`.
+    ///
+    /// When the borrowed place is a simple `*local_ptr` (deref of a raw pointer),
+    /// propagate provenance from `local_ptr`'s slot rather than minting a fresh
+    /// `RawBorrow` base.  This lets bases established by pointer-arithmetic call
+    /// handlers (`is_pointer_arithmetic`, `is_as_ptr`) flow through re-borrow
+    /// patterns like `&mut *offset_result as *mut T`.
+    fn collect_raw_borrow_flow(
+        &mut self,
+        lhs: Place<'tcx>,
+        place: Place<'tcx>,
+        dst: PfgNode,
+        dst_slots: &std::ops::Range<SlotIdx>,
+        location: Location,
+    ) {
+        // for `*local_ptr` (raw pointer or reference), inherit its existing
+        // provenance instead of minting a fresh RawBorrow base.  The reborrow
+        // pattern `&mut *(_5: *mut T)` gives `_4: &mut T`, and `&raw mut *(_4:
+        // &mut T)` gives `_3: *mut T`.  Both steps must propagate through.
+        let propagated = if let [ProjectionElem::Deref] = place.projection.as_ref()
+            && (self.local_ty(place.local).is_raw_ptr() || self.local_ty(place.local).is_ref())
+            && let Some(slot) = self.slot_table.local_head_slot(place.local)
+        {
+            self.graph.add_edge(PfgNode::Slot(slot), dst.clone());
+            true
+        } else {
+            false
+        };
+
+        if !propagated {
+            let base = self.base_for_raw_borrow(place, location);
+            self.graph.add_base_edge(base, dst.clone());
+        }
+
+        self.collect_address_links(lhs, place, location);
+
+        if self
+            .slot_table
+            .place_slots(place, self.body, self.tcx)
+            .is_none()
+        {
+            for slot in dst_slots.clone().skip(1) {
+                self.graph.add_base_edge(
+                    BaseId::Unknown {
+                        location,
+                        reason: UnknownReason::UnsupportedProjection,
+                    },
+                    PfgNode::Slot(slot),
+                );
+            }
+        }
+    }
+
+    fn link_tail_slots(&mut self, src: Place<'tcx>, dst_head: PfgNode) {
+        let Some(dst_slot) = dst_head.as_slot() else {
+            return;
+        };
+        let Some(src_slots) = self.slot_table.place_slots(src, self.body, self.tcx) else {
+            return;
+        };
+        let dst_slots = dst_slot..dst_slot + src_slots.len();
+
+        for (src_slot, dst_slot) in src_slots.skip(1).zip(dst_slots.skip(1)) {
+            // propagate direct-param status across copy edges so that UML suppression
+            // in add_unknown_pointee_slots also covers slots of param copies
+            if self.direct_param_slots.contains(&src_slot) {
+                self.direct_param_slots.insert(dst_slot);
+            } else if self.direct_param_slots.contains(&dst_slot) {
+                self.direct_param_slots.insert(src_slot);
+            }
+            self.graph
+                .add_bidirectional_edge(PfgNode::Slot(src_slot), PfgNode::Slot(dst_slot));
+        }
+    }
+
+    fn base_for_raw_borrow(&self, place: Place<'tcx>, location: Location) -> BaseId {
+        if let Some(base) = self.local_array_base_from_place(place, location) {
+            return base;
+        }
+
+        if place.projection.is_empty() && !self.local_ty(place.local).is_raw_ptr() {
+            return BaseId::LocalScalar { local: place.local };
+        }
+
+        BaseId::RawBorrow {
+            target: self.slot_table.place_head_slot(place, self.body, self.tcx),
+            location,
+        }
+    }
+
+    fn local_array_base_from_place(
+        &self,
+        place: Place<'tcx>,
+        _location: Location,
+    ) -> Option<BaseId> {
+        if place.projection.iter().any(is_array_projection) {
+            return Some(BaseId::LocalArray { local: place.local });
+        }
+
+        self.array_source_for_local(place.local, &mut FxHashSet::default())
+            .map(|local| BaseId::LocalArray { local })
+    }
+
+    fn array_source_for_local(
+        &self,
+        local: Local,
+        visited: &mut FxHashSet<Local>,
+    ) -> Option<Local> {
+        if !visited.insert(local) {
+            return None;
+        }
+
+        if matches!(self.local_ty(local).kind(), ty::TyKind::Array(..)) {
+            return Some(local);
+        }
+
+        for rhs in self.rhs_map.get(&local).into_iter().flatten() {
+            match rhs {
+                AssignRhs::ArrayBorrow(place) => {
+                    if matches!(self.local_ty(place.local).kind(), ty::TyKind::Array(..))
+                        || place.projection.iter().any(is_array_projection)
+                        || matches!(
+                            place.ty(self.body, self.tcx).ty.kind(),
+                            ty::TyKind::Array(..)
+                        )
+                    {
+                        return Some(place.local);
+                    }
+                }
+                AssignRhs::Follow(src_local) => {
+                    if let Some(array_local) = self.array_source_for_local(*src_local, visited) {
+                        return Some(array_local);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    fn local_ty(&self, local: Local) -> Ty<'tcx> {
+        self.body.local_decls[local].ty
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_slot_infos<'tcx>(
+    root: Local,
+    ty: Ty<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    path: &mut Vec<SlotPathElem>,
+    depth: usize,
+    qualifier_context: &mut QualifierContext,
+    seen_adts: &mut FxHashSet<DefId>,
+    out: &mut Vec<SlotInfo>,
+) {
+    if let Some(inner_ty) = ty.builtin_deref(true) {
+        let qualifier_key = qualifier_context.next_key();
+        out.push(SlotInfo {
+            root,
+            path: path.clone(),
+            depth,
+            qualifier_key,
+        });
+        path.push(SlotPathElem::Pointee);
+        collect_slot_infos(
+            root,
+            inner_ty,
+            tcx,
+            path,
+            depth + 1,
+            qualifier_context,
+            seen_adts,
+            out,
+        );
+        path.pop();
+        return;
+    }
+
+    if let Some(inner_ty) = ty.builtin_index() {
+        path.push(SlotPathElem::Element);
+        collect_slot_infos(
+            root,
+            inner_ty,
+            tcx,
+            path,
+            depth,
+            qualifier_context,
+            seen_adts,
+            out,
+        );
+        path.pop();
+        return;
+    }
+
+    match ty.kind() {
+        ty::TyKind::Adt(adt_def, substs) if adt_def.is_struct() && !adt_def.is_union() => {
+            let def_id = adt_def.did();
+            if !seen_adts.insert(def_id) {
+                return;
+            }
+            for (idx, field) in adt_def.all_fields().enumerate() {
+                let mut field_qualifier_context =
+                    match def_id
+                        .as_local()
+                        .map(|local_def_id| QualifierContext::StructField {
+                            def_id: local_def_id,
+                            field: FieldIdx::from_usize(idx),
+                            next_offset: 0,
+                        }) {
+                        Some(context) => context,
+                        None => QualifierContext::None,
+                    };
+                path.push(SlotPathElem::Field(FieldIdx::from_usize(idx)));
+                collect_slot_infos(
+                    root,
+                    field.ty(tcx, substs),
+                    tcx,
+                    path,
+                    depth,
+                    &mut field_qualifier_context,
+                    seen_adts,
+                    out,
+                );
+                path.pop();
+            }
+            seen_adts.remove(&def_id);
+        }
+        ty::TyKind::Tuple(tys) => {
+            for (idx, field_ty) in tys.iter().enumerate() {
+                path.push(SlotPathElem::Field(FieldIdx::from_usize(idx)));
+                collect_slot_infos(
+                    root,
+                    field_ty,
+                    tcx,
+                    path,
+                    depth,
+                    qualifier_context,
+                    seen_adts,
+                    out,
+                );
+                path.pop();
+            }
+        }
+        _ => {}
+    }
+}
+
+#[derive(Clone, Debug)]
+enum QualifierContext {
+    Local {
+        next_offset: usize,
+    },
+    StructField {
+        def_id: LocalDefId,
+        field: FieldIdx,
+        next_offset: usize,
+    },
+    None,
+}
+
+impl QualifierContext {
+    fn next_key(&mut self) -> Option<QualifierKey> {
+        match self {
+            QualifierContext::Local { next_offset } => {
+                let offset = *next_offset;
+                *next_offset += 1;
+                Some(QualifierKey::Local { offset })
+            }
+            QualifierContext::StructField {
+                def_id,
+                field,
+                next_offset,
+            } => {
+                let offset = *next_offset;
+                *next_offset += 1;
+                Some(QualifierKey::StructField {
+                    def_id: *def_id,
+                    field: *field,
+                    offset,
+                })
+            }
+            QualifierContext::None => None,
+        }
+    }
+}
+
+fn count_slots<'tcx>(ty: Ty<'tcx>, tcx: TyCtxt<'tcx>, seen_adts: &mut FxHashSet<DefId>) -> usize {
+    if let Some(inner_ty) = ty.builtin_deref(true) {
+        return 1 + count_slots(inner_ty, tcx, seen_adts);
+    }
+
+    if let Some(inner_ty) = ty.builtin_index() {
+        return count_slots(inner_ty, tcx, seen_adts);
+    }
+
+    match ty.kind() {
+        ty::TyKind::Adt(adt_def, substs) if adt_def.is_struct() && !adt_def.is_union() => {
+            let def_id = adt_def.did();
+            if !seen_adts.insert(def_id) {
+                return 0;
+            }
+            let count = adt_def
+                .all_fields()
+                .map(|field| count_slots(field.ty(tcx, substs), tcx, seen_adts))
+                .sum();
+            seen_adts.remove(&def_id);
+            count
+        }
+        ty::TyKind::Tuple(tys) => tys
+            .iter()
+            .map(|field_ty| count_slots(field_ty, tcx, seen_adts))
+            .sum(),
+        _ => 0,
+    }
+}
+
+fn field_slot_offset<'tcx>(base_ty: Ty<'tcx>, field: FieldIdx, tcx: TyCtxt<'tcx>) -> Option<usize> {
+    match base_ty.kind() {
+        ty::TyKind::Adt(adt_def, substs) if adt_def.is_struct() && !adt_def.is_union() => {
+            let mut offset = 0;
+            let mut seen = FxHashSet::default();
+            for field_def in adt_def.all_fields().take(field.index()) {
+                seen.clear();
+                offset += count_slots(field_def.ty(tcx, substs), tcx, &mut seen);
+            }
+            Some(offset)
+        }
+        ty::TyKind::Tuple(tys) => {
+            let mut seen = FxHashSet::default();
+            Some(
+                tys.iter()
+                    .take(field.index())
+                    .map(|field_ty| {
+                        seen.clear();
+                        count_slots(field_ty, tcx, &mut seen)
+                    })
+                    .sum(),
+            )
+        }
+        _ => None,
+    }
+}
+
+fn is_array_projection(elem: ProjectionElem<Local, Ty<'_>>) -> bool {
+    matches!(
+        elem,
+        ProjectionElem::Index(_)
+            | ProjectionElem::ConstantIndex { .. }
+            | ProjectionElem::Subslice { .. }
+    )
+}
+
+fn operand_place<'tcx>(operand: &Operand<'tcx>) -> Option<Place<'tcx>> {
+    match operand {
+        Operand::Copy(place) | Operand::Move(place) => Some(*place),
+        Operand::Constant(_) => None,
+    }
+}
+
+fn call_name(tcx: TyCtxt<'_>, func: &Operand<'_>) -> Option<(DefId, String)> {
+    let constant = func.constant()?;
+    let ty = constant.ty();
+    let ty::TyKind::FnDef(def_id, _) = ty.kind() else {
+        return None;
+    };
+    Some((*def_id, tcx.def_path_str(*def_id)))
+}
+
+fn is_pointer_arithmetic(name: &str) -> bool {
+    matches!(
+        name.rsplit("::").next(),
+        Some(
+            "offset"
+                | "wrapping_offset"
+                | "byte_offset"
+                | "wrapping_byte_offset"
+                | "add"
+                | "wrapping_add"
+                | "sub"
+                | "wrapping_sub"
+        )
+    )
+}
+
+fn is_as_ptr(name: &str) -> bool {
+    matches!(name.rsplit("::").next(), Some("as_ptr" | "as_mut_ptr"))
+}
+
+fn call_no_writes(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
+    let crate_name = tcx.crate_name(def_id.krate);
+    matches!(crate_name.as_str(), "core" | "std")
+        && name.contains("::ptr::")
+        && matches!(name.rsplit("::").next(), Some("is_null"))
+}
+
+/// Returns `true` for `core::ptr::null()` / `core::ptr::null_mut()` and
+/// the inherent `<*mut T>::null()` / `<*const T>::null()` methods, which
+/// always produce a null (zero) pointer and carry no real provenance.
+fn is_null_ptr_call(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
+    let crate_name = tcx.crate_name(def_id.krate);
+    matches!(crate_name.as_str(), "core" | "std")
+        && matches!(name.rsplit("::").next(), Some("null" | "null_mut"))
+}
+
+/// Returns true when `operand` is the integer constant zero, i.e. `0 as *mut T`.
+/// Used to classify `PointerWithExposedProvenance` casts of zero as NullLike.
+fn is_zero_int_operand<'tcx>(operand: &Operand<'tcx>, _tcx: TyCtxt<'tcx>) -> bool {
+    let Some(const_op) = operand.constant() else {
+        return false;
+    };
+    let Some(scalar) = const_op.const_.try_to_scalar() else {
+        return false;
+    };
+    let Ok(int_val) = scalar.try_to_scalar_int() else {
+        return false;
+    };
+    int_val.to_bits(int_val.size()) == 0
+}
+
+fn call_propagates_first_arg<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+    name: &str,
+    args: &[Spanned<Operand<'tcx>>],
+    destination: Place<'tcx>,
+    body: &Body<'tcx>,
+) -> bool {
+    is_memchr_call(tcx, def_id, name, args, destination, body)
+        || is_from_raw_parts_mut_call(tcx, def_id, name, args, destination, body)
+        || is_slice_index_mut_call(tcx, def_id, name, args, destination, body)
+}
+
+fn is_memchr_call<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+    name: &str,
+    args: &[Spanned<Operand<'tcx>>],
+    destination: Place<'tcx>,
+    body: &Body<'tcx>,
+) -> bool {
+    matches!(name.rsplit("::").next(), Some("memchr"))
+        && tcx.is_foreign_item(def_id)
+        && args.len() == 3
+        && args
+            .first()
+            .is_some_and(|arg| arg.node.ty(body, tcx).is_raw_ptr())
+        && destination.ty(body, tcx).ty.is_raw_ptr()
+}
+
+fn is_from_raw_parts_mut_call<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+    name: &str,
+    args: &[Spanned<Operand<'tcx>>],
+    destination: Place<'tcx>,
+    body: &Body<'tcx>,
+) -> bool {
+    matches!(name.rsplit("::").next(), Some("from_raw_parts_mut"))
+        && is_core_or_std_from_raw_parts_mut_path(tcx, def_id, name)
+        && args
+            .first()
+            .is_some_and(|arg| arg.node.ty(body, tcx).is_raw_ptr())
+        && is_mut_slice_ref_ty(destination.ty(body, tcx).ty)
+}
+
+fn is_slice_index_mut_call<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+    name: &str,
+    args: &[Spanned<Operand<'tcx>>],
+    destination: Place<'tcx>,
+    body: &Body<'tcx>,
+) -> bool {
+    matches!(name.rsplit("::").next(), Some("index_mut"))
+        && is_core_or_std_slice_index_mut_path(tcx, def_id, name)
+        && args
+            .first()
+            .and_then(|arg| operand_place(&arg.node))
+            .is_some_and(|place| is_mut_slice_ref_ty(place.ty(body, tcx).ty))
+        && is_mut_slice_ref_ty(destination.ty(body, tcx).ty)
+}
+
+fn is_core_or_std_from_raw_parts_mut_path(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
+    let crate_name = tcx.crate_name(def_id.krate);
+    matches!(crate_name.as_str(), "core" | "std")
+        && name.contains("::slice::")
+        && name.ends_with("::from_raw_parts_mut")
+}
+
+fn is_core_or_std_slice_index_mut_path(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
+    let crate_name = tcx.crate_name(def_id.krate);
+    matches!(crate_name.as_str(), "core" | "std") && name.ends_with("::ops::IndexMut::index_mut")
+}
+
+fn is_mut_slice_ref_ty(ty: Ty<'_>) -> bool {
+    matches!(
+        ty.kind(),
+        ty::TyKind::Ref(_, inner_ty, mutability)
+            if mutability.is_mut() && matches!(inner_ty.kind(), ty::TyKind::Slice(_))
+    )
+}
+
+fn is_empty_array_ref_ty<'tcx>(ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) -> bool {
+    let ty::TyKind::Ref(_, inner_ty, _) = ty.kind() else {
+        return false;
+    };
+    let ty::TyKind::Array(_, len) = inner_ty.kind() else {
+        return false;
+    };
+    len.try_to_target_usize(tcx) == Some(0)
+}
+
+fn is_heap_alloc_call(
+    tcx: TyCtxt<'_>,
+    def_id: DefId,
+    name: &str,
+    alloc_fns: &FxHashSet<LocalDefId>,
+) -> bool {
+    if matches!(
+        name.rsplit("::").next(),
+        Some("malloc" | "calloc" | "realloc")
+    ) {
+        return true;
+    }
+    def_id
+        .as_local()
+        .is_some_and(|local_def_id| alloc_fns.contains(&local_def_id))
+        || tcx.is_foreign_item(def_id)
+            && matches!(
+                tcx.item_name(def_id).as_str(),
+                "malloc" | "calloc" | "realloc"
+            )
+}
+
+/// Returns `(base_local, slot_offset_within_local)` for `DirectlyRewriteable` bases.
+/// Returns `None` for `RawBorrow { target: None }` (no trackable local).
+fn base_local_of_base(base: &BaseId, slot_table: &SlotTable) -> Option<(Local, usize)> {
+    match base {
+        BaseId::Param { local, slot } => {
+            let offset = slot - slot_table.local_slots(*local).start;
+            Some((*local, offset))
+        }
+        BaseId::LocalArray { local } | BaseId::LocalScalar { local } => Some((*local, 0)),
+        BaseId::RawBorrow {
+            target: Some(slot), ..
+        } => {
+            let root = slot_table.slot_infos[*slot].root;
+            let offset = slot - slot_table.local_slots(root).start;
+            Some((root, offset))
+        }
+        BaseId::RawBorrow { target: None, .. } => None,
+        _ => None,
+    }
+}
+
+fn solve_reachable_bases(graph: &PointerFlowGraph) -> ProvenanceResult {
+    let mut reachable_bases: FxHashMap<PfgNode, FxHashSet<BaseId>> = FxHashMap::default();
+    let mut worklist = VecDeque::new();
+
+    for base in &graph.bases {
+        let node = PfgNode::Base(base.clone());
+        reachable_bases
+            .entry(node.clone())
+            .or_default()
+            .insert(base.clone());
+        worklist.push_back(node);
+    }
+
+    while let Some(src) = worklist.pop_front() {
+        let Some(src_bases) = reachable_bases.get(&src).cloned() else {
+            continue;
+        };
+        let Some(dsts) = graph.edges.get(&src) else {
+            continue;
+        };
+        for dst in dsts {
+            let dst_bases = reachable_bases.entry(dst.clone()).or_default();
+            let before_len = dst_bases.len();
+            dst_bases.extend(src_bases.iter().cloned());
+            if dst_bases.len() != before_len {
+                worklist.push_back(dst.clone());
+            }
+        }
+    }
+
+    ProvenanceResult { reachable_bases }
+}
+
+fn classify_base(base: &BaseId) -> BaseClassification {
+    let (admissibility, reason) = match base {
+        BaseId::Param { .. } => (
+            BaseAdmissibility::DirectlyRewriteable,
+            "raw pointer parameter; later rewrite must provide length/bounds evidence",
+        ),
+        BaseId::LocalArray { .. } => (
+            BaseAdmissibility::DirectlyRewriteable,
+            "local array pointer can later become array/slice indexing",
+        ),
+        BaseId::LocalScalar { .. } => (
+            BaseAdmissibility::DirectlyRewriteable,
+            "local scalar raw borrow can later become direct local access",
+        ),
+        BaseId::RawBorrow { target, .. } => (
+            BaseAdmissibility::DirectlyRewriteable,
+            if target.is_none() {
+                "raw borrow has unique provenance but unresolved target must be validated before rewrite"
+            } else {
+                "raw borrow has a known local slot"
+            },
+        ),
+        BaseId::HeapAlloc { .. } => (
+            BaseAdmissibility::RewriteableWithOwnershipTransform,
+            "heap allocation requires consistent allocation/free ownership transform",
+        ),
+        BaseId::OpaqueReturn { .. } => (
+            BaseAdmissibility::TrackOnly,
+            "opaque pointer return has unknown size, ownership, validity, nullability, and aliasing",
+        ),
+        BaseId::IntToPtr { .. } => (
+            BaseAdmissibility::Reject,
+            "integer-to-pointer cast has no known safe Rust allocation object",
+        ),
+        BaseId::Unknown { reason, .. } => (
+            BaseAdmissibility::Reject,
+            match reason {
+                UnknownReason::NullLike => "null-like pointer constant has no rewriteable base",
+                UnknownReason::ConstantPointer => "constant pointer value has unknown provenance",
+                UnknownReason::UnsupportedProjection => {
+                    "unsupported projection prevents precise provenance"
+                }
+                UnknownReason::UnsupportedMemoryLoad => {
+                    "unsupported memory load prevents precise provenance"
+                }
+                UnknownReason::UnsupportedCall => "unsupported call prevents precise provenance",
+            },
+        ),
+    };
+
+    BaseClassification {
+        base: base.clone(),
+        admissibility,
+        reason: reason.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -1,0 +1,1811 @@
+use points_to::andersen;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{self as hir, ItemKind, OwnerNode, PatKind, intravisit};
+use typed_arena::Arena;
+use utils::ty_shape;
+
+use super::{BaseAdmissibility, BaseId, PfgNode, analyze_body};
+use crate::{
+    analyses::type_qualifier::foster::mutability::mutability_analysis, utils::rustc::RustProgram,
+};
+
+fn build_rust_program(tcx: rustc_middle::ty::TyCtxt<'_>) -> RustProgram<'_> {
+    let mut functions = vec![];
+    let mut structs = vec![];
+    for maybe_owner in tcx.hir_crate(()).owners.iter() {
+        let Some(owner) = maybe_owner.as_owner() else {
+            continue;
+        };
+        let OwnerNode::Item(item) = owner.node() else {
+            continue;
+        };
+        match item.kind {
+            ItemKind::Fn { .. } => functions.push(item.owner_id.def_id),
+            ItemKind::Struct(..) => structs.push(item.owner_id.def_id),
+            _ => {}
+        }
+    }
+    RustProgram {
+        tcx,
+        functions,
+        structs,
+    }
+}
+
+fn collect_bindings(body: &hir::Body<'_>) -> FxHashMap<hir::HirId, String> {
+    struct BindingVisitor(FxHashMap<hir::HirId, String>);
+
+    impl<'tcx> intravisit::Visitor<'tcx> for BindingVisitor {
+        fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
+            if let PatKind::Binding(_, hir_id, ident, _) = pat.kind {
+                self.0.insert(hir_id, ident.name.to_string());
+            }
+            intravisit::walk_pat(self, pat);
+        }
+    }
+
+    let mut visitor = BindingVisitor(FxHashMap::default());
+    intravisit::walk_body(&mut visitor, body);
+    visitor.0
+}
+
+#[derive(Clone, Debug)]
+struct LocalFacts {
+    bases: FxHashSet<BaseId>,
+    unique: Option<BaseId>,
+    admissibility: Option<BaseAdmissibility>,
+}
+
+fn run_analysis(code: &str) -> FxHashMap<(String, String), LocalFacts> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let rust_program = build_rust_program(tcx);
+        let alloc_fns = FxHashSet::default();
+        let mut facts = FxHashMap::default();
+
+        for &did in &rust_program.functions {
+            let fn_name = tcx.item_name(did.to_def_id()).to_string();
+            let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+            let result = analyze_body(tcx, did, &body, &alloc_fns);
+            let hir_to_mir = utils::ir::map_thir_to_mir(did, false, tcx);
+            let hir_body = tcx.hir_body_owned_by(did);
+            let bindings = collect_bindings(hir_body);
+
+            for (hir_id, local) in &hir_to_mir.binding_to_local {
+                let Some(var_name) = bindings.get(hir_id) else {
+                    continue;
+                };
+                let bases = result
+                    .slot_table
+                    .local_head_slot(*local)
+                    .and_then(|slot| {
+                        result
+                            .provenance
+                            .reachable_bases
+                            .get(&PfgNode::Slot(slot))
+                            .cloned()
+                    })
+                    .unwrap_or_default();
+                let unique = result.unique_base_of_local(*local);
+                let admissibility = unique
+                    .as_ref()
+                    .map(|base| result.admissibility_of_base(base));
+                facts.insert(
+                    (fn_name.clone(), var_name.clone()),
+                    LocalFacts {
+                        bases,
+                        unique,
+                        admissibility,
+                    },
+                );
+            }
+        }
+
+        facts
+    })
+    .unwrap()
+}
+
+#[derive(Clone, Debug)]
+struct RewriteGroupFacts {
+    base: BaseId,
+    base_name: Option<String>,
+    member_names: FxHashSet<String>,
+    member_root_names: FxHashSet<String>,
+    index_tracked: bool,
+}
+
+fn run_rewrite_groups_with_points_to(code: &str) -> FxHashMap<String, Vec<RewriteGroupFacts>> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let rust_program = build_rust_program(tcx);
+        let mutability_result = mutability_analysis(&rust_program);
+
+        let arena = Arena::new();
+        let tss = ty_shape::get_ty_shapes(&arena, tcx, false);
+        let andersen_config = andersen::Config {
+            use_optimized_mir: false,
+            c_exposed_fns: FxHashSet::default(),
+        };
+        let pre_points_to = andersen::pre_analyze(&andersen_config, &tss, tcx);
+        let alloc_fns = pre_points_to.alloc_fns.clone();
+        let solutions = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
+        let points_to =
+            andersen::post_analyze(&andersen_config, pre_points_to, solutions, &tss, tcx);
+
+        let mut facts = FxHashMap::default();
+
+        for &did in &rust_program.functions {
+            let fn_name = tcx.item_name(did.to_def_id()).to_string();
+            let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+            let result = analyze_body(tcx, did, &body, &alloc_fns);
+            let groups = super::select_rewrite_groups(
+                &result,
+                &body,
+                &mutability_result,
+                did,
+                super::RewriteSelectionContext {
+                    tcx,
+                    points_to: &points_to,
+                },
+            );
+
+            let mut local_names: FxHashMap<rustc_middle::mir::Local, String> = FxHashMap::default();
+            for dbg in &body.var_debug_info {
+                if let rustc_middle::mir::VarDebugInfoContents::Place(place) = &dbg.value
+                    && let Some(local) = place.as_local()
+                {
+                    local_names.entry(local).or_insert(dbg.name.to_string());
+                }
+            }
+
+            let group_facts = groups
+                .into_iter()
+                .map(|group| {
+                    let member_names = group
+                        .members
+                        .iter()
+                        .filter_map(|slot| {
+                            let info = &result.slot_table.slot_infos[*slot];
+                            super::source_var_identity_for_slot(tcx, &body, &local_names, info)
+                        })
+                        .collect();
+                    let member_root_names = group
+                        .members
+                        .iter()
+                        .filter_map(|slot| {
+                            let info = &result.slot_table.slot_infos[*slot];
+                            local_names.get(&info.root).cloned()
+                        })
+                        .collect();
+                    let base_name = super::base_slot_info(&result, &group)
+                        .and_then(|info| {
+                            super::source_var_identity_for_slot(tcx, &body, &local_names, info)
+                        })
+                        .or_else(|| local_names.get(&group.base_local).cloned());
+                    RewriteGroupFacts {
+                        base: group.base,
+                        base_name,
+                        member_names,
+                        member_root_names,
+                        index_tracked: group.index_tracked,
+                    }
+                })
+                .collect();
+            facts.insert(fn_name, group_facts);
+        }
+
+        facts
+    })
+    .unwrap()
+}
+
+fn facts<'a>(
+    map: &'a FxHashMap<(String, String), LocalFacts>,
+    fn_name: &str,
+    var_name: &str,
+) -> &'a LocalFacts {
+    map.get(&(fn_name.to_string(), var_name.to_string()))
+        .unwrap_or_else(|| panic!("missing facts for {fn_name}::{var_name}: {map:#?}"))
+}
+
+fn assert_unique_param(fact: &LocalFacts) {
+    assert!(
+        matches!(fact.unique, Some(BaseId::Param { .. })),
+        "expected unique param base, got {fact:#?}"
+    );
+    assert_eq!(
+        fact.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable)
+    );
+}
+
+#[test]
+fn array_local_provenance_rewrite_groups_select_immutable_param_aliases() {
+    let map = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(p: *mut i32, i: usize) {
+            let q = p.add(i);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let groups = map
+        .get("f")
+        .unwrap_or_else(|| panic!("missing f: {map:#?}"));
+    assert!(
+        groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.base_name.as_deref() == Some("p")
+                && group.member_names.contains("q")
+                && group.member_names.contains("r")
+        }),
+        "expected Param rewrite group containing q and r: {groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_accepts_mut_param_when_base_is_not_reassigned() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            let q = p.add(i);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.member_names.contains("q")
+                && group.member_names.contains("r")
+        }),
+        "mut Param base should be accepted when no base storage write occurs: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_selects_as_index_tracked_when_param_directly_reassigned_while_member_live()
+{
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            let q = p.add(i);
+            p = p.add(1);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.index_tracked
+                && group.member_names.contains("q")
+                && group.member_names.contains("r")
+        }),
+        "Param base with direct-only reassignment while member is live must be selected as index_tracked: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_index_tracked_when_named_aggregate_member_live_after_direct_param_reassign()
+ {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct Holder { pub ptr: *mut i32 }
+
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            let q = p.add(i);
+            let m = p.add(2);
+            let mut h = Holder { ptr: core::ptr::null_mut() };
+            h.ptr = q;
+            let _ = m;
+            p = p.add(1);
+            let keep = h.ptr;
+            let _ = keep;
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.index_tracked
+                && group.member_names.contains("q")
+                && group.member_root_names.contains("h")
+        }),
+        "direct-only p reassignment while h holds a derived pointer must produce index_tracked group: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_rejects_mut_param_written_through_pointer_to_param() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            let pp = &raw mut p;
+            let q = p.add(i);
+            *pp = p.add(1);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        !f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.member_names.contains("q")
+                && group.member_names.contains("r")
+        }),
+        "Param base must be rejected when *pp may write p while q is live: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_rejects_param_when_call_may_write_base_storage() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        unsafe extern "C" {
+            fn touch(slot: *mut *mut i32);
+        }
+
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            let pp = &raw mut p;
+            let q = p.add(i);
+            touch(pp);
+            let r = q.add(1);
+            let _ = (*r);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        !f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. }) && group.member_names.contains("q")
+        }),
+        "extern call through pp may mutate p while q is live, so Param group must be rejected: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_rejects_param_when_by_value_aggregate_call_arg_contains_base_pointer() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct Holder {
+            pub other: *mut i32,
+            pub pp: *mut *mut i32,
+        }
+
+        unsafe extern "C" {
+            fn touch_holder(holder: Holder);
+        }
+
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            let holder = Holder {
+                other: 0 as *mut i32,
+                pp: &raw mut p,
+            };
+            let q = p.add(i);
+            touch_holder(holder);
+            let r = q.add(1);
+            let _ = *r;
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        !f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. }) && group.member_names.contains("q")
+        }),
+        "by-value aggregate call arg contains pointer to p storage while q is live: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_rejects_param_when_projected_call_arg_may_write_base_storage() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct Holder {
+            pub pp: *mut *mut i32,
+        }
+
+        unsafe extern "C" {
+            fn touch(slot: *mut *mut i32);
+        }
+
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            let holder = Holder { pp: &raw mut p };
+            let q = p.add(i);
+            touch(holder.pp);
+            let r = q.add(1);
+            let _ = (*r);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        !f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. }) && group.member_names.contains("q")
+        }),
+        "extern call through holder.pp may mutate p while q is live, so Param group must be rejected: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_rejects_param_field_when_call_may_write_parent_aggregate() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct Pair {
+            pub a: *mut i32,
+            pub b: *mut i32,
+        }
+
+        unsafe extern "C" {
+            fn touch_pair(pair: *mut Pair);
+        }
+
+        pub unsafe fn f(mut pair: Pair, i: usize) {
+            let ppair = &raw mut pair;
+            let qb = pair.b.add(i);
+            touch_pair(ppair);
+            let rb = qb.add(1);
+            let _ = *rb;
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        !f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. }) && group.member_names.contains("qb")
+        }),
+        "call through parent Pair pointer may mutate pair.b while qb is live: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_rejects_mut_param_field_written_through_pointer_to_field() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct S { pub n: i32, pub p: *mut i32 }
+
+        pub unsafe fn f(mut s: S, i: usize) {
+            let pp = &raw mut s.p;
+            let q = s.p.add(i);
+            *pp = s.p.add(1);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        !f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.member_names.contains("q")
+                && group.member_names.contains("r")
+        }),
+        "Param field base must be rejected when *pp may write s.p while q is live: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_rejects_pointee_param_base_written_through_alias() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(p: *mut *mut i32, replacement: *mut i32, i: usize) {
+            let pp = p;
+            let q = (*p).add(i);
+            *pp = replacement;
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        !f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.member_names.contains("q")
+                && group.member_names.contains("r")
+        }),
+        "Param pointee base must be rejected when an alias writes *p while q is live: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_index_tracked_for_mutated_struct_param_field() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct Pair {
+            pub a: *mut i32,
+            pub b: *mut i32,
+        }
+
+        pub unsafe fn f(mut pair: Pair, i: usize) {
+            let qa = pair.a.add(i);
+            let qb = pair.b.add(i);
+            pair.a = pair.a.add(1);
+            let ra = qa.add(1);
+            let rb = qb.add(1);
+            let _ = (*ra, *rb);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups
+            .iter()
+            .any(|group| group.index_tracked && group.member_names.contains("qa")),
+        "group for pair.a should be selected as index_tracked after direct field reassignment: {f_groups:#?}"
+    );
+    assert!(
+        f_groups
+            .iter()
+            .any(|group| group.member_names.contains("qb")),
+        "group for pair.b should remain selectable when only pair.a is reassigned: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_counts_named_param_field_as_source_var() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct State {
+            pub buffer: *mut i8,
+        }
+
+        pub unsafe fn f(state: *mut State) {
+            let mut ptr = (*state).buffer;
+            let _ = ptr;
+        }
+        "#,
+    );
+
+    let facts = groups.get("f").expect("missing facts for f");
+    let group = facts
+        .iter()
+        .find(|fact| {
+            fact.member_names.contains("ptr") && fact.member_names.contains("state.buffer")
+        })
+        .unwrap_or_else(|| {
+            panic!("expected rewrite group containing ptr and state.buffer, got {facts:#?}")
+        });
+
+    assert_eq!(group.base_name.as_deref(), Some("state.buffer"));
+}
+
+#[test]
+fn select_rewrite_groups_memchr_raw_cast_offset_preserves_state_buffer_base() {
+    let code = r#"
+        pub type size_t = usize;
+
+        pub struct State {
+            pub buffer: *mut core::ffi::c_char,
+        }
+
+        unsafe extern "C" {
+            fn memchr(
+                s: *const core::ffi::c_void,
+                c: i32,
+                n: size_t,
+            ) -> *mut core::ffi::c_void;
+        }
+
+        pub unsafe fn f(state: *mut State, target: core::ffi::c_char, remaining: size_t) {
+            let mut ptr: *mut core::ffi::c_char = (*state).buffer;
+            let found: *mut core::ffi::c_char = memchr(
+                ptr as *const core::ffi::c_void,
+                target as i32,
+                remaining,
+            ) as *mut core::ffi::c_char;
+            ptr = found.offset(1 as core::ffi::c_int as isize);
+            let _ = ptr;
+        }
+        "#;
+    let groups = run_rewrite_groups_with_points_to(code);
+
+    let facts = groups.get("f").expect("missing facts for f");
+    let _group = facts
+        .iter()
+        .find(|fact| {
+            fact.member_names.contains("ptr") && fact.member_names.contains("state.buffer")
+        })
+        .unwrap_or_else(|| {
+            panic!("expected rewrite group containing ptr and state.buffer, got {facts:#?}")
+        });
+}
+
+#[test]
+fn select_rewrite_groups_live_is_null_does_not_destabilize_state_buffer_base() {
+    let code = r#"
+        pub struct State {
+            pub buffer: *mut core::ffi::c_char,
+        }
+
+        unsafe extern "C" {
+            fn memchr(
+                s: *const core::ffi::c_void,
+                c: i32,
+                n: usize,
+            ) -> *mut core::ffi::c_void;
+        }
+
+        pub unsafe fn f(state: *mut State, target: core::ffi::c_char, remaining: usize) {
+            let mut ptr: *mut core::ffi::c_char = (*state).buffer;
+            if state.is_null() {
+                let _ = ptr;
+            }
+            let found: *mut core::ffi::c_char = memchr(
+                ptr as *const core::ffi::c_void,
+                target as i32,
+                remaining,
+            ) as *mut core::ffi::c_char;
+            ptr = found.offset(1 as core::ffi::c_int as isize);
+            let _ = ptr;
+        }
+        "#;
+    let groups = run_rewrite_groups_with_points_to(code);
+
+    let facts = groups.get("f").expect("missing facts for f");
+    let _group = facts
+        .iter()
+        .find(|fact| {
+            fact.member_names.contains("ptr") && fact.member_names.contains("state.buffer")
+        })
+        .unwrap_or_else(|| {
+            panic!("expected rewrite group containing ptr and state.buffer, got {facts:#?}")
+        });
+}
+
+#[test]
+fn select_rewrite_groups_counts_named_local_field_as_source_var() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct Holder {
+            pub ptr: *mut i32,
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let mut holder = Holder { ptr: core::ptr::null_mut() };
+            holder.ptr = p;
+            let mut q = holder.ptr;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let facts = groups.get("f").expect("missing facts for f");
+    let _group = facts
+        .iter()
+        .find(|fact| fact.member_names.contains("q") && fact.member_names.contains("holder.ptr"))
+        .unwrap_or_else(|| {
+            panic!("expected rewrite group containing q and holder.ptr, got {facts:#?}")
+        });
+}
+
+#[test]
+fn select_rewrite_groups_does_not_count_array_element_as_source_var() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(p: *mut i32) {
+            let mut slots = [core::ptr::null_mut()];
+            slots[0] = p;
+            let q = slots[0];
+            let r = q.offset(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let facts = groups.get("f").expect("missing facts for f");
+    let group = facts
+        .iter()
+        .find(|fact| {
+            (fact.member_names.contains("q") || fact.member_root_names.contains("q"))
+                && fact.member_root_names.contains("slots")
+        })
+        .unwrap_or_else(|| {
+            panic!("expected rewrite group involving q and slots root, got {facts:#?}")
+        });
+
+    assert!(
+        !group.member_names.contains("slots"),
+        "array element should not be counted as a named source var: {facts:#?}"
+    );
+    assert!(
+        !group.member_names.contains("slots.0"),
+        "array element should not be counted as a named source var: {facts:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_does_not_count_tuple_field_as_source_var() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(p: *mut i32) {
+            let mut pair = (core::ptr::null_mut(), 1i32);
+            pair.0 = p;
+            let q = pair.0;
+            let r = q.offset(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let facts = groups.get("f").expect("missing facts for f");
+    let group = facts
+        .iter()
+        .find(|fact| {
+            (fact.member_names.contains("q") || fact.member_root_names.contains("q"))
+                && fact.member_root_names.contains("pair")
+        })
+        .unwrap_or_else(|| {
+            panic!("expected rewrite group involving q and pair root, got {facts:#?}")
+        });
+
+    assert!(
+        !group.member_names.contains("pair"),
+        "tuple field should not be counted as a named source var: {facts:#?}"
+    );
+    assert!(
+        !group.member_names.contains("pair.0"),
+        "tuple field should not be counted as a named source var: {facts:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_accepts_mut_param_reassigned_before_members_exist() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            p = p.add(1);
+            let q = p.add(i);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.member_names.contains("q")
+                && group.member_names.contains("r")
+        }),
+        "Param base reassignment before q/r are live should not reject the group: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_accepts_mut_param_reassigned_from_member_not_live_after() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            let q = p.add(i);
+            p = q;
+            let r = p.add(1);
+            let _ = *r;
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.member_names.contains("q")
+                && group.member_names.contains("r")
+        }),
+        "Param base reassignment from q should be accepted when q is not live after the write: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_rewrite_groups_select_local_array_base() {
+    let map = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(i: usize) {
+            let mut arr = [0_i32; 4];
+            let p = arr.as_mut_ptr();
+            let q = p.add(i);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let groups = map
+        .get("f")
+        .unwrap_or_else(|| panic!("missing f: {map:#?}"));
+    assert!(
+        groups.iter().any(|group| {
+            matches!(group.base, BaseId::LocalArray { .. })
+                && group.base_name.as_deref() == Some("arr")
+                && group.member_names.contains("p")
+                && group.member_names.contains("q")
+                && group.member_names.contains("r")
+        }),
+        "local-array base should be accepted for rewrite selection: {groups:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_param_flows_through_copy_and_arithmetic() {
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(p: *mut i32, i: usize) {
+            let q = p;
+            let r = q.add(i);
+            let s = r.sub(1);
+            let _ = *s;
+        }
+        "#,
+    );
+
+    let s = facts(&map, "f", "s");
+    assert!(matches!(s.unique, Some(BaseId::Param { .. })));
+    assert_eq!(
+        s.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable)
+    );
+}
+
+#[test]
+fn array_local_provenance_int_cast_is_unique_but_rejected() {
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(addr: usize) {
+            let p = addr as *mut i32;
+            let _ = p;
+        }
+        "#,
+    );
+
+    let p = facts(&map, "f", "p");
+    assert!(matches!(p.unique, Some(BaseId::IntToPtr { .. })));
+    assert_eq!(p.admissibility, Some(BaseAdmissibility::Reject));
+}
+
+#[test]
+fn array_local_provenance_join_from_two_params_is_not_unique() {
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(p: *mut i32, r: *mut i32, cond: bool) {
+            let q;
+            if cond {
+                q = p;
+            } else {
+                q = r;
+            }
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert_eq!(q.bases.len(), 2);
+    assert!(q.unique.is_none());
+}
+
+#[test]
+fn array_local_provenance_raw_borrow_of_scalar_is_directly_rewriteable() {
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f() {
+            let mut x = 0_i32;
+            let p = &raw mut x;
+            let _ = *p;
+        }
+        "#,
+    );
+
+    let p = facts(&map, "f", "p");
+    assert!(matches!(p.unique, Some(BaseId::LocalScalar { .. })));
+    assert_eq!(
+        p.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable)
+    );
+}
+
+#[test]
+fn array_local_provenance_unknown_pointer_return_is_track_only() {
+    let map = run_analysis(
+        r#"
+        unsafe extern "C" {
+            fn make() -> *mut i32;
+        }
+
+        pub unsafe fn f() {
+            let p = make();
+            let _ = p;
+        }
+        "#,
+    );
+
+    let p = facts(&map, "f", "p");
+    assert!(matches!(p.unique, Some(BaseId::OpaqueReturn { .. })));
+    assert_eq!(p.admissibility, Some(BaseAdmissibility::TrackOnly));
+}
+
+#[test]
+fn array_local_provenance_simple_field_store_and_load_preserves_base() {
+    let map = run_analysis(
+        r#"
+        pub struct Slot {
+            pub p: *mut i32,
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let mut s = Slot { p: core::ptr::null_mut() };
+            s.p = p;
+            let q = s.p;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(matches!(q.unique, Some(BaseId::Param { .. })));
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable)
+    );
+}
+
+#[test]
+fn array_local_provenance_field_slots_are_per_local() {
+    let map = run_analysis(
+        r#"
+        pub struct Slot {
+            pub p: *mut i32,
+        }
+
+        pub unsafe fn f(p: *mut i32, r: *mut i32) {
+            let mut s1 = Slot { p: core::ptr::null_mut() };
+            let mut s2 = Slot { p: core::ptr::null_mut() };
+            s1.p = p;
+            s2.p = r;
+            let q = s1.p;
+            let t = s2.p;
+            let _ = (q, t);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    let t = facts(&map, "f", "t");
+    assert_unique_param(q);
+    assert_unique_param(t);
+    assert_ne!(q.unique, t.unique);
+}
+
+#[test]
+fn array_local_provenance_array_index_slots_are_collapsed() {
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(p: *mut i32, i: usize, j: usize) {
+            let mut a = [core::ptr::null_mut(); 2];
+            a[i & 1] = p;
+            let q = a[j & 1];
+            let _ = q;
+        }
+        "#,
+    );
+
+    assert_unique_param(facts(&map, "f", "q"));
+}
+
+#[test]
+fn array_local_provenance_union_field_projection_is_unknown() {
+    let map = run_analysis(
+        r#"
+        pub union U {
+            pub p: *mut i32,
+            pub n: usize,
+        }
+
+        pub unsafe fn f(u: U) {
+            let q = u.p;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(matches!(q.unique, Some(BaseId::Unknown { .. })));
+    assert_eq!(q.admissibility, Some(BaseAdmissibility::Reject));
+}
+
+#[test]
+fn array_local_provenance_raw_address_load_reads_pointer_field() {
+    let map = run_analysis(
+        r#"
+        pub struct Slot {
+            pub p: *mut i32,
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let mut s = Slot { p: core::ptr::null_mut() };
+            s.p = p;
+            let slot = &raw const s.p;
+            let q = *slot;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(matches!(q.unique, Some(BaseId::Param { .. })));
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable)
+    );
+}
+
+#[test]
+fn array_local_provenance_raw_address_store_updates_pointer_field() {
+    let map = run_analysis(
+        r#"
+        pub struct Slot {
+            pub p: *mut i32,
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let mut s = Slot { p: core::ptr::null_mut() };
+            let slot = &raw mut s.p;
+            *slot = p;
+            let q = s.p;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(matches!(q.unique, Some(BaseId::Param { .. })));
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable)
+    );
+}
+
+#[test]
+fn array_local_provenance_copied_raw_address_preserves_pointee_slot() {
+    let map = run_analysis(
+        r#"
+        pub struct Slot {
+            pub p: *mut i32,
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let mut s = Slot { p: core::ptr::null_mut() };
+            let slot = &raw mut s.p;
+            let alias = slot;
+            *alias = p;
+            let q = s.p;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(matches!(q.unique, Some(BaseId::Param { .. })));
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable)
+    );
+}
+
+#[test]
+fn array_local_provenance_struct_param_fields_get_distinct_bases() {
+    let map = run_analysis(
+        r#"
+        pub struct Pair {
+            pub a: *mut i32,
+            pub b: *mut i32,
+        }
+
+        pub unsafe fn f(pair: Pair) {
+            let q = pair.a;
+            let r = pair.b;
+            let _ = (q, r);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    let r = facts(&map, "f", "r");
+    assert_unique_param(q);
+    assert_unique_param(r);
+    assert_ne!(
+        q.unique, r.unique,
+        "distinct pointer fields must have distinct Param bases"
+    );
+}
+
+#[test]
+fn array_local_provenance_call_invalidates_pointer_fields_through_struct_pointer() {
+    let map = run_analysis(
+        r#"
+        pub struct Slot {
+            pub p: *mut i32,
+        }
+
+        unsafe extern "C" {
+            fn touch(slot: *mut Slot);
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let mut s = Slot { p };
+            let slot = &raw mut s;
+            touch(slot);
+            let q = s.p;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::Unknown { .. })),
+        "call invalidation should mark the field unknown: {q:#?}"
+    );
+    assert_eq!(q.admissibility, Some(BaseAdmissibility::Reject));
+}
+
+#[test]
+fn array_local_provenance_call_returning_struct_fills_all_pointer_slots() {
+    // when a function returns a struct that contains pointer fields, every
+    // pointer slot in the destination should receive a CallReturn edge so
+    // that provenance propagates to all fields, not only the first one.
+    let map = run_analysis(
+        r#"
+        pub struct Pair {
+            pub a: *mut i32,
+            pub b: *mut i32,
+        }
+
+        unsafe extern "C" {
+            fn make_pair() -> Pair;
+        }
+
+        pub unsafe fn f() {
+            let s = make_pair();
+            let q = s.a;
+            let r = s.b;
+            let _ = (q, r);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    let r = facts(&map, "f", "r");
+    assert!(
+        matches!(q.unique, Some(BaseId::OpaqueReturn { .. })),
+        "s.a should have unique OpaqueReturn base: {q:#?}"
+    );
+    assert!(
+        matches!(r.unique, Some(BaseId::OpaqueReturn { .. })),
+        "s.b should have unique OpaqueReturn base: {r:#?}"
+    );
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::TrackOnly),
+        "OpaqueReturn base must be TrackOnly: {q:#?}"
+    );
+    assert_eq!(
+        r.admissibility,
+        Some(BaseAdmissibility::TrackOnly),
+        "OpaqueReturn base must be TrackOnly: {r:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_call_returning_raw_pointer_non_regression() {
+    // `make()` returns `*mut i32` — the destination IS a raw pointer.
+    // Both old (is_raw_ptr) and new (place_slots) code must emit one
+    // CallReturn(loc) → slot(p) edge so that p has OpaqueReturn provenance.
+    let map = run_analysis(
+        r#"
+        unsafe extern "C" {
+            fn make() -> *mut i32;
+        }
+
+        pub unsafe fn f() {
+            let p = make();
+            let q = p;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::OpaqueReturn { .. })),
+        "call returning *mut i32 must still give OpaqueReturn provenance (AC 2 non-regression): {q:#?}"
+    );
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::TrackOnly),
+        "OpaqueReturn base must be TrackOnly: {q:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_use_rvalue_struct_copy_pairs_all_pointer_slots() {
+    // Rvalue::Use for a whole-struct copy must pair every pointer slot in the
+    // source with the corresponding slot in the destination.  Head slot (i=0)
+    // gets an add_edge (unidirectional); tail slots (i>0) get
+    // add_bidirectional_edge.  Both fields must carry provenance from their
+    // respective parameters after the copy.
+    let map = run_analysis(
+        r#"
+        pub struct Pair {
+            pub a: *mut i32,
+            pub b: *mut i32,
+        }
+
+        pub unsafe fn f(p1: *mut i32, p2: *mut i32) {
+            let mut s1 = Pair { a: core::ptr::null_mut(), b: core::ptr::null_mut() };
+            s1.a = p1;
+            s1.b = p2;
+            let s2 = s1;
+            let q = s2.a;
+            let r = s2.b;
+            let _ = (q, r);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    let r = facts(&map, "f", "r");
+
+    // head slot (a): provenance should flow from p1 via the unidirectional edge
+    assert!(
+        matches!(q.unique, Some(BaseId::Param { .. })),
+        "s2.a should carry p1's Param base after struct copy: {q:#?}"
+    );
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable),
+        "p1's base must be DirectlyRewriteable: {q:#?}"
+    );
+
+    // tail slot (b): provenance should flow from p2 via the bidirectional edge
+    assert!(
+        matches!(r.unique, Some(BaseId::Param { .. })),
+        "s2.b should carry p2's Param base after struct copy: {r:#?}"
+    );
+    assert_eq!(
+        r.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable),
+        "p2's base must be DirectlyRewriteable: {r:#?}"
+    );
+
+    // the two fields must trace back to distinct parameters
+    assert_ne!(
+        q.unique, r.unique,
+        "s2.a and s2.b must have distinct Param bases after copying a Pair"
+    );
+}
+
+#[test]
+fn array_local_provenance_struct_copy_all_pointer_slots_receive_flow_edges() {
+    // A struct copy (Rvalue::Use on a struct destination) must propagate
+    // provenance to every pointer slot in the destination, not only the head
+    // slot.  This test uses a three-field struct so we exercise the head slot
+    // (i=0) and two tail slots (i=1, i=2) in a single copy statement.
+    //
+    // Fields are set via explicit assignment statements (not a struct literal)
+    // so that MIR emits individual field-store statements for the source and
+    // then a single Rvalue::Use for the whole-struct copy.
+    let map = run_analysis(
+        r#"
+        pub struct Triple {
+            pub a: *mut i32,
+            pub b: *mut i32,
+            pub c: *mut i32,
+        }
+
+        pub unsafe fn f(p1: *mut i32, p2: *mut i32, p3: *mut i32) {
+            let mut src = Triple {
+                a: core::ptr::null_mut(),
+                b: core::ptr::null_mut(),
+                c: core::ptr::null_mut(),
+            };
+            src.a = p1;
+            src.b = p2;
+            src.c = p3;
+            let dst = src;
+            let q = dst.a;
+            let r = dst.b;
+            let s = dst.c;
+            let _ = (q, r, s);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    let r = facts(&map, "f", "r");
+    let s = facts(&map, "f", "s");
+
+    // every pointer slot in dst must carry its respective Param base
+    assert!(
+        matches!(q.unique, Some(BaseId::Param { .. })),
+        "dst.a should carry p1 Param base after struct copy: {q:#?}"
+    );
+    assert!(
+        matches!(r.unique, Some(BaseId::Param { .. })),
+        "dst.b should carry p2 Param base after struct copy: {r:#?}"
+    );
+    assert!(
+        matches!(s.unique, Some(BaseId::Param { .. })),
+        "dst.c should carry p3 Param base after struct copy: {s:#?}"
+    );
+    // each field must trace back to a *distinct* parameter
+    assert_ne!(
+        q.unique, r.unique,
+        "a and b must trace back to distinct params"
+    );
+    assert_ne!(
+        r.unique, s.unique,
+        "b and c must trace back to distinct params"
+    );
+    assert_ne!(
+        q.unique, s.unique,
+        "a and c must trace back to distinct params"
+    );
+}
+
+#[test]
+fn array_local_provenance_through_pointer_write_struct_field_gets_edge() {
+    // when a struct value is written *through* a raw pointer to a struct —
+    // i.e., the destination place begins with a Deref projection and the
+    // resulting type is a struct containing pointer fields (NOT itself a raw
+    // pointer) — every pointer slot in the destination must receive an
+    // appropriate edge so that provenance propagates correctly.
+    //   1. src.p = p       — direct field write; src.p's slot gets a Param edge
+    //                        (raw-pointer destination, handled by old code too).
+    //   2. *lptr = src     — add_edge(src.p, (*lptr).p).
+    //   3. let q = local.p — direct field read; local.p is linked bidirectionally
+    //                        to (*lptr).p via collect_address_links (from step when
+    //                        lptr = &raw mut local).
+    let map = run_analysis(
+        r#"
+        pub struct Slot {
+            pub p: *mut i32,
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let mut local = Slot { p: core::ptr::null_mut() };
+            let lptr = &raw mut local;
+            let mut src = Slot { p: core::ptr::null_mut() };
+            src.p = p;
+            *lptr = src;
+            let q = local.p;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::Param { .. })),
+        "through-pointer struct write should propagate param provenance to the \
+         local field slot — q must have a unique Param base: {q:#?}"
+    );
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable),
+        "param base must be DirectlyRewriteable: {q:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_through_pointer_nested_field_write_slot_gets_edge() {
+    let map = run_analysis(
+        r#"
+        pub struct Inner {
+            pub p: *mut i32,
+        }
+
+        pub struct Outer {
+            pub inner: Inner,
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let mut local = Outer { inner: Inner { p: core::ptr::null_mut() } };
+            let ptr = &raw mut local;
+            let mut src = Inner { p: core::ptr::null_mut() };
+            src.p = p;
+            (*ptr).inner = src;
+            let q = local.inner.p;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::Param { .. })),
+        "through-pointer write to a struct field (Inner) containing a pointer must \
+         propagate param provenance to the nested pointer slot — q must have a \
+         unique Param base (AC 8): {q:#?}"
+    );
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable),
+        "param base must be DirectlyRewriteable: {q:#?}"
+    );
+}
+
+/// source_node must work for a reference-typed source (&*mut i32) so that
+/// provenance can flow even when the place is a reference, not a raw pointer.
+#[test]
+fn array_local_provenance_source_node_reference_to_pointer_flows_provenance() {
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(p: *mut i32) {
+            let r = &p;   // r: &*mut i32 — not a raw pointer
+            let q = *r;   // may emit CopyForDeref(r) in MIR
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::Param { .. })),
+        "dereferencing a reference-to-raw-pointer must preserve param provenance \
+         via the range-based source_node (AC 5): {q:#?}"
+    );
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable),
+        "param base must be DirectlyRewriteable: {q:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_rawptr_of_union_field_fills_tail_slot_unknown() {
+    let map = run_analysis(
+        r#"
+        pub union U {
+            pub inner: *mut i32,
+            pub bits: usize,
+        }
+
+        pub unsafe fn f(v: *mut i32) {
+            let mut u = U { inner: v };
+            let ptr: *mut *mut i32 = &raw mut u.inner;
+            let q = *ptr;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::Unknown { .. })),
+        "loading through a ptr-to-ptr whose tail slot came from an unsupported \
+         projection should yield Unknown provenance, not absent provenance: {q:#?}"
+    );
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::Reject),
+        "Unknown base must be classified as Reject: {q:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_cast_to_double_ptr_tail_slot_gets_unknown() {
+    // Cast *mut i32 → *mut *mut i32.
+    //   slot[0] of pptr = CastResult edge (cast provenance, not directly rewriteable)
+    //   slot[1] of pptr = Unknown{UnsupportedProjection}
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(p: *mut i32) {
+            let pptr: *mut *mut i32 = p as *mut *mut i32;
+            let q = *pptr;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::Unknown { .. })),
+        "dereferencing a *mut *mut i32 produced by a Cast must yield Unknown provenance \
+         for the inner pointer slot (AC 4 Cast arm): {q:#?}"
+    );
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::Reject),
+        "Unknown base must be classified as Reject: {q:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_cast_single_slot_slot0_preserves_param_provenance() {
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(sequence: *mut i8) {
+            let bools = sequence as *mut bool;
+            let _ = bools;
+        }
+        "#,
+    );
+
+    let bools = facts(&map, "f", "bools");
+    assert!(
+        matches!(bools.unique, Some(BaseId::Param { .. })),
+        "slot[0] of a single-slot Cast result must carry Param provenance (AC 4 Cast \
+         non-regression): {bools:#?}"
+    );
+    assert_eq!(
+        bools.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable),
+        "Param base must be DirectlyRewriteable: {bools:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_rawptr_double_ptr_tail_slot_preserves_param_provenance() {
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(p: *mut i32) {
+            let mut ptr = p;
+            let pptr: *mut *mut i32 = &raw mut ptr;
+            let q = *pptr;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::Param { .. })),
+        "dereferencing *mut *mut i32 from &raw mut ptr must yield Param provenance \
+         via collect_address_links (AC 4 RawPtr non-regression): {q:#?}"
+    );
+    assert_eq!(
+        q.admissibility,
+        Some(BaseAdmissibility::DirectlyRewriteable),
+        "Param base must be DirectlyRewriteable: {q:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_struct_field_array_offset_pointers_share_base() {
+    let map = run_analysis(
+        r#"
+        pub struct Buf {
+            pub data: [i32; 8],
+        }
+        pub unsafe fn f(buf: *mut Buf, i: usize) {
+            let current = &mut *(*buf).data.as_mut_ptr().add(i) as *mut i32;
+            let base = &mut *(*buf).data.as_mut_ptr().add(0) as *mut i32;
+            let _ = (current, base);
+        }
+        "#,
+    );
+
+    let current = facts(&map, "f", "current");
+    let base_var = facts(&map, "f", "base");
+    assert!(
+        current.unique.is_some(),
+        "current should have a unique base: {current:#?}"
+    );
+    assert_eq!(
+        current.unique, base_var.unique,
+        "current and base must share the same unique base so offset_from can be rewritten"
+    );
+    assert!(
+        matches!(current.unique, Some(BaseId::LocalArray { .. })),
+        "the shared base should be LocalArray: {current:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_accepts_mixed_mut_and_const_members_from_param_field() {
+    // Only one *mut identity (state.out itself) plus one *const derivation (src).
+    // With the old gate-2 (mut_count > 1) this is rejected; with the relaxation
+    // (mut >= 1 AND imm >= 1) it must be accepted.
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct State {
+            pub out: *mut i8,
+        }
+
+        pub unsafe fn f(state: *mut State, backward: usize) {
+            let src: *const i8 = ((*state).out as *const i8).sub(backward);
+            let _ = *src;
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.member_names.contains("state.out")
+                && group.member_names.contains("src")
+        }),
+        "one *mut (state.out) plus one *const (src) from the same param field must form a group: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_extern_call_with_struct_param_does_not_contaminate_param_field_slot() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct State {
+            pub out: *mut i8,
+        }
+
+        unsafe extern "C" {
+            fn process(state: *mut State);
+        }
+
+        pub unsafe fn f(state: *mut State, n: usize) {
+            process(state);
+            let dst: *mut i8 = (*state).out;
+            let next: *mut i8 = dst.add(1);
+            let _ = (*dst, *next);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.member_names.contains("dst")
+                && group.member_names.contains("next")
+        }),
+        "extern call before members are live must not contaminate the param field slot via UML: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_cp_block_pattern_produces_index_tracked_group() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct State {
+            pub out: *mut i8,
+        }
+
+        unsafe extern "C" {
+            fn process(state: *mut State);
+        }
+
+        pub unsafe fn f(state: *mut State, backward: usize, n: usize) {
+            process(state);
+            let src: *const i8 = ((*state).out as *const i8).sub(backward);
+            (*state).out = ((*state).out).add(n);
+            let _keep: *const i8 = src;
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.index_tracked
+                && group.member_names.contains("state.out")
+                && group.member_names.contains("src")
+        }),
+        "cp_block pattern must produce an index_tracked Param group for state.out and src: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn liveness_gate_rejects_group_when_two_mut_locals_never_simultaneously_live() {
+    // q is used and dead before r is created — no simultaneous borrow conflict.
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(p: *mut i32) {
+            let q = p.add(1);
+            let _ = *q;
+            let r = p.add(2);
+            let _ = *r;
+        }
+        "#,
+    );
+    let f_groups = groups
+        .get("f")
+        .unwrap_or_else(|| panic!("missing f: {groups:#?}"));
+    assert!(
+        !f_groups
+            .iter()
+            .any(|g| { g.member_names.contains("q") && g.member_names.contains("r") }),
+        "q and r have non-overlapping live ranges — no group should be selected: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn liveness_gate_accepts_group_when_two_mut_locals_simultaneously_live() {
+    // q and r are both live at the tuple read — genuine borrow conflict.
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(p: *mut i32) {
+            let q = p.add(1);
+            let r = p.add(2);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+    let f_groups = groups
+        .get("f")
+        .unwrap_or_else(|| panic!("missing f: {groups:#?}"));
+    assert!(
+        f_groups
+            .iter()
+            .any(|g| { g.member_names.contains("q") && g.member_names.contains("r") }),
+        "q and r are simultaneously live — group must be selected: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn liveness_gate_rejects_group_when_mut_and_imm_locals_never_simultaneously_live() {
+    // q (mut) is dead before r (const cast) is created.
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(p: *mut i32) {
+            let q = p.add(1);
+            let _ = *q;
+            let r = p.add(2) as *const i32;
+            let _ = *r;
+        }
+        "#,
+    );
+    let f_groups = groups
+        .get("f")
+        .unwrap_or_else(|| panic!("missing f: {groups:#?}"));
+    assert!(
+        !f_groups
+            .iter()
+            .any(|g| { g.member_names.contains("q") && g.member_names.contains("r") }),
+        "q (*mut) and r (*const) have non-overlapping live ranges — no group should be selected: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn liveness_gate_accepts_group_when_mut_and_imm_locals_simultaneously_live() {
+    // q (*mut) and r (*const alias of q) are both alive at the tuple read.
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn f(p: *mut i32) {
+            let q = p.add(1);
+            let r = q as *const i32;
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+    let f_groups = groups
+        .get("f")
+        .unwrap_or_else(|| panic!("missing f: {groups:#?}"));
+    assert!(
+        f_groups
+            .iter()
+            .any(|g| { g.member_names.contains("q") && g.member_names.contains("r") }),
+        "q (*mut) and r (*const) are simultaneously live — group must be selected: {f_groups:#?}"
+    );
+}

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -563,75 +563,6 @@ fn select_rewrite_groups_index_tracked_for_mutated_struct_param_field() {
 }
 
 #[test]
-fn select_rewrite_groups_counts_named_param_field_as_source_var() {
-    let groups = run_rewrite_groups_with_points_to(
-        r#"
-        pub struct State {
-            pub buffer: *mut i8,
-        }
-
-        pub unsafe fn f(state: *mut State) {
-            let mut ptr = (*state).buffer;
-            let _ = ptr;
-        }
-        "#,
-    );
-
-    let facts = groups.get("f").expect("missing facts for f");
-    let group = facts
-        .iter()
-        .find(|fact| {
-            fact.member_names.contains("ptr") && fact.member_names.contains("state.buffer")
-        })
-        .unwrap_or_else(|| {
-            panic!("expected rewrite group containing ptr and state.buffer, got {facts:#?}")
-        });
-
-    assert_eq!(group.base_name.as_deref(), Some("state.buffer"));
-}
-
-#[test]
-fn select_rewrite_groups_memchr_raw_cast_offset_preserves_state_buffer_base() {
-    let code = r#"
-        pub type size_t = usize;
-
-        pub struct State {
-            pub buffer: *mut core::ffi::c_char,
-        }
-
-        unsafe extern "C" {
-            fn memchr(
-                s: *const core::ffi::c_void,
-                c: i32,
-                n: size_t,
-            ) -> *mut core::ffi::c_void;
-        }
-
-        pub unsafe fn f(state: *mut State, target: core::ffi::c_char, remaining: size_t) {
-            let mut ptr: *mut core::ffi::c_char = (*state).buffer;
-            let found: *mut core::ffi::c_char = memchr(
-                ptr as *const core::ffi::c_void,
-                target as i32,
-                remaining,
-            ) as *mut core::ffi::c_char;
-            ptr = found.offset(1 as core::ffi::c_int as isize);
-            let _ = ptr;
-        }
-        "#;
-    let groups = run_rewrite_groups_with_points_to(code);
-
-    let facts = groups.get("f").expect("missing facts for f");
-    let _group = facts
-        .iter()
-        .find(|fact| {
-            fact.member_names.contains("ptr") && fact.member_names.contains("state.buffer")
-        })
-        .unwrap_or_else(|| {
-            panic!("expected rewrite group containing ptr and state.buffer, got {facts:#?}")
-        });
-}
-
-#[test]
 fn select_rewrite_groups_live_is_null_does_not_destabilize_state_buffer_base() {
     let code = r#"
         pub struct State {
@@ -790,30 +721,6 @@ fn select_rewrite_groups_accepts_mut_param_reassigned_before_members_exist() {
                 && group.member_names.contains("r")
         }),
         "Param base reassignment before q/r are live should not reject the group: {f_groups:#?}"
-    );
-}
-
-#[test]
-fn select_rewrite_groups_accepts_mut_param_reassigned_from_member_not_live_after() {
-    let groups = run_rewrite_groups_with_points_to(
-        r#"
-        pub unsafe fn f(mut p: *mut i32, i: usize) {
-            let q = p.add(i);
-            p = q;
-            let r = p.add(1);
-            let _ = *r;
-        }
-        "#,
-    );
-
-    let f_groups = groups.get("f").unwrap();
-    assert!(
-        f_groups.iter().any(|group| {
-            matches!(group.base, BaseId::Param { .. })
-                && group.member_names.contains("q")
-                && group.member_names.contains("r")
-        }),
-        "Param base reassignment from q should be accepted when q is not live after the write: {f_groups:#?}"
     );
 }
 
@@ -1619,35 +1526,6 @@ fn array_local_provenance_struct_field_array_offset_pointers_share_base() {
     assert!(
         matches!(current.unique, Some(BaseId::LocalArray { .. })),
         "the shared base should be LocalArray: {current:#?}"
-    );
-}
-
-#[test]
-fn select_rewrite_groups_accepts_mixed_mut_and_const_members_from_param_field() {
-    // Only one *mut identity (state.out itself) plus one *const derivation (src).
-    // With the old gate-2 (mut_count > 1) this is rejected; with the relaxation
-    // (mut >= 1 AND imm >= 1) it must be accepted.
-    let groups = run_rewrite_groups_with_points_to(
-        r#"
-        pub struct State {
-            pub out: *mut i8,
-        }
-
-        pub unsafe fn f(state: *mut State, backward: usize) {
-            let src: *const i8 = ((*state).out as *const i8).sub(backward);
-            let _ = *src;
-        }
-        "#,
-    );
-
-    let f_groups = groups.get("f").unwrap();
-    assert!(
-        f_groups.iter().any(|group| {
-            matches!(group.base, BaseId::Param { .. })
-                && group.member_names.contains("state.out")
-                && group.member_names.contains("src")
-        }),
-        "one *mut (state.out) plus one *const (src) from the same param field must form a group: {f_groups:#?}"
     );
 }
 

--- a/crates/pointer_replacer/src/analyses/borrow/tests.rs
+++ b/crates/pointer_replacer/src/analyses/borrow/tests.rs
@@ -53,12 +53,11 @@ fn user_var_names(tcx: TyCtxt, def_id: LocalDefId, locals: &DenseBitSet<Local>) 
     let body = &*tcx.mir_drops_elaborated_and_const_checked(def_id).borrow();
     let mut names = vec![];
     for var_debug_info in body.var_debug_info.iter() {
-        if let VarDebugInfoContents::Place(place) = &var_debug_info.value {
-            if let Some(local) = place.as_local()
-                && locals.contains(local)
-            {
-                names.push(var_debug_info.name.as_str().to_string());
-            }
+        if let VarDebugInfoContents::Place(place) = &var_debug_info.value
+            && let Some(local) = place.as_local()
+            && locals.contains(local)
+        {
+            names.push(var_debug_info.name.as_str().to_string());
         }
     }
     names.sort();

--- a/crates/pointer_replacer/src/analyses/mod.rs
+++ b/crates/pointer_replacer/src/analyses/mod.rs
@@ -1,3 +1,4 @@
+pub mod array_local_provenance;
 pub mod borrow;
 mod encoding;
 pub mod fn_ptr_groups;

--- a/crates/pointer_replacer/src/analyses/offset_sign/tests.rs
+++ b/crates/pointer_replacer/src/analyses/offset_sign/tests.rs
@@ -54,10 +54,10 @@ fn run_analysis(code: &str) -> FxHashMap<(String, String), bool> {
             let body = tcx.hir_body_owned_by(did);
             let bindings = collect_bindings(body);
             for (hir_id, local) in &hir_to_mir.binding_to_local {
-                if cursor_locals.contains(*local) {
-                    if let Some(var_name) = bindings.get(hir_id) {
-                        map.insert((fn_name.clone(), var_name.clone()), true);
-                    }
+                if cursor_locals.contains(*local)
+                    && let Some(var_name) = bindings.get(hir_id)
+                {
+                    map.insert((fn_name.clone(), var_name.clone()), true);
                 }
             }
         }

--- a/crates/pointer_replacer/src/analyses/ownership/struct_ctxt.rs
+++ b/crates/pointer_replacer/src/analyses/ownership/struct_ctxt.rs
@@ -330,7 +330,7 @@ mod tests {
 
     fn has_name(tcx: TyCtxt<'_>, did: DefId, name: &str) -> bool {
         let path = tcx.def_path_str(did);
-        path.rsplit("::").next().map_or(false, |last| last == name)
+        path.rsplit("::").next() == Some(name)
     }
 
     #[test]

--- a/crates/pointer_replacer/src/analyses/type_qualifier/foster/mod.rs
+++ b/crates/pointer_replacer/src/analyses/type_qualifier/foster/mod.rs
@@ -98,9 +98,40 @@ impl<Qualifier> TypeQualifiers<Qualifier> {
         self.fn_locals.locals(did).map(|vars| &self.model[vars])
     }
 
+    pub fn function_body_fact(
+        &self,
+        did: LocalDefId,
+        local_idx: usize,
+        offset: usize,
+    ) -> Option<Qualifier>
+    where
+        Qualifier: Copy,
+    {
+        self.function_body_facts(did)
+            .nth(local_idx)
+            .and_then(|quals| quals.get(offset))
+            .copied()
+    }
+
     #[allow(unused)]
     pub fn struct_facts(&self, did: LocalDefId) -> impl Iterator<Item = &[Qualifier]> {
         self.struct_fields.fields(did).map(|vars| &self.model[vars])
+    }
+
+    #[allow(dead_code)]
+    pub fn struct_field_fact(
+        &self,
+        did: LocalDefId,
+        field_idx: usize,
+        offset: usize,
+    ) -> Option<Qualifier>
+    where
+        Qualifier: Copy,
+    {
+        self.struct_facts(did)
+            .nth(field_idx)
+            .and_then(|quals| quals.get(offset))
+            .copied()
     }
 }
 

--- a/crates/pointer_replacer/src/lib.rs
+++ b/crates/pointer_replacer/src/lib.rs
@@ -28,7 +28,7 @@ mod analyses;
 mod rewriter;
 mod utils;
 
-pub use rewriter::{BytemuckDependency, Config, replace_local_borrows, rewrite_struct_arrays};
+pub use rewriter::{BytemuckDependency, Config, replace_local_borrows, rewrite_struct_arrays, rewrite_array_local_provenance};
 
 #[cfg(test)]
 mod tests;

--- a/crates/pointer_replacer/src/lib.rs
+++ b/crates/pointer_replacer/src/lib.rs
@@ -28,7 +28,10 @@ mod analyses;
 mod rewriter;
 mod utils;
 
-pub use rewriter::{BytemuckDependency, Config, replace_local_borrows, rewrite_struct_arrays, rewrite_array_local_provenance};
+pub use rewriter::{
+    BytemuckDependency, Config, replace_local_borrows, rewrite_array_local_provenance,
+    rewrite_struct_arrays,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -732,9 +732,9 @@ fn rewrite_binding_pat(pat: &mut Pat, index_name: &str) -> bool {
 
 fn index_ty(nullable: bool) -> P<Ty> {
     if nullable {
-        P(utils::ty!("Option<usize>"))
+        P(utils::ty!("Option<isize>"))
     } else {
-        P(utils::ty!("usize"))
+        P(utils::ty!("isize"))
     }
 }
 
@@ -760,25 +760,21 @@ fn is_null_expr(expr: &Expr) -> bool {
     }
 }
 
-fn offset_index_arg_expr(_name: &str, arg: &Expr) -> Expr {
-    utils::expr!("({}) as usize", pprust::expr_to_string(arg))
+fn offset_index_arg_expr(name: &str, arg: &Expr) -> Expr {
+    if name == "add" || matches!(unwrap_cast_and_paren(arg).kind, ExprKind::Lit(_)) {
+        utils::expr!("({}) as isize", pprust::expr_to_string(arg))
+    } else {
+        utils::expr!("{}", pprust::expr_to_string(arg))
+    }
 }
 
-fn add_usize_index_expr(current: &str, offset: &Expr) -> Expr {
-    utils::expr!(
-        "(({}) as isize + ({}) as isize) as usize",
-        current,
-        pprust::expr_to_string(offset)
-    )
+fn add_index_expr(current: &str, offset: &Expr) -> Expr {
+    utils::expr!("({}) + ({})", current, pprust::expr_to_string(offset))
 }
 
 fn relative_index_expr(current: &str, method_name: &str, arg: &Expr) -> Expr {
-    let delta = if method_name == "add" {
-        format!("({}) as isize", pprust::expr_to_string(arg))
-    } else {
-        pprust::expr_to_string(arg)
-    };
-    utils::expr!("(({}) as isize + ({})) as usize", current, delta)
+    let offset = offset_index_arg_expr(method_name, arg);
+    add_index_expr(current, &offset)
 }
 
 fn base_current_index_expr(rewrite: &BindingRewrite) -> Option<&str> {
@@ -834,7 +830,7 @@ fn offset_from_base_expr(
     if hir_id_of_ast_expr(ast_to_hir, tcx, expr.id) == Some(rewrite.base_hir_id) {
         return IndexExpr::Plain(match base_current_index_expr(rewrite) {
             Some(base_index_name) => utils::expr!("{}", base_index_name),
-            None => utils::expr!("0usize"),
+            None => utils::expr!("0isize"),
         });
     }
     let ExprKind::MethodCall(call) = &expr.kind else {
@@ -850,7 +846,7 @@ fn offset_from_base_expr(
     }
     let offset = offset_index_arg_expr(name, &call.args[0]);
     if let Some(base_index_name) = base_current_index_expr(rewrite) {
-        IndexExpr::Plain(add_usize_index_expr(base_index_name, &offset))
+        IndexExpr::Plain(add_index_expr(base_index_name, &offset))
     } else {
         IndexExpr::Plain(offset)
     }
@@ -920,7 +916,7 @@ fn base_assignment_index_expr(
         || receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, base_rewrite.base_hir_id)
     {
         let offset = offset_index_arg_expr(name, &call.args[0]);
-        return IndexExpr::Plain(add_usize_index_expr(&base_rewrite.index_name, &offset));
+        return IndexExpr::Plain(add_index_expr(&base_rewrite.index_name, &offset));
     }
     if let Some(rewrite) = receiver_hir_id.and_then(|hir_id| planned_rewrites.get(&hir_id))
         && rewrite.base_hir_id == base_rewrite.base_hir_id
@@ -959,9 +955,9 @@ fn idx_read_expr(rewrite: &BindingRewrite) -> String {
 
 fn base_offset_expr_for_parts(base_name: &str, base_is_raw_ptr: bool, index_expr: &str) -> String {
     if base_is_raw_ptr {
-        format!("({base_name}).offset({index_expr} as isize)")
+        format!("({base_name}).offset({index_expr})")
     } else {
-        format!("({base_name}).as_ptr().offset({index_expr} as isize)")
+        format!("({base_name}).as_ptr().offset({index_expr})")
     }
 }
 
@@ -1039,7 +1035,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                 for rewrite in cursors.into_iter().rev() {
                     stmts.insert(
                         0,
-                        utils::stmt!("let mut {}: usize = 0usize;", rewrite.index_name),
+                        utils::stmt!("let mut {}: isize = 0isize;", rewrite.index_name),
                     );
                 }
                 self.changed = true;

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -1,0 +1,1244 @@
+use points_to::andersen;
+use rustc_ast::{
+    mut_visit::{self, MutVisitor},
+    ptr::P,
+    visit::{self, Visitor as AstVisitor},
+    *,
+};
+use rustc_ast_pretty::pprust;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{
+    self as hir, HirId, def::Res, def_id::LocalDefId, intravisit::Visitor as HirVisitor,
+};
+use rustc_middle::{
+    mir::Local,
+    ty::{self, TyCtxt},
+};
+use rustc_span::Symbol;
+use utils::{
+    ast::{unwrap_cast_and_paren, unwrap_paren},
+    ir::AstToHir,
+};
+
+use crate::{
+    analyses::{
+        self,
+        array_local_provenance::{
+            ArrayLocalProvenance, PfgNode, RewriteGroup, RewriteSelectionContext,
+        },
+        type_qualifier::foster::mutability::MutabilityResult,
+    },
+    utils::rustc::RustProgram,
+};
+
+#[derive(Clone, Debug)]
+struct BindingRewrite {
+    source_hir_id: HirId,
+    index_name: String,
+    base_hir_id: HirId,
+    base_name: String,
+    base_index_name: Option<String>,
+    base_is_raw_ptr: bool,
+    nullable: bool,
+    ptr_ty: String,
+    ptr_mut: bool,
+}
+
+#[derive(Clone, Debug)]
+struct BaseCursorRewrite {
+    fn_def_id: LocalDefId,
+    base_hir_id: HirId,
+    base_name: String,
+    index_name: String,
+    base_is_raw_ptr: bool,
+    ptr_ty: String,
+}
+
+#[derive(Default)]
+struct RewritePlan {
+    by_hir_id: FxHashMap<HirId, BindingRewrite>,
+    base_by_hir_id: FxHashMap<HirId, BaseCursorRewrite>,
+    index_names_by_fn: FxHashMap<LocalDefId, FxHashSet<String>>,
+}
+
+pub(crate) fn apply_array_local_index_rewrite<'tcx>(
+    krate: &mut Crate,
+    input: &RustProgram<'tcx>,
+    provenances: &FxHashMap<LocalDefId, ArrayLocalProvenance>,
+    mutability_result: &MutabilityResult,
+    nullity_result: &analyses::nullity::NullityResult,
+    points_to: &andersen::AnalysisResult,
+    ast_to_hir: &AstToHir,
+) -> bool {
+    let mut plan = build_rewrite_plan(
+        input,
+        provenances,
+        mutability_result,
+        nullity_result,
+        points_to,
+    );
+    refine_base_pointer_kinds_from_ast(krate, ast_to_hir, input.tcx, &mut plan);
+    prune_unsupported_direct_place_uses(krate, ast_to_hir, input.tcx, &mut plan);
+    if plan.by_hir_id.is_empty() {
+        return false;
+    }
+
+    let mut visitor = ArrayLocalIndexRewriteVisitor {
+        tcx: input.tcx,
+        ast_to_hir,
+        plan,
+        introduced_hir_ids: FxHashSet::default(),
+        changed: false,
+    };
+    visitor.visit_crate(krate);
+    visitor.changed
+}
+
+fn build_rewrite_plan<'tcx>(
+    input: &RustProgram<'tcx>,
+    provenances: &FxHashMap<LocalDefId, ArrayLocalProvenance>,
+    mutability_result: &MutabilityResult,
+    nullity_result: &analyses::nullity::NullityResult,
+    points_to: &andersen::AnalysisResult,
+) -> RewritePlan {
+    let mut plan = RewritePlan::default();
+    for &def_id in &input.functions {
+        let Some(provenance) = provenances.get(&def_id) else {
+            continue;
+        };
+        let body = input
+            .tcx
+            .mir_drops_elaborated_and_const_checked(def_id)
+            .borrow();
+        let groups = analyses::array_local_provenance::select_rewrite_groups(
+            provenance,
+            &body,
+            mutability_result,
+            def_id,
+            RewriteSelectionContext {
+                tcx: input.tcx,
+                points_to,
+            },
+        );
+        if groups.is_empty() {
+            continue;
+        }
+
+        let hir_to_mir = utils::ir::map_thir_to_mir(def_id, false, input.tcx);
+        let local_to_hir: FxHashMap<Local, HirId> = hir_to_mir
+            .binding_to_local
+            .iter()
+            .map(|(hir_id, local)| (*local, *hir_id))
+            .collect();
+        let mut existing_names = binding_names_in_body(input.tcx, def_id);
+
+        for group in groups {
+            let mut context = GroupPlanContext {
+                tcx: input.tcx,
+                def_id,
+                body: &body,
+                provenance,
+                nullity_result,
+                local_to_hir: &local_to_hir,
+                existing_names: &mut existing_names,
+                plan: &mut plan,
+            };
+            add_group_to_plan(&mut context, &group);
+        }
+    }
+    plan
+}
+
+fn refine_base_pointer_kinds_from_ast(
+    krate: &Crate,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    plan: &mut RewritePlan,
+) {
+    if plan.by_hir_id.is_empty() {
+        return;
+    }
+    let base_hir_ids = plan
+        .by_hir_id
+        .values()
+        .map(|rewrite| rewrite.base_hir_id)
+        .chain(plan.base_by_hir_id.keys().copied())
+        .collect();
+    let base_names = plan
+        .by_hir_id
+        .values()
+        .map(|rewrite| rewrite.base_name.clone())
+        .chain(
+            plan.base_by_hir_id
+                .values()
+                .map(|rewrite| rewrite.base_name.clone()),
+        )
+        .collect();
+    let mut visitor = BaseBindingTypeVisitor {
+        ast_to_hir,
+        tcx,
+        base_hir_ids,
+        base_names,
+        base_is_raw_ptr_by_hir_id: FxHashMap::default(),
+        base_is_raw_ptr_by_name: FxHashMap::default(),
+    };
+    visitor.visit_crate(krate);
+    for rewrite in plan.by_hir_id.values_mut() {
+        if let Some(&base_is_raw_ptr) = visitor.base_is_raw_ptr_by_hir_id.get(&rewrite.base_hir_id)
+        {
+            rewrite.base_is_raw_ptr = base_is_raw_ptr;
+        } else if let Some(Some(base_is_raw_ptr)) =
+            visitor.base_is_raw_ptr_by_name.get(&rewrite.base_name)
+        {
+            rewrite.base_is_raw_ptr = *base_is_raw_ptr;
+        }
+    }
+    for rewrite in plan.base_by_hir_id.values_mut() {
+        if let Some(&base_is_raw_ptr) = visitor.base_is_raw_ptr_by_hir_id.get(&rewrite.base_hir_id)
+        {
+            rewrite.base_is_raw_ptr = base_is_raw_ptr;
+        } else if let Some(Some(base_is_raw_ptr)) =
+            visitor.base_is_raw_ptr_by_name.get(&rewrite.base_name)
+        {
+            rewrite.base_is_raw_ptr = *base_is_raw_ptr;
+        }
+    }
+}
+
+struct BaseBindingTypeVisitor<'a, 'tcx> {
+    ast_to_hir: &'a AstToHir,
+    tcx: TyCtxt<'tcx>,
+    base_hir_ids: FxHashSet<HirId>,
+    base_names: FxHashSet<String>,
+    base_is_raw_ptr_by_hir_id: FxHashMap<HirId, bool>,
+    base_is_raw_ptr_by_name: FxHashMap<String, Option<bool>>,
+}
+
+impl AstVisitor<'_> for BaseBindingTypeVisitor<'_, '_> {
+    fn visit_param(&mut self, param: &Param) {
+        self.record_ast_pat_type_by_name(&param.pat, &param.ty);
+        if let Some(hir_id) = self.param_binding_hir_id(param)
+            && self.base_hir_ids.contains(&hir_id)
+        {
+            self.base_is_raw_ptr_by_hir_id
+                .insert(hir_id, ast_ty_is_raw_ptr(&param.ty));
+        }
+        visit::walk_param(self, param);
+    }
+
+    fn visit_local(&mut self, local: &rustc_ast::Local) {
+        if let Some(ty) = &local.ty {
+            self.record_ast_pat_type_by_name(&local.pat, ty);
+        }
+        if let Some(hir_id) = self.local_binding_hir_id(local)
+            && self.base_hir_ids.contains(&hir_id)
+            && let Some(ty) = &local.ty
+        {
+            self.base_is_raw_ptr_by_hir_id
+                .insert(hir_id, ast_ty_is_raw_ptr(ty));
+        }
+        visit::walk_local(self, local);
+    }
+}
+
+impl BaseBindingTypeVisitor<'_, '_> {
+    fn record_ast_pat_type_by_name(&mut self, pat: &Pat, ty: &Ty) {
+        let PatKind::Ident(_, ident, _) = &pat.kind else {
+            return;
+        };
+        let name = ident.name.to_string();
+        if !self.base_names.contains(&name) {
+            return;
+        }
+        let is_raw_ptr = ast_ty_is_raw_ptr(ty);
+        self.base_is_raw_ptr_by_name
+            .entry(name)
+            .and_modify(|existing| {
+                if *existing != Some(is_raw_ptr) {
+                    *existing = None;
+                }
+            })
+            .or_insert(Some(is_raw_ptr));
+    }
+
+    fn param_binding_hir_id(&self, param: &Param) -> Option<HirId> {
+        let hir_param = self.ast_to_hir.get_param(param.id, self.tcx)?;
+        let hir::PatKind::Binding(_, hir_id, _, _) = hir_param.pat.kind else {
+            return None;
+        };
+        Some(hir_id)
+    }
+
+    fn local_binding_hir_id(&self, local: &rustc_ast::Local) -> Option<HirId> {
+        let let_stmt = self.ast_to_hir.get_let_stmt(local.id, self.tcx)?;
+        let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind else {
+            return None;
+        };
+        Some(hir_id)
+    }
+}
+
+fn ast_ty_is_raw_ptr(ty: &Ty) -> bool {
+    match &ty.kind {
+        TyKind::Ptr(_) => true,
+        TyKind::Paren(inner) => ast_ty_is_raw_ptr(inner),
+        _ => false,
+    }
+}
+
+fn binding_names_in_body(tcx: TyCtxt<'_>, def_id: LocalDefId) -> FxHashSet<String> {
+    struct NameVisitor {
+        names: FxHashSet<String>,
+    }
+    impl<'tcx> hir::intravisit::Visitor<'tcx> for NameVisitor {
+        fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
+            if let hir::PatKind::Binding(_, _, ident, _) = pat.kind {
+                self.names.insert(ident.name.to_string());
+            }
+            hir::intravisit::walk_pat(self, pat);
+        }
+    }
+
+    let mut visitor = NameVisitor {
+        names: FxHashSet::default(),
+    };
+    visitor.visit_body(tcx.hir_body_owned_by(def_id));
+    visitor.names
+}
+
+struct GroupPlanContext<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+    body: &'a rustc_middle::mir::Body<'tcx>,
+    provenance: &'a ArrayLocalProvenance,
+    nullity_result: &'a analyses::nullity::NullityResult,
+    local_to_hir: &'a FxHashMap<Local, HirId>,
+    existing_names: &'a mut FxHashSet<String>,
+    plan: &'a mut RewritePlan,
+}
+
+fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGroup) {
+    if group.base_slot_offset != 0 {
+        return;
+    }
+    let Some(&base_hir_id) = context.local_to_hir.get(&group.base_local) else {
+        return;
+    };
+    let base_name = context.tcx.hir_name(base_hir_id).to_string();
+    let base_is_raw_ptr = matches!(
+        context.body.local_decls[group.base_local].ty.kind(),
+        ty::TyKind::RawPtr(..)
+    );
+    let base_index_name = if group.index_tracked {
+        if let Some(rewrite) = context.plan.base_by_hir_id.get(&base_hir_id) {
+            Some(rewrite.index_name.clone())
+        } else {
+            let ty::TyKind::RawPtr(pointee, mutability) =
+                context.body.local_decls[group.base_local].ty.kind()
+            else {
+                return;
+            };
+            let index_name = fresh_index_name(&base_name, context.existing_names);
+            let pointee = utils::ir::mir_ty_to_string(*pointee, context.tcx);
+            let ptr_ty = format!(
+                "*{} {}",
+                if mutability.is_mut() { "mut" } else { "const" },
+                pointee
+            );
+            context
+                .plan
+                .index_names_by_fn
+                .entry(context.def_id)
+                .or_default()
+                .insert(index_name.clone());
+            context.plan.base_by_hir_id.insert(
+                base_hir_id,
+                BaseCursorRewrite {
+                    fn_def_id: context.def_id,
+                    base_hir_id,
+                    base_name: base_name.clone(),
+                    index_name: index_name.clone(),
+                    base_is_raw_ptr,
+                    ptr_ty,
+                },
+            );
+            Some(index_name)
+        }
+    } else {
+        None
+    };
+    let non_null = context.nullity_result.non_null_locals.get(&context.def_id);
+
+    for &slot_idx in &group.members {
+        let Some(info) = context.provenance.slot_table.slot_infos.get(slot_idx) else {
+            continue;
+        };
+        if info.root == group.base_local || !info.path.is_empty() {
+            continue;
+        }
+        let Some(&source_hir_id) = context.local_to_hir.get(&info.root) else {
+            continue;
+        };
+        if context.plan.by_hir_id.contains_key(&source_hir_id) {
+            continue;
+        }
+        let source_name = context.tcx.hir_name(source_hir_id).to_string();
+        let ptr_ty = context.body.local_decls[info.root].ty;
+        let ty::TyKind::RawPtr(pointee, mutability) = ptr_ty.kind() else {
+            continue;
+        };
+        let index_name = fresh_index_name(&source_name, context.existing_names);
+        let pointee = utils::ir::mir_ty_to_string(*pointee, context.tcx);
+        let ptr_ty = format!(
+            "*{} {}",
+            if mutability.is_mut() { "mut" } else { "const" },
+            pointee
+        );
+        let nullable = context
+            .provenance
+            .provenance
+            .unique_base(&PfgNode::Slot(slot_idx))
+            .is_none()
+            && !non_null.is_some_and(|set| set.contains(info.root));
+        context
+            .plan
+            .index_names_by_fn
+            .entry(context.def_id)
+            .or_default()
+            .insert(index_name.clone());
+        context.plan.by_hir_id.insert(
+            source_hir_id,
+            BindingRewrite {
+                source_hir_id,
+                index_name,
+                base_hir_id,
+                base_name: base_name.clone(),
+                base_index_name: base_index_name.clone(),
+                base_is_raw_ptr,
+                nullable,
+                ptr_ty,
+                ptr_mut: mutability.is_mut(),
+            },
+        );
+    }
+}
+
+fn fresh_index_name(source_name: &str, existing_names: &mut FxHashSet<String>) -> String {
+    let mut candidate = format!("{source_name}_idx");
+    let mut suffix = 1usize;
+    while existing_names.contains(&candidate) {
+        candidate = format!("{source_name}_idx_{suffix}");
+        suffix += 1;
+    }
+    existing_names.insert(candidate.clone());
+    candidate
+}
+
+fn prune_unsupported_direct_place_uses(
+    krate: &Crate,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    plan: &mut RewritePlan,
+) {
+    if plan.by_hir_id.is_empty() {
+        return;
+    }
+
+    let mut visitor = UnsupportedDirectPlaceUseVisitor {
+        ast_to_hir,
+        tcx,
+        planned_rewrites: plan.by_hir_id.clone(),
+        base_rewrites: plan.base_by_hir_id.clone(),
+        unsupported_hir_ids: FxHashSet::default(),
+    };
+    visitor.visit_crate(krate);
+    if !visitor.unsupported_hir_ids.is_empty() {
+        plan.by_hir_id
+            .retain(|hir_id, _| !visitor.unsupported_hir_ids.contains(hir_id));
+    }
+    prune_orphan_base_cursors(plan);
+}
+
+fn prune_orphan_base_cursors(plan: &mut RewritePlan) {
+    let live_base_hir_ids = plan
+        .by_hir_id
+        .values()
+        .filter(|rewrite| rewrite.base_index_name.is_some())
+        .map(|rewrite| rewrite.base_hir_id)
+        .collect::<FxHashSet<_>>();
+    plan.base_by_hir_id
+        .retain(|base_hir_id, _| live_base_hir_ids.contains(base_hir_id));
+}
+
+struct UnsupportedDirectPlaceUseVisitor<'a, 'tcx> {
+    ast_to_hir: &'a AstToHir,
+    tcx: TyCtxt<'tcx>,
+    planned_rewrites: FxHashMap<HirId, BindingRewrite>,
+    base_rewrites: FxHashMap<HirId, BaseCursorRewrite>,
+    unsupported_hir_ids: FxHashSet<HirId>,
+}
+
+impl AstVisitor<'_> for UnsupportedDirectPlaceUseVisitor<'_, '_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        match &expr.kind {
+            ExprKind::Assign(lhs, rhs, _) => {
+                self.check_assignment(lhs, rhs);
+                self.visit_expr(rhs);
+            }
+            ExprKind::AssignOp(_, lhs, rhs) => {
+                if self.mark_direct_base_cursor(lhs).is_none()
+                    && self.mark_direct_planned_local(lhs).is_none()
+                {
+                    self.visit_expr(lhs);
+                }
+                self.visit_expr(rhs);
+            }
+            ExprKind::AddrOf(_, _, inner) => {
+                if self.mark_direct_base_cursor(inner).is_none()
+                    && self.mark_direct_planned_local(inner).is_none()
+                {
+                    self.visit_expr(inner);
+                }
+            }
+            _ => visit::walk_expr(self, expr),
+        }
+    }
+}
+
+impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
+    fn check_assignment(&mut self, lhs: &Expr, rhs: &Expr) {
+        if let Some(base_hir_id) = direct_local_hir_id(self.ast_to_hir, self.tcx, lhs) {
+            if let Some(base_rewrite) = self.base_rewrites.get(&base_hir_id) {
+                let index = base_assignment_index_expr(
+                    rhs,
+                    self.ast_to_hir,
+                    self.tcx,
+                    &self.planned_rewrites,
+                    base_rewrite,
+                );
+                let unsupported = matches!(index, IndexExpr::Null | IndexExpr::Unsupported)
+                    || base_assignment_index_arg_contains_planned_local(
+                        rhs,
+                        self.ast_to_hir,
+                        self.tcx,
+                        &self.planned_rewrites,
+                        base_rewrite,
+                    );
+                if unsupported {
+                    self.mark_rewrites_for_base_unsupported(base_hir_id);
+                }
+                return;
+            } else {
+                self.mark_rewrites_for_base_unsupported(base_hir_id);
+            }
+        }
+
+        let Some(hir_id) =
+            direct_planned_local_hir_id(self.ast_to_hir, self.tcx, &self.planned_rewrites, lhs)
+        else {
+            self.visit_expr(lhs);
+            return;
+        };
+        let Some(rewrite) = self.planned_rewrites.get(&hir_id) else {
+            return;
+        };
+        let index = assignment_index_expr(rhs, self.ast_to_hir, self.tcx, rewrite);
+        if index_init_expr(index, rewrite.nullable).is_none()
+            || assignment_index_arg_contains_planned_local(
+                rhs,
+                self.ast_to_hir,
+                self.tcx,
+                &self.planned_rewrites,
+                rewrite,
+            )
+        {
+            self.unsupported_hir_ids.insert(hir_id);
+        }
+    }
+
+    fn mark_rewrites_for_base_unsupported(&mut self, base_hir_id: HirId) {
+        for rewrite in self.planned_rewrites.values() {
+            if rewrite.base_hir_id == base_hir_id {
+                self.unsupported_hir_ids.insert(rewrite.source_hir_id);
+            }
+        }
+    }
+
+    fn mark_direct_base_cursor(&mut self, expr: &Expr) -> Option<HirId> {
+        let hir_id = direct_local_hir_id(self.ast_to_hir, self.tcx, expr)?;
+        if self.base_rewrites.contains_key(&hir_id) {
+            self.mark_rewrites_for_base_unsupported(hir_id);
+            Some(hir_id)
+        } else {
+            None
+        }
+    }
+
+    fn mark_direct_planned_local(&mut self, expr: &Expr) -> Option<HirId> {
+        let hir_id =
+            direct_planned_local_hir_id(self.ast_to_hir, self.tcx, &self.planned_rewrites, expr)?;
+        if self.planned_rewrites.contains_key(&hir_id) {
+            self.unsupported_hir_ids.insert(hir_id);
+            Some(hir_id)
+        } else {
+            None
+        }
+    }
+}
+
+struct PlannedLocalUseVisitor<'a, 'tcx> {
+    ast_to_hir: &'a AstToHir,
+    tcx: TyCtxt<'tcx>,
+    planned_rewrites: &'a FxHashMap<HirId, BindingRewrite>,
+    found: bool,
+}
+
+impl AstVisitor<'_> for PlannedLocalUseVisitor<'_, '_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        if self.found {
+            return;
+        }
+        if direct_planned_local_hir_id(self.ast_to_hir, self.tcx, self.planned_rewrites, expr)
+            .is_some()
+        {
+            self.found = true;
+            return;
+        }
+        visit::walk_expr(self, expr);
+    }
+}
+
+fn contains_planned_local_use(
+    expr: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+) -> bool {
+    let mut visitor = PlannedLocalUseVisitor {
+        ast_to_hir,
+        tcx,
+        planned_rewrites,
+        found: false,
+    };
+    visitor.visit_expr(expr);
+    visitor.found
+}
+
+fn assignment_index_arg_contains_planned_local(
+    rhs: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+    rewrite: &BindingRewrite,
+) -> bool {
+    let rhs = unwrap_paren(rhs);
+    let ExprKind::MethodCall(call) = &rhs.kind else {
+        return false;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return false;
+    }
+    let receiver = unwrap_cast_and_paren(&call.receiver);
+    let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
+    let receiver_is_base = receiver_hir_id == Some(rewrite.base_hir_id)
+        || receiver_is_base_as_ptr(receiver, ast_to_hir, tcx, rewrite);
+    if !receiver_is_base && receiver_hir_id != Some(rewrite.source_hir_id) {
+        return false;
+    }
+    contains_planned_local_use(&call.args[0], ast_to_hir, tcx, planned_rewrites)
+}
+
+fn base_assignment_index_arg_contains_planned_local(
+    rhs: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+    base_rewrite: &BaseCursorRewrite,
+) -> bool {
+    let rhs = unwrap_paren(rhs);
+    let ExprKind::MethodCall(call) = &rhs.kind else {
+        return false;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return false;
+    }
+    let receiver = unwrap_cast_and_paren(&call.receiver);
+    let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
+    let receiver_is_base = receiver_hir_id == Some(base_rewrite.base_hir_id)
+        || receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, base_rewrite.base_hir_id);
+    if !receiver_is_base
+        && !receiver_hir_id.is_some_and(|hir_id| {
+            planned_rewrites
+                .get(&hir_id)
+                .is_some_and(|rewrite| rewrite.base_hir_id == base_rewrite.base_hir_id)
+        })
+    {
+        return false;
+    }
+    contains_planned_local_use(&call.args[0], ast_to_hir, tcx, planned_rewrites)
+}
+
+fn direct_planned_local_hir_id(
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+    expr: &Expr,
+) -> Option<HirId> {
+    let hir_id = direct_local_hir_id(ast_to_hir, tcx, expr)?;
+    planned_rewrites.contains_key(&hir_id).then_some(hir_id)
+}
+
+fn direct_base_cursor_hir_id(
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    base_rewrites: &FxHashMap<HirId, BaseCursorRewrite>,
+    expr: &Expr,
+) -> Option<HirId> {
+    let hir_id = direct_local_hir_id(ast_to_hir, tcx, expr)?;
+    base_rewrites.contains_key(&hir_id).then_some(hir_id)
+}
+
+fn direct_local_hir_id(ast_to_hir: &AstToHir, tcx: TyCtxt<'_>, expr: &Expr) -> Option<HirId> {
+    hir_id_of_ast_expr(ast_to_hir, tcx, unwrap_paren(expr).id)
+}
+
+#[derive(Clone)]
+enum IndexExpr {
+    Plain(Expr),
+    Null,
+    Unsupported,
+}
+
+fn hir_id_of_ast_expr(ast_to_hir: &AstToHir, tcx: TyCtxt<'_>, node_id: NodeId) -> Option<HirId> {
+    let hir_expr = ast_to_hir.get_expr(node_id, tcx)?;
+    let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_expr.kind else {
+        return None;
+    };
+    let Res::Local(hir_id) = path.res else {
+        return None;
+    };
+    Some(hir_id)
+}
+
+fn rewrite_binding_pat(pat: &mut Pat, index_name: &str) -> bool {
+    let PatKind::Ident(_, ident, _) = &mut pat.kind else {
+        return false;
+    };
+    ident.name = Symbol::intern(index_name);
+    true
+}
+
+fn index_ty(nullable: bool) -> P<Ty> {
+    if nullable {
+        P(utils::ty!("Option<usize>"))
+    } else {
+        P(utils::ty!("usize"))
+    }
+}
+
+fn is_null_expr(expr: &Expr) -> bool {
+    let expr = unwrap_cast_and_paren(expr);
+    match &expr.kind {
+        ExprKind::Call(callee, _) => {
+            let ExprKind::Path(_, path) = &unwrap_cast_and_paren(callee).kind else {
+                return false;
+            };
+            let segments = path
+                .segments
+                .iter()
+                .map(|seg| seg.ident.name.as_str())
+                .collect::<Vec<_>>();
+            matches!(
+                segments.as_slice(),
+                ["std", "ptr", "null" | "null_mut"] | ["core", "ptr", "null" | "null_mut"]
+            )
+        }
+        ExprKind::Lit(lit) => lit.kind == token::LitKind::Integer && lit.symbol.as_str() == "0",
+        _ => false,
+    }
+}
+
+fn offset_index_arg_expr(_name: &str, arg: &Expr) -> Expr {
+    utils::expr!("({}) as usize", pprust::expr_to_string(arg))
+}
+
+fn add_usize_index_expr(current: &str, offset: &Expr) -> Expr {
+    utils::expr!(
+        "(({}) as isize + ({}) as isize) as usize",
+        current,
+        pprust::expr_to_string(offset)
+    )
+}
+
+fn relative_index_expr(current: &str, method_name: &str, arg: &Expr) -> Expr {
+    let delta = if method_name == "add" {
+        format!("({}) as isize", pprust::expr_to_string(arg))
+    } else {
+        pprust::expr_to_string(arg)
+    };
+    utils::expr!("(({}) as isize + ({})) as usize", current, delta)
+}
+
+fn base_current_index_expr(rewrite: &BindingRewrite) -> Option<&str> {
+    rewrite.base_index_name.as_deref()
+}
+
+fn receiver_is_base_as_ptr_hir(
+    receiver: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    base_hir_id: HirId,
+) -> bool {
+    let ExprKind::MethodCall(call) = &receiver.kind else {
+        return false;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "as_ptr" | "as_mut_ptr") || !call.args.is_empty() {
+        return false;
+    }
+    hir_id_of_ast_expr(ast_to_hir, tcx, unwrap_cast_and_paren(&call.receiver).id)
+        == Some(base_hir_id)
+}
+
+fn receiver_is_base_as_ptr(
+    receiver: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    rewrite: &BindingRewrite,
+) -> bool {
+    receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, rewrite.base_hir_id)
+}
+
+fn receiver_is_base_pointer_expr(
+    receiver: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    rewrite: &BindingRewrite,
+) -> bool {
+    hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) == Some(rewrite.base_hir_id)
+        || receiver_is_base_as_ptr(receiver, ast_to_hir, tcx, rewrite)
+}
+
+fn offset_from_base_expr(
+    expr: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    rewrite: &BindingRewrite,
+) -> IndexExpr {
+    if is_null_expr(expr) {
+        return IndexExpr::Null;
+    }
+    let expr = unwrap_cast_and_paren(expr);
+    if hir_id_of_ast_expr(ast_to_hir, tcx, expr.id) == Some(rewrite.base_hir_id) {
+        return IndexExpr::Plain(match base_current_index_expr(rewrite) {
+            Some(base_index_name) => utils::expr!("{}", base_index_name),
+            None => utils::expr!("0usize"),
+        });
+    }
+    let ExprKind::MethodCall(call) = &expr.kind else {
+        return IndexExpr::Unsupported;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return IndexExpr::Unsupported;
+    }
+    let receiver = unwrap_cast_and_paren(&call.receiver);
+    if !receiver_is_base_pointer_expr(receiver, ast_to_hir, tcx, rewrite) {
+        return IndexExpr::Unsupported;
+    }
+    let offset = offset_index_arg_expr(name, &call.args[0]);
+    if let Some(base_index_name) = base_current_index_expr(rewrite) {
+        IndexExpr::Plain(add_usize_index_expr(base_index_name, &offset))
+    } else {
+        IndexExpr::Plain(offset)
+    }
+}
+
+fn assignment_index_expr(
+    rhs: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    rewrite: &BindingRewrite,
+) -> IndexExpr {
+    match offset_from_base_expr(rhs, ast_to_hir, tcx, rewrite) {
+        IndexExpr::Unsupported => {}
+        index => return index,
+    }
+
+    let rhs = unwrap_paren(rhs);
+    let ExprKind::MethodCall(call) = &rhs.kind else {
+        return IndexExpr::Unsupported;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return IndexExpr::Unsupported;
+    }
+    let receiver = unwrap_paren(&call.receiver);
+    if hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) != Some(rewrite.source_hir_id) {
+        return IndexExpr::Unsupported;
+    }
+    IndexExpr::Plain(relative_index_expr(
+        &idx_read_expr(rewrite),
+        name,
+        &call.args[0],
+    ))
+}
+
+fn base_assignment_index_expr(
+    rhs: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+    base_rewrite: &BaseCursorRewrite,
+) -> IndexExpr {
+    if is_null_expr(rhs) {
+        return IndexExpr::Null;
+    }
+    let rhs = unwrap_cast_and_paren(rhs);
+    if hir_id_of_ast_expr(ast_to_hir, tcx, rhs.id) == Some(base_rewrite.base_hir_id) {
+        return IndexExpr::Plain(utils::expr!("{}", base_rewrite.index_name));
+    }
+    if let Some(rewrite) = direct_planned_local_hir_id(ast_to_hir, tcx, planned_rewrites, rhs)
+        .and_then(|hir_id| planned_rewrites.get(&hir_id))
+        && rewrite.base_hir_id == base_rewrite.base_hir_id
+    {
+        return IndexExpr::Plain(utils::expr!("{}", idx_read_expr(rewrite)));
+    }
+
+    let ExprKind::MethodCall(call) = &rhs.kind else {
+        return IndexExpr::Unsupported;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return IndexExpr::Unsupported;
+    }
+    let receiver = unwrap_cast_and_paren(&call.receiver);
+    let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
+    if receiver_hir_id == Some(base_rewrite.base_hir_id)
+        || receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, base_rewrite.base_hir_id)
+    {
+        let offset = offset_index_arg_expr(name, &call.args[0]);
+        return IndexExpr::Plain(add_usize_index_expr(&base_rewrite.index_name, &offset));
+    }
+    if let Some(rewrite) = receiver_hir_id.and_then(|hir_id| planned_rewrites.get(&hir_id))
+        && rewrite.base_hir_id == base_rewrite.base_hir_id
+    {
+        return IndexExpr::Plain(relative_index_expr(
+            &idx_read_expr(rewrite),
+            name,
+            &call.args[0],
+        ));
+    }
+    IndexExpr::Unsupported
+}
+
+fn index_init_expr(index: IndexExpr, nullable: bool) -> Option<Expr> {
+    match (index, nullable) {
+        (IndexExpr::Plain(expr), false) => Some(expr),
+        (IndexExpr::Plain(expr), true) => {
+            Some(utils::expr!("Some({})", pprust::expr_to_string(&expr)))
+        }
+        (IndexExpr::Null, true) => Some(utils::expr!("None")),
+        (IndexExpr::Null, false) | (IndexExpr::Unsupported, _) => None,
+    }
+}
+
+fn index_assignment_rhs_expr(index: IndexExpr, nullable: bool) -> Option<Expr> {
+    index_init_expr(index, nullable)
+}
+
+fn idx_read_expr(rewrite: &BindingRewrite) -> String {
+    if rewrite.nullable {
+        format!("{}.unwrap()", rewrite.index_name)
+    } else {
+        rewrite.index_name.clone()
+    }
+}
+
+fn base_offset_expr_for_parts(base_name: &str, base_is_raw_ptr: bool, index_expr: &str) -> String {
+    if base_is_raw_ptr {
+        format!("({base_name}).offset({index_expr} as isize)")
+    } else {
+        format!("({base_name}).as_ptr().offset({index_expr} as isize)")
+    }
+}
+
+fn base_offset_expr_for_index(rewrite: &BindingRewrite, index_expr: &str) -> String {
+    base_offset_expr_for_parts(&rewrite.base_name, rewrite.base_is_raw_ptr, index_expr)
+}
+
+fn pointer_expr_for_index(rewrite: &BindingRewrite) -> Expr {
+    let base_offset = base_offset_expr_for_index(rewrite, &idx_read_expr(rewrite));
+    utils::expr!("{} as {}", base_offset, rewrite.ptr_ty)
+}
+
+fn pointer_value_expr(rewrite: &BindingRewrite) -> Expr {
+    if rewrite.nullable {
+        let null_fn = if rewrite.ptr_mut {
+            "std::ptr::null_mut()"
+        } else {
+            "std::ptr::null()"
+        };
+        utils::expr!(
+            "{}.map_or({} as {}, |idx| ({}) as {})",
+            rewrite.index_name,
+            null_fn,
+            rewrite.ptr_ty,
+            base_offset_expr_for_index(rewrite, "idx"),
+            rewrite.ptr_ty
+        )
+    } else {
+        pointer_expr_for_index(rewrite)
+    }
+}
+
+fn base_cursor_pointer_expr(rewrite: &BaseCursorRewrite) -> Expr {
+    let base_offset = base_offset_expr_for_parts(
+        &rewrite.base_name,
+        rewrite.base_is_raw_ptr,
+        &rewrite.index_name,
+    );
+    utils::expr!("{} as {}", base_offset, rewrite.ptr_ty)
+}
+
+fn introduced_planned_local_hir_id(
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    introduced_hir_ids: &FxHashSet<HirId>,
+    expr: &Expr,
+) -> Option<HirId> {
+    let hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, unwrap_cast_and_paren(expr).id)?;
+    introduced_hir_ids.contains(&hir_id).then_some(hir_id)
+}
+
+struct ArrayLocalIndexRewriteVisitor<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    ast_to_hir: &'a AstToHir,
+    plan: RewritePlan,
+    introduced_hir_ids: FxHashSet<HirId>,
+    changed: bool,
+}
+
+impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
+    fn visit_item(&mut self, item: &mut Item) {
+        if let ItemKind::Fn(box fn_item) = &mut item.kind
+            && let Some(def_id) = self.ast_to_hir.global_map.get(&item.id).copied()
+        {
+            let mut cursors = self
+                .plan
+                .base_by_hir_id
+                .values()
+                .filter(|rewrite| rewrite.fn_def_id == def_id)
+                .cloned()
+                .collect::<Vec<_>>();
+            cursors.sort_by(|a, b| a.index_name.cmp(&b.index_name));
+            if !cursors.is_empty() {
+                let stmts = &mut fn_item.body.as_mut().unwrap().stmts;
+                for rewrite in cursors.into_iter().rev() {
+                    stmts.insert(
+                        0,
+                        utils::stmt!("let mut {}: usize = 0usize;", rewrite.index_name),
+                    );
+                }
+                self.changed = true;
+            }
+        }
+        mut_visit::walk_item(self, item);
+    }
+
+    fn visit_local(&mut self, local: &mut rustc_ast::Local) {
+        let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx) else {
+            mut_visit::walk_local(self, local);
+            return;
+        };
+        let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind else {
+            mut_visit::walk_local(self, local);
+            return;
+        };
+        let Some(rewrite) = self.plan.by_hir_id.get(&hir_id).cloned() else {
+            mut_visit::walk_local(self, local);
+            return;
+        };
+        let Some(init) = local.kind.init_mut() else {
+            mut_visit::walk_local(self, local);
+            return;
+        };
+        let index = offset_from_base_expr(init, self.ast_to_hir, self.tcx, &rewrite);
+        let Some(new_init) = index_init_expr(index, rewrite.nullable) else {
+            mut_visit::walk_local(self, local);
+            return;
+        };
+        if !rewrite_binding_pat(&mut local.pat, &rewrite.index_name) {
+            mut_visit::walk_local(self, local);
+            return;
+        }
+        local.ty = Some(index_ty(rewrite.nullable));
+        *init = P(new_init);
+        self.introduced_hir_ids.insert(hir_id);
+        self.changed = true;
+    }
+
+    fn visit_expr(&mut self, expr: &mut Expr) {
+        match &mut expr.kind {
+            ExprKind::Assign(lhs, rhs, _) => {
+                if let Some(hir_id) = direct_base_cursor_hir_id(
+                    self.ast_to_hir,
+                    self.tcx,
+                    &self.plan.base_by_hir_id,
+                    lhs,
+                ) && let Some(rewrite) = self.plan.base_by_hir_id.get(&hir_id)
+                {
+                    let index = base_assignment_index_expr(
+                        rhs,
+                        self.ast_to_hir,
+                        self.tcx,
+                        &self.plan.by_hir_id,
+                        rewrite,
+                    );
+                    if let IndexExpr::Plain(new_rhs) = index {
+                        *lhs = P(utils::expr!("{}", rewrite.index_name));
+                        *rhs = P(new_rhs);
+                        self.changed = true;
+                    } else {
+                        self.visit_expr(rhs);
+                    }
+                    return;
+                }
+                if let Some(hir_id) = introduced_planned_local_hir_id(
+                    self.ast_to_hir,
+                    self.tcx,
+                    &self.introduced_hir_ids,
+                    lhs,
+                ) && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
+                {
+                    let index = assignment_index_expr(rhs, self.ast_to_hir, self.tcx, rewrite);
+                    if let Some(new_rhs) = index_assignment_rhs_expr(index, rewrite.nullable) {
+                        *lhs = P(utils::expr!("{}", rewrite.index_name));
+                        *rhs = P(new_rhs);
+                        self.changed = true;
+                    } else {
+                        self.visit_expr(rhs);
+                    }
+                } else {
+                    self.visit_expr(lhs);
+                    self.visit_expr(rhs);
+                }
+                return;
+            }
+            ExprKind::AssignOp(_, lhs, rhs) => {
+                if direct_base_cursor_hir_id(
+                    self.ast_to_hir,
+                    self.tcx,
+                    &self.plan.base_by_hir_id,
+                    lhs,
+                )
+                .is_none()
+                    && introduced_planned_local_hir_id(
+                        self.ast_to_hir,
+                        self.tcx,
+                        &self.introduced_hir_ids,
+                        lhs,
+                    )
+                    .is_none()
+                {
+                    self.visit_expr(lhs);
+                }
+                self.visit_expr(rhs);
+                return;
+            }
+            ExprKind::AddrOf(_, _, inner) => {
+                if direct_base_cursor_hir_id(
+                    self.ast_to_hir,
+                    self.tcx,
+                    &self.plan.base_by_hir_id,
+                    inner,
+                )
+                .is_none()
+                    && introduced_planned_local_hir_id(
+                        self.ast_to_hir,
+                        self.tcx,
+                        &self.introduced_hir_ids,
+                        inner,
+                    )
+                    .is_none()
+                {
+                    self.visit_expr(inner);
+                }
+                return;
+            }
+            _ => {}
+        }
+
+        if let ExprKind::MethodCall(call) = &expr.kind {
+            let receiver = unwrap_paren(&call.receiver);
+            if call.seg.ident.name.as_str() == "is_null"
+                && call.args.is_empty()
+                && let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, receiver.id)
+                && self.introduced_hir_ids.contains(&hir_id)
+                && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
+            {
+                *expr = if rewrite.nullable {
+                    utils::expr!("{}.is_none()", rewrite.index_name)
+                } else {
+                    utils::expr!("false")
+                };
+                self.changed = true;
+                return;
+            }
+        }
+
+        if let ExprKind::Unary(UnOp::Deref, inner) = &mut expr.kind
+            && let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, inner.id)
+            && let Some(rewrite) = self.plan.base_by_hir_id.get(&hir_id)
+        {
+            let ptr = base_cursor_pointer_expr(rewrite);
+            *expr = utils::expr!("*({})", pprust::expr_to_string(&ptr));
+            self.changed = true;
+            return;
+        }
+
+        if let ExprKind::Unary(UnOp::Deref, inner) = &mut expr.kind
+            && let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, inner.id)
+            && self.introduced_hir_ids.contains(&hir_id)
+            && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
+        {
+            let ptr = pointer_expr_for_index(rewrite);
+            *expr = utils::expr!("*({})", pprust::expr_to_string(&ptr));
+            self.changed = true;
+            return;
+        }
+
+        mut_visit::walk_expr(self, expr);
+
+        if let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, expr.id)
+            && let Some(rewrite) = self.plan.base_by_hir_id.get(&hir_id)
+        {
+            *expr = base_cursor_pointer_expr(rewrite);
+            self.changed = true;
+            return;
+        }
+
+        if let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, expr.id)
+            && self.introduced_hir_ids.contains(&hir_id)
+            && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
+        {
+            *expr = pointer_value_expr(rewrite);
+            self.changed = true;
+        }
+    }
+}
+
+trait LocalKindInitMut {
+    fn init_mut(&mut self) -> Option<&mut P<Expr>>;
+}
+
+impl LocalKindInitMut for LocalKind {
+    fn init_mut(&mut self) -> Option<&mut P<Expr>> {
+        match self {
+            LocalKind::Init(init) | LocalKind::InitElse(init, _) => Some(init),
+            LocalKind::Decl => None,
+        }
+    }
+}

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -33,10 +33,10 @@ use crate::{
     utils::rustc::RustProgram,
 };
 
+mod array_local_index_rewriter;
 pub(crate) mod collector;
 pub(crate) mod decision;
 mod lifetimes;
-mod array_local_index_rewriter;
 mod struct_array_field_pre;
 mod transform;
 

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -36,6 +36,7 @@ use crate::{
 pub(crate) mod collector;
 pub(crate) mod decision;
 mod lifetimes;
+mod array_local_index_rewriter;
 mod struct_array_field_pre;
 mod transform;
 
@@ -208,6 +209,50 @@ pub fn rewrite_struct_arrays(config: &Config, tcx: TyCtxt<'_>) -> (String, bool)
         &mut krate,
         &candidates,
         tcx,
+        &ast_to_hir,
+    );
+
+    (pprust::crate_to_string_for_macros(&krate), changed)
+}
+
+pub fn rewrite_array_local_provenance(config: &Config, tcx: TyCtxt<'_>) -> (String, bool) {
+    let mut krate = utils::ast::expanded_ast(tcx);
+    let ast_to_hir = utils::ast::make_ast_to_hir(&mut krate, tcx);
+    utils::ast::remove_unnecessary_items_from_ast(&mut krate);
+
+    let input = collect_input(tcx);
+    let arena = typed_arena::Arena::new();
+    let tss = utils::ty_shape::get_ty_shapes(&arena, tcx, false);
+    let andersen_config = andersen::Config {
+        use_optimized_mir: false,
+        c_exposed_fns: config.c_exposed_fns.clone(),
+    };
+    let pre_points_to = andersen::pre_analyze(&andersen_config, &tss, tcx);
+    let alloc_fns = pre_points_to.alloc_fns.clone();
+    let points_to_solutions = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
+    let points_to = andersen::post_analyze(
+        &andersen_config,
+        pre_points_to,
+        points_to_solutions,
+        &tss,
+        tcx,
+    );
+    let mutability_result =
+        analyses::type_qualifier::foster::mutability::mutability_analysis(&input);
+    let source_var_groups = analyses::mir_variable_grouping::SourceVarGroups::new(&input);
+    let mut nullity_result = analyses::nullity::analyze(&input, &points_to);
+    nullity_result.non_null_locals =
+        source_var_groups.postprocess_non_null_locals(nullity_result.non_null_locals);
+    let provenances =
+        analyses::array_local_provenance::array_local_provenance_analysis(&input, &alloc_fns);
+
+    let changed = array_local_index_rewriter::apply_array_local_index_rewrite(
+        &mut krate,
+        &input,
+        &provenances,
+        &mutability_result,
+        &nullity_result,
+        &points_to,
         &ast_to_hir,
     );
 

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -640,6 +640,23 @@ impl MutVisitor for TransformVisitor<'_, '_> {
     }
 
     fn visit_expr(&mut self, expr: &mut Expr) {
+        if let ExprKind::MethodCall(call) = &expr.kind
+            && let ExprKind::Path(_, _) = &unwrap_cast_and_paren(&call.receiver).kind
+            && call.seg.ident.name.as_str() == "offset"
+            && call.args.len() == 1
+        {
+            let hir_expr = self.ast_to_hir.get_expr(expr.id, self.tcx).unwrap();
+            if let hir::ExprKind::MethodCall(_, hir_receiver, _, _) = hir_expr.kind {
+                let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
+                if let Some((_, raw_mut)) =
+                    unwrap_ptr_from_mir_ty(typeck.expr_ty_adjusted(hir_receiver))
+                {
+                    self.transform_ptr(expr, hir_expr, PtrCtx::Rhs(PtrKind::Raw(raw_mut.is_mut())));
+                    return;
+                }
+            }
+        }
+
         mut_visit::walk_expr(self, expr);
 
         match &mut expr.kind {

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -10,7 +10,7 @@ use rustc_ast::{
 use rustc_ast_pretty::pprust;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::{
-    self as hir, HirId,
+    self as hir, HirId, LangItem,
     def::{DefKind, Res},
     def_id::LocalDefId,
     intravisit::{self, Visitor},
@@ -640,24 +640,8 @@ impl MutVisitor for TransformVisitor<'_, '_> {
     }
 
     fn visit_expr(&mut self, expr: &mut Expr) {
-        if let ExprKind::MethodCall(call) = &expr.kind
-            && let ExprKind::Path(_, _) = &unwrap_cast_and_paren(&call.receiver).kind
-            && call.seg.ident.name.as_str() == "offset"
-            && call.args.len() == 1
-        {
-            let hir_expr = self.ast_to_hir.get_expr(expr.id, self.tcx).unwrap();
-            if let hir::ExprKind::MethodCall(_, hir_receiver, _, _) = hir_expr.kind {
-                let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
-                if let Some((_, raw_mut)) =
-                    unwrap_ptr_from_mir_ty(typeck.expr_ty_adjusted(hir_receiver))
-                {
-                    self.transform_ptr(expr, hir_expr, PtrCtx::Rhs(PtrKind::Raw(raw_mut.is_mut())));
-                    return;
-                }
-            }
-        }
-
         mut_visit::walk_expr(self, expr);
+        let expr_id = expr.id;
 
         match &mut expr.kind {
             ExprKind::Field(base, _) => {
@@ -680,6 +664,15 @@ impl MutVisitor for TransformVisitor<'_, '_> {
             }
             ExprKind::Struct(se) => {
                 self.rewrite_struct_literal_fields(expr.id, se);
+            }
+            ExprKind::MethodCall(call)
+                if call.seg.ident.name.as_str() == "map_or" && call.args.len() == 2 =>
+            {
+                if let Some((m, body, hir_body)) =
+                    raw_pointer_map_or_closure_body(self.tcx, &self.ast_to_hir, expr_id, call)
+                {
+                    self.transform_ptr(body, hir_body, PtrCtx::Rhs(PtrKind::Raw(m)));
+                }
             }
             ExprKind::Assign(lhs, rhs, _) => {
                 let hir_expr = self.ast_to_hir.get_expr(expr.id, self.tcx).unwrap();
@@ -9680,6 +9673,48 @@ fn is_cursor_anchor_decision(kind: PtrKind) -> bool {
 
 fn hir_expr_ty_is_raw_ptr(tcx: TyCtxt<'_>, expr: &hir::Expr<'_>) -> bool {
     unwrap_ptr_from_mir_ty(tcx.typeck(expr.hir_id.owner).expr_ty_adjusted(expr)).is_some()
+}
+
+fn raw_pointer_map_or_closure_body<'a, 'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ast_to_hir: &AstToHir,
+    expr_id: NodeId,
+    ast_call: &'a mut MethodCall,
+) -> Option<(bool, &'a mut Expr, &'tcx hir::Expr<'tcx>)> {
+    if ast_call.seg.ident.name.as_str() != "map_or" || ast_call.args.len() != 2 {
+        return None;
+    }
+    let ExprKind::Closure(box ast_closure) = &mut ast_call.args[1].kind else {
+        return None;
+    };
+
+    let hir_expr = ast_to_hir.get_expr(expr_id, tcx)?;
+    let typeck = tcx.typeck(hir_expr.hir_id.owner);
+    let (_, raw_mutability) = unwrap_ptr_from_mir_ty(typeck.expr_ty_adjusted(hir_expr))?;
+
+    let hir::ExprKind::MethodCall(_, hir_receiver, hir_args, _) = hir_expr.kind else {
+        return None;
+    };
+    let ty::TyKind::Adt(adt_def, _) = typeck.expr_ty_adjusted(hir_receiver).kind() else {
+        return None;
+    };
+    if !tcx.is_lang_item(adt_def.did(), LangItem::Option) {
+        return None;
+    }
+    let hir_closure_arg = hir_args.get(1)?;
+    let hir::ExprKind::Closure(hir::Closure { body, .. }) = hir_closure_arg.kind else {
+        return None;
+    };
+    let hir_body = tcx.hir_body(*body);
+    let ty::TyKind::RawPtr(_, _) = typeck.expr_ty(hir_body.value).kind() else {
+        return None;
+    };
+
+    Some((
+        raw_mutability.is_mut(),
+        &mut ast_closure.body,
+        hir_body.value,
+    ))
 }
 
 fn tcx_node_ty_is_raw_ptr(tcx: TyCtxt<'_>, hir_id: HirId) -> bool {

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -7485,10 +7485,7 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
     assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
     assert!(s.contains("let mut q_idx: isize = (3) as isize"), "{s}");
-    assert!(
-        s.contains("*((p).offset(q_idx) as *mut i32) = 3"),
-        "{s}"
-    );
+    assert!(s.contains("*((p).offset(q_idx) as *mut i32) = 3"), "{s}");
     assert!(
         s.matches("*((p).offset(q_idx) as *mut i32)").count() >= 2,
         "{s}"
@@ -7543,10 +7540,7 @@ pub unsafe fn foo(mut p: *mut i32, mut take: bool) -> *mut i32 {
         s.contains("q_idx.map_or(std::ptr::null_mut() as *mut i32"),
         "{s}"
     );
-    assert!(
-        s.contains("|idx| ((p).offset(idx)) as *mut i32"),
-        "{s}"
-    );
+    assert!(s.contains("|idx| ((p).offset(idx)) as *mut i32"), "{s}");
     assert!(!s.contains("let mut q: *mut i32"), "{s}");
 }
 
@@ -7669,10 +7663,7 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
     assert!(s.contains("let mut q_idx: isize = (1) as isize"), "{s}");
     assert!(s.contains("q_idx ="), "{s}");
     assert!(s.contains("(q_idx) + ((2) as isize)"), "{s}");
-    assert!(
-        s.contains("*((p).offset(q_idx) as *mut i32) = 9"),
-        "{s}"
-    );
+    assert!(s.contains("*((p).offset(q_idx) as *mut i32) = 9"), "{s}");
     assert!(!s.contains("q = q.offset"), "{s}");
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -7553,6 +7553,73 @@ pub unsafe fn foo(mut p: *mut i32, mut take: bool) -> *mut i32 {
 }
 
 #[test]
+fn test_array_local_map_or_closure_body_rewrites_slice_base_offset() {
+    let code = r#"
+pub unsafe fn foo(mut raw: *mut i32, mut take: bool, mut k: isize) -> *mut i32 {
+    let mut prev: *mut i32 = std::ptr::null_mut();
+    if take {
+        prev = raw.offset(k);
+    }
+    *raw.offset(0) = 3;
+    prev
+}
+"#;
+    let (s, _) = rewrite_struct_arrays_then_array_local_then_pointer(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("mut raw: &mut [i32]"), "{s}");
+    let compact = s.split_whitespace().collect::<String>();
+    assert!(
+        compact.contains(
+            "prev_idx.map_or(std::ptr::null_mut()as*muti32,|idx|((raw)[(idxasisize)asusize..]).as_mut_ptr())"
+        ),
+        "{s}"
+    );
+    assert!(!s.contains("(raw).offset(idx as isize)"), "{s}");
+}
+
+#[test]
+fn test_raw_map_or_with_reference_closure_body_is_not_rewritten() {
+    let code = r#"
+pub unsafe fn foo(mut opt: Option<&mut i32>) -> *mut i32 {
+    opt.as_deref_mut().map_or(std::ptr::null_mut::<i32>(), |_x| _x)
+}
+"#;
+    let (s, _) = rewrite_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("map_or"), "{s}");
+}
+
+#[test]
+fn test_non_option_map_or_with_raw_closure_body_is_not_rewritten() {
+    let code = r#"
+struct Wrapper;
+
+impl Wrapper {
+    unsafe fn map_or<F>(self, fallback: *mut i32, f: F) -> *mut i32
+    where
+        F: FnOnce(usize) -> *mut i32,
+    {
+        let result = f(0);
+        if result.is_null() {
+            fallback
+        } else {
+            result
+        }
+    }
+}
+
+pub unsafe fn foo(wrapper: Wrapper) -> *mut i32 {
+    let addr = 0usize;
+    wrapper.map_or(std::ptr::null_mut::<i32>(), |idx| (addr as *mut i32).offset(idx as isize))
+}
+"#;
+    let (s, _) = rewrite_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("wrapper.map_or"), "{s}");
+    assert!(s.contains("(addr as *mut i32).offset(idx as isize)"), "{s}");
+}
+
+#[test]
 fn test_array_local_rewriter_skips_assignment_with_planned_local_in_rhs() {
     let code = r#"
 pub unsafe fn foo(mut p: *mut i32) -> i32 {

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -10,9 +10,27 @@ fn rewrite_struct_arrays_with_config(code: &str, config: &Config) -> (String, bo
         .unwrap()
 }
 
+fn rewrite_array_local_provenance_with_config(code: &str, config: &Config) -> (String, bool) {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        rewrite_array_local_provenance(config, tcx)
+    })
+    .unwrap()
+}
+
 fn rewrite_struct_arrays_then_pointer(code: &str, config: &Config) -> (String, BytemuckDependency) {
     let (pre, changed) = rewrite_struct_arrays_with_config(code, config);
     let input = if changed { pre.as_str() } else { code };
+    rewrite_with_config(input, config)
+}
+
+fn rewrite_struct_arrays_then_array_local_then_pointer(
+    code: &str,
+    config: &Config,
+) -> (String, BytemuckDependency) {
+    let (pre, struct_changed) = rewrite_struct_arrays_with_config(code, config);
+    let input = if struct_changed { pre.as_str() } else { code };
+    let (pre, array_changed) = rewrite_array_local_provenance_with_config(input, config);
+    let input = if array_changed { pre.as_str() } else { input };
     rewrite_with_config(input, config)
 }
 
@@ -7451,6 +7469,272 @@ pub unsafe fn foo() -> i32 {
     assert!(!s.contains("pub a: [Elem; 3]"), "{s}");
     assert!(s.contains("pub b: Elem"), "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+}
+
+#[test]
+fn test_array_local_rewriter_rewrites_simple_non_null_derived_local() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = p.offset(3);
+    *p = 1;
+    *q = 3;
+    *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut q_idx: usize = (3) as usize"), "{s}");
+    assert!(
+        s.contains("*((p).offset(q_idx as isize) as *mut i32) = 3"),
+        "{s}"
+    );
+    assert!(
+        s.matches("*((p).offset(q_idx as isize) as *mut i32)")
+            .count()
+            >= 2,
+        "{s}"
+    );
+    assert!(!s.contains("let mut q: *mut i32"), "{s}");
+    assert!(!s.contains("*q"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_uses_option_index_for_nullable_local() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32, mut k: isize) -> i32 {
+    let mut q: *mut i32 = std::ptr::null_mut();
+    if q.is_null() {
+        q = p.offset(k);
+    }
+    *q = 7;
+    *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut q_idx: Option<usize> = None"), "{s}");
+    assert!(s.contains("if q_idx.is_none()"), "{s}");
+    assert!(s.contains("q_idx = Some((k) as usize)"), "{s}");
+    assert!(
+        s.contains("*((p).offset(q_idx.unwrap() as isize) as *mut i32) = 7"),
+        "{s}"
+    );
+    assert!(!s.contains("let mut q: *mut i32"), "{s}");
+    assert!(!s.contains("q.is_null()"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_preserves_nullable_pointer_value_use() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32, mut take: bool) -> *mut i32 {
+    let mut q: *mut i32 = std::ptr::null_mut();
+    if take {
+        q = p.add(2);
+    }
+    q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut q_idx: Option<usize> = None"), "{s}");
+    assert!(s.contains("q_idx = Some((2) as usize)"), "{s}");
+    assert!(
+        s.contains("q_idx.map_or(std::ptr::null_mut() as *mut i32"),
+        "{s}"
+    );
+    assert!(
+        s.contains("|idx| ((p).offset(idx as isize)) as *mut i32"),
+        "{s}"
+    );
+    assert!(!s.contains("let mut q: *mut i32"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_skips_assignment_with_planned_local_in_rhs() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = std::ptr::null_mut();
+    q = p.offset(if q.is_null() { 0 } else { 1 });
+    *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut q: *mut i32"), "{s}");
+    assert!(s.contains("q = p.offset(if q.is_null()"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_does_not_treat_local_null_mut_as_null_literal() {
+    let code = r#"
+pub unsafe fn null_mut() -> *mut i32 {
+    0 as *mut i32
+}
+
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = null_mut();
+    q = p.add(1);
+    *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut q: *mut i32 = null_mut()"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_rewrites_self_relative_assignment() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = p.offset(1);
+    *p = 1;
+    q = q.offset(2);
+    *q = 9;
+    *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut q_idx: usize = (1) as usize"), "{s}");
+    assert!(s.contains("q_idx ="), "{s}");
+    assert!(s.contains("as isize +"), "{s}");
+    assert!(
+        s.contains("*((p).offset(q_idx as isize) as *mut i32) = 9"),
+        "{s}"
+    );
+    assert!(!s.contains("q = q.offset"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_skips_address_taken_derived_local() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32, out: *mut *mut i32) {
+    let mut q: *mut i32 = p.offset(3);
+    let _addr: *mut *mut i32 = &raw mut q;
+    *p = 0;
+    *q = 1;
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    assert!(s.contains("let mut q: *mut i32 = p.offset(3)"), "{s}");
+    assert!(s.contains("&raw mut q"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_skips_unsupported_assignment_source() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32, r: *mut i32) {
+    let mut q: *mut i32 = p.offset(3);
+    *p = 0;
+    q = r;
+    *q = 1;
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(!changed, "{s}");
+    assert!(s.contains("let mut q: *mut i32 = p.offset(3)"), "{s}");
+    assert!(s.contains("q = r"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_tracks_index_when_base_is_reassigned() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = p.offset(1);
+    p = p.offset(1);
+    *q + *p
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut p_idx: usize = 0usize"), "{s}");
+    assert!(s.contains("let mut q_idx: usize"), "{s}");
+    assert!(
+        s.contains("((p_idx) as isize + ((1) as usize) as isize) as usize"),
+        "{s}"
+    );
+    assert!(
+        s.contains("p_idx = ((p_idx) as isize + ((1) as usize) as isize) as usize"),
+        "{s}"
+    );
+    assert!(
+        s.contains("*((p).offset(q_idx as isize) as *mut i32)")
+            && s.contains("*((p).offset(p_idx as isize) as *mut i32)"),
+        "{s}"
+    );
+    assert!(!s.contains("let mut q: *mut i32"), "{s}");
+    assert!(!s.contains("p = p.offset(1)"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_preserves_member_before_base_cursor_move() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32, n: isize) -> i32 {
+    let mut prev: *mut i32 = p;
+    p = p.offset(n);
+    *prev + *p
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut p_idx: usize = 0usize"), "{s}");
+    assert!(s.contains("let mut prev_idx: usize = p_idx"), "{s}");
+    assert!(
+        s.contains("p_idx = ((p_idx) as isize + ((n) as usize) as isize) as usize"),
+        "{s}"
+    );
+    assert!(
+        s.contains("*((p).offset(prev_idx as isize) as *mut i32)")
+            && s.contains("*((p).offset(p_idx as isize) as *mut i32)"),
+        "{s}"
+    );
+    assert!(!s.contains("let mut prev: *mut i32"), "{s}");
+    assert!(!s.contains("p = p.offset(n)"), "{s}");
+}
+
+#[test]
+fn test_pointer_pipeline_runs_array_local_rewriter_before_pointer_rewriter() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = p.offset(3);
+    *p = 1;
+    *q = 3;
+    *q
+}
+"#;
+    let (s, _) = rewrite_struct_arrays_then_array_local_then_pointer(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("q_idx"), "{s}");
+    assert!(!s.contains("let mut q: *mut i32"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_uses_slice_base_pointer_after_struct_arrays() {
+    let code = r#"
+pub unsafe fn foo(p: &[i32], n: isize) -> i32 {
+    let mut q: *mut i32 = p.as_ptr().offset(n) as *mut i32;
+    if q > p.as_ptr() as *mut i32 {
+        *q
+    } else {
+        0
+    }
+}
+"#;
+    let (s, array_changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(array_changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("q_idx"), "{s}");
+    assert!(s.contains("(p).as_ptr().offset"), "{s}");
+    assert!(!s.contains("p.offset"), "{s}");
 }
 
 #[test]

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -7484,15 +7484,13 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("let mut q_idx: usize = (3) as usize"), "{s}");
+    assert!(s.contains("let mut q_idx: isize = (3) as isize"), "{s}");
     assert!(
-        s.contains("*((p).offset(q_idx as isize) as *mut i32) = 3"),
+        s.contains("*((p).offset(q_idx) as *mut i32) = 3"),
         "{s}"
     );
     assert!(
-        s.matches("*((p).offset(q_idx as isize) as *mut i32)")
-            .count()
-            >= 2,
+        s.matches("*((p).offset(q_idx) as *mut i32)").count() >= 2,
         "{s}"
     );
     assert!(!s.contains("let mut q: *mut i32"), "{s}");
@@ -7514,11 +7512,11 @@ pub unsafe fn foo(mut p: *mut i32, mut k: isize) -> i32 {
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("let mut q_idx: Option<usize> = None"), "{s}");
+    assert!(s.contains("let mut q_idx: Option<isize> = None"), "{s}");
     assert!(s.contains("if q_idx.is_none()"), "{s}");
-    assert!(s.contains("q_idx = Some((k) as usize)"), "{s}");
+    assert!(s.contains("q_idx = Some(k)"), "{s}");
     assert!(
-        s.contains("*((p).offset(q_idx.unwrap() as isize) as *mut i32) = 7"),
+        s.contains("*((p).offset(q_idx.unwrap()) as *mut i32) = 7"),
         "{s}"
     );
     assert!(!s.contains("let mut q: *mut i32"), "{s}");
@@ -7539,14 +7537,14 @@ pub unsafe fn foo(mut p: *mut i32, mut take: bool) -> *mut i32 {
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("let mut q_idx: Option<usize> = None"), "{s}");
-    assert!(s.contains("q_idx = Some((2) as usize)"), "{s}");
+    assert!(s.contains("let mut q_idx: Option<isize> = None"), "{s}");
+    assert!(s.contains("q_idx = Some((2) as isize)"), "{s}");
     assert!(
         s.contains("q_idx.map_or(std::ptr::null_mut() as *mut i32"),
         "{s}"
     );
     assert!(
-        s.contains("|idx| ((p).offset(idx as isize)) as *mut i32"),
+        s.contains("|idx| ((p).offset(idx)) as *mut i32"),
         "{s}"
     );
     assert!(!s.contains("let mut q: *mut i32"), "{s}");
@@ -7570,7 +7568,7 @@ pub unsafe fn foo(mut raw: *mut i32, mut take: bool, mut k: isize) -> *mut i32 {
     let compact = s.split_whitespace().collect::<String>();
     assert!(
         compact.contains(
-            "prev_idx.map_or(std::ptr::null_mut()as*muti32,|idx|((raw)[(idxasisize)asusize..]).as_mut_ptr())"
+            "prev_idx.map_or(std::ptr::null_mut()as*muti32,|idx|((raw)[(idx)asusize..]).as_mut_ptr())"
         ),
         "{s}"
     );
@@ -7668,14 +7666,31 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("let mut q_idx: usize = (1) as usize"), "{s}");
+    assert!(s.contains("let mut q_idx: isize = (1) as isize"), "{s}");
     assert!(s.contains("q_idx ="), "{s}");
-    assert!(s.contains("as isize +"), "{s}");
+    assert!(s.contains("(q_idx) + ((2) as isize)"), "{s}");
     assert!(
-        s.contains("*((p).offset(q_idx as isize) as *mut i32) = 9"),
+        s.contains("*((p).offset(q_idx) as *mut i32) = 9"),
         "{s}"
     );
     assert!(!s.contains("q = q.offset"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_parenthesizes_compound_relative_offset() {
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32, n: isize, mask: isize) -> i32 {
+    let mut q: *mut i32 = p.offset(1);
+    *p = 1;
+    q = q.offset(n & mask);
+    *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("q_idx = (q_idx) + (n & mask)"), "{s}");
+    assert!(!s.contains("q_idx = q_idx + n & mask"), "{s}");
 }
 
 #[test]
@@ -7722,19 +7737,13 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("let mut p_idx: usize = 0usize"), "{s}");
-    assert!(s.contains("let mut q_idx: usize"), "{s}");
+    assert!(s.contains("let mut p_idx: isize = 0isize"), "{s}");
+    assert!(s.contains("let mut q_idx: isize"), "{s}");
+    assert!(s.contains("(p_idx) + ((1) as isize)"), "{s}");
+    assert!(s.contains("p_idx = (p_idx) + ((1) as isize)"), "{s}");
     assert!(
-        s.contains("((p_idx) as isize + ((1) as usize) as isize) as usize"),
-        "{s}"
-    );
-    assert!(
-        s.contains("p_idx = ((p_idx) as isize + ((1) as usize) as isize) as usize"),
-        "{s}"
-    );
-    assert!(
-        s.contains("*((p).offset(q_idx as isize) as *mut i32)")
-            && s.contains("*((p).offset(p_idx as isize) as *mut i32)"),
+        s.contains("*((p).offset(q_idx) as *mut i32)")
+            && s.contains("*((p).offset(p_idx) as *mut i32)"),
         "{s}"
     );
     assert!(!s.contains("let mut q: *mut i32"), "{s}");
@@ -7753,15 +7762,12 @@ pub unsafe fn foo(mut p: *mut i32, n: isize) -> i32 {
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("let mut p_idx: usize = 0usize"), "{s}");
-    assert!(s.contains("let mut prev_idx: usize = p_idx"), "{s}");
+    assert!(s.contains("let mut p_idx: isize = 0isize"), "{s}");
+    assert!(s.contains("let mut prev_idx: isize = p_idx"), "{s}");
+    assert!(s.contains("p_idx = (p_idx) + (n)"), "{s}");
     assert!(
-        s.contains("p_idx = ((p_idx) as isize + ((n) as usize) as isize) as usize"),
-        "{s}"
-    );
-    assert!(
-        s.contains("*((p).offset(prev_idx as isize) as *mut i32)")
-            && s.contains("*((p).offset(p_idx as isize) as *mut i32)"),
+        s.contains("*((p).offset(prev_idx) as *mut i32)")
+            && s.contains("*((p).offset(p_idx) as *mut i32)"),
         "{s}"
     );
     assert!(!s.contains("let mut prev: *mut i32"), "{s}");

--- a/crates/points_to/src/andersen.rs
+++ b/crates/points_to/src/andersen.rs
@@ -202,6 +202,7 @@ pub struct AnalysisResult {
     pub call_graph_sccs: graph::Sccs<LocalDefId, false>,
     pub reachables: RefCell<FxHashMap<SccId, FxHashSet<SccId>>>,
 
+    pub all_writes: FxHashMap<LocalDefId, FxHashMap<Location, ChunkedBitSet<Loc>>>,
     pub writes: FxHashMap<LocalDefId, FxHashMap<Location, ChunkedBitSet<Loc>>>,
     pub bitfield_writes: FxHashMap<LocalDefId, FxHashMap<Location, ChunkedBitSet<Loc>>>,
     pub fn_writes: FxHashMap<LocalDefId, ChunkedBitSet<Loc>>,
@@ -978,6 +979,8 @@ pub fn post_analyze<'a, 'tcx>(
             }
         }
     }
+    let all_writes = writes.clone();
+
     // only keep poinatble writes
     for writes in writes.values_mut() {
         for writes in writes.values_mut() {
@@ -1027,6 +1030,7 @@ pub fn post_analyze<'a, 'tcx>(
         indirect_calls,
         call_graph_sccs,
         reachables: RefCell::new(FxHashMap::default()),
+        all_writes,
         writes,
         bitfield_writes,
         fn_writes,

--- a/crates/points_to/src/tests.rs
+++ b/crates/points_to/src/tests.rs
@@ -2315,6 +2315,37 @@ fn wg(
 }
 
 #[test]
+fn test_all_writes_keeps_direct_pointer_local_write() {
+    analyze_fn_with(
+        "",
+        "mut p: *mut i32",
+        "
+            p = p.offset(1);
+        ",
+        |mut res, tcx| {
+            let def_id = res
+                .writes
+                .keys()
+                .copied()
+                .find(|def_id| tcx.item_name(def_id.to_def_id()).as_str() == "f")
+                .unwrap();
+
+            let filtered = res.writes.remove(&def_id).unwrap_or_default();
+            let all = res.all_writes.remove(&def_id).unwrap_or_default();
+
+            assert!(
+                filtered.values().all(|writes| writes.is_empty()),
+                "filtered writes may omit direct pointer-local writes that are not address-taken"
+            );
+            assert!(
+                all.values().any(|writes| !writes.is_empty()),
+                "all_writes must retain the direct assignment to p"
+            );
+        },
+    );
+}
+
+#[test]
 fn test_writes_compound() {
     // _1 = const 0_i32
     // _2 = const 0_i32

--- a/src/bin/crat.rs
+++ b/src/bin/crat.rs
@@ -558,6 +558,14 @@ fn main() {
                     std::fs::write(&file, s).unwrap();
                 }
 
+                let (s, changed) = run_compiler_on_path(&file, |tcx| {
+                    pointer_replacer::rewrite_array_local_provenance(&config.pointer, tcx)
+                })
+                .unwrap();
+                if changed {
+                    std::fs::write(&file, s).unwrap();
+                }
+
                 let (s, bytemuck) = run_compiler_on_path(&file, |tcx| {
                     pointer_replacer::replace_local_borrows(&config.pointer, tcx)
                 })


### PR DESCRIPTION
# Summary
This pull request introduces a new array local provenance analysis and rewriting pass to the `pointer_replacer` crate.
The purpose of the analysis is to pre-transform derived pointers to indexes to base pointers, when it is unable to promote the base and derived pointer at the same time.

### Array Local Provenance Analysis and Rewriting

* Added a new analysis module `array_local_provenance`.
  * Constructs a pointer flow graph to infer base pointers.
  * Among groups with a unique base pointer, choose groups to rewrite.
    * Condition 1: base is `DirectlyRewritable`
    * Condition 2: base is stable or its index can be tracked for the live range of members.
    * Condition 3: the group contains >= 2 mutable pointers or >=1 mutable and immutable pointers.
* Implemented `array_local_index_rewriter` and its integration into the rewriter, allowing the transformation of code patterns involving array pointer manipulation to use indices or options as appropriate.
* Added test helpers and a comprehensive suite of tests for the array local provenance rewriter.

### Limitation
* Currently we cannot infer base information of pointers which are passed to opaque calls, or string libraries. (CJSON_lib, parse_uname_lib)
* Currently rewrites only if there is a source variable for the base pointer. To rewrite a broader range of pointers, selection criteria should be improved.
* Currently rewriter only rewrites if base pointer offset is not zero, so some target groups are selected but not rewritten yet (I'll handle it in a separate work)

# Test

### Regression test (unsafe counts)

Metric | master | current | Delta
-- | -- | -- | --
total unsafe occurrences | 23,422 | 23,296 | -126
DerefOfRawPointer | 2,895 | 2,821 | -74
offset | 2,759 | 2,698 | -61
from_raw_parts_mut | 7,555 | 7,564 | +9

Case | Total Delta | Feature Deltas
-- | -- | --
Public-Tests/B01_organic/wcscat_lib | -5 | DerefOfRawPointer -3, offset -2
Public-Tests/B02_organic/hm_geti_lib | +7 | offset +7
Public-Tests/B02_organic/load_png_mem_lib | -61 | DerefOfRawPointer -30, offset -32, from_raw_parts_mut +1
Public-Tests/B02_organic/sh_geti_lib | +7 | offset +7
Public-Tests/B02_organic/unfilter_lib | -61 | DerefOfRawPointer -30, offset -32, from_raw_parts_mut +1
Public-Tests/B02_synthetic/char_to_bool | -7 | DerefOfRawPointer -7, offset -7, from_raw_parts_mut +7
Public-Tests/B02_synthetic/dataentry_lib | -6 | DerefOfRawPointer -4, offset -2

Rewritten test cases:
```
Public-Tests/B01_organic/dequantize_granule_lib
Public-Tests/B01_organic/gaussian_kernel_lib
Public-Tests/B01_organic/wcscat_lib
Public-Tests/B02_organic/arr_del_lib
Public-Tests/B02_organic/arr_ins_lib
Public-Tests/B02_organic/arr_push_lib
Public-Tests/B02_organic/helxo_lib
Public-Tests/B02_organic/hm_geti_lib
Public-Tests/B02_organic/intput_lib
Public-Tests/B02_organic/load_png_mem_lib
Public-Tests/B02_organic/sh_geti_lib
Public-Tests/B02_organic/sh_puts_lib
Public-Tests/B02_organic/str_dups_lib
Public-Tests/B02_organic/str_put_lib
Public-Tests/B02_organic/unfilter_lib
Public-Tests/B02_synthetic/char_to_bool
Public-Tests/B02_synthetic/dataentry_lib
Public-Tests/B02_synthetic/jumpnode_lib
Public-Tests/B02_synthetic/memchra2_lib
P01_sphincs cases from 005 to 132
```

### Example transformation
```Rust
// B01_organic/wcscat_lib
// without array_local_provenance rewriting
pub(crate) unsafe fn wcscat_internal(mut dst: &mut [i32], mut numElem: usize,
    mut src: &[i32]) -> i32 {
    let mut ptr: *mut i32 = dst.as_mut_ptr();
    ...
    while ptr < dst[numElem..].as_mut_ptr() {
        let fresh0 = src[0];
        src = &src[1..];
        *ptr = fresh0;
        let fresh1 = *ptr;
        ptr = ptr.offset(1);
        if fresh1 == 0 { return 0; }
    }
    (&mut dst[0..])[0] = 0;
    return 34;
}
// with array_local_provenance rewriting
pub(crate) fn wcscat_internal(mut dst: &mut [i32], mut numElem: usize,
    mut src: &[i32]) -> i32 {
    let mut ptr_idx: isize = 0isize;
    ...
    while dst[ptr_idx as usize..].as_mut_ptr() < dst[numElem..].as_mut_ptr() {
        let fresh0 = src[0];
        src = &src[1..];
        (&mut dst[ptr_idx as usize..])[0] = fresh0;
        let fresh1 = (&dst[ptr_idx as usize..])[0];
        ptr_idx = ptr_idx + 1;
        if fresh1 == 0 { return 0; }
    }
    (&mut dst[0..])[0] = 0;
    return 34;
}
```