### PR TITLE
Improve pointer slice rewrites for array-originated data

### DIFF
--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -6462,6 +6462,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             && (name == "offset" || name == "as_mut_ptr" || name == "as_ptr")
         {
             // we assume that the pointer is not null when such methods are called
+            if let Some(slice) = self.plain_slice_from_as_ptr_receiver(e, m, lhs_inner_ty) {
+                return slice;
+            }
             let len = proven_len
                 .or_else(|| self.raw_parts_len_from_as_ptr_receiver(e, lhs_inner_ty))
                 .unwrap_or_else(|| "1_000_000".to_string());
@@ -6541,6 +6544,47 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 cast_mut,
                 if m { "mut" } else { "const" },
             )
+        }
+    }
+
+    fn plain_slice_from_as_ptr_receiver(
+        &self,
+        e: &Expr,
+        target_mut: bool,
+        target_inner_ty: ty::Ty<'tcx>,
+    ) -> Option<Expr> {
+        let ExprKind::MethodCall(call) = &unwrap_cast_and_paren(e).kind else {
+            return None;
+        };
+        let name = call.seg.ident.name.as_str();
+        if !matches!(name, "as_ptr" | "as_mut_ptr")
+            || target_mut && name != "as_mut_ptr"
+            || utils::ast::has_side_effects(&call.receiver)
+        {
+            return None;
+        }
+
+        let hir_e = self.ast_to_hir.get_expr(e.id, self.tcx)?;
+        let hir::ExprKind::MethodCall(_, hir_receiver, _, _) = hir_unwrap_casts(hir_e).kind else {
+            return None;
+        };
+        let typeck = self.tcx.typeck(hir_receiver.hir_id.owner);
+        let source_inner_ty =
+            slice_like_container_inner_ty(typeck.expr_ty(hir_receiver), self.tcx)?;
+        if source_inner_ty != target_inner_ty {
+            return None;
+        }
+
+        if target_mut {
+            Some(utils::expr!(
+                "&mut (&mut ({}))[..]",
+                pprust::expr_to_string(&call.receiver),
+            ))
+        } else {
+            Some(utils::expr!(
+                "&(&({}))[..]",
+                pprust::expr_to_string(&call.receiver),
+            ))
         }
     }
 

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -3883,7 +3883,14 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     return PtrKind::OptRef(m);
                 }
                 PtrCtx::Rhs(PtrKind::Slice(m)) => {
-                    *ptr = self.slice_from_raw(e, m, rhs_mut.is_mut(), lhs_inner_ty, rhs_inner_ty);
+                    *ptr = self.slice_from_raw(
+                        e,
+                        m,
+                        rhs_mut.is_mut(),
+                        lhs_inner_ty,
+                        rhs_inner_ty,
+                        None,
+                    );
                     return PtrKind::Slice(m);
                 }
                 PtrCtx::Rhs(PtrKind::SliceCursor(m)) => {
@@ -4299,11 +4306,15 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                             pprust::expr_to_string(e),
                         );
                     } else {
+                        let lhs_ty_str = mir_ty_to_string(lhs_inner_ty, self.tcx);
+                        let source_ty_str = mir_ty_to_string(pe.base_ty, self.tcx);
                         *ptr = utils::expr!(
-                            "std::slice::from_raw_parts{0}(&raw {1} ({2}) as *{1} _, 1_000_000)",
+                            "std::slice::from_raw_parts{0}(&raw {1} ({2}) as *{1} {3}, std::mem::size_of::<{4}>() / std::mem::size_of::<{3}>())",
                             if m { "_mut" } else { "" },
                             if m { "mut" } else { "const" },
                             pprust::expr_to_string(e),
+                            lhs_ty_str,
+                            source_ty_str,
                         );
                     }
                     return PtrKind::Slice(m);
@@ -4440,12 +4451,14 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     return PtrKind::SliceCursor(m);
                 }
                 PtrCtx::Rhs(PtrKind::Slice(m)) => {
+                    let len = self.raw_parts_len_from_ptr_expr(&pe, lhs_inner_ty);
                     *ptr = self.slice_from_raw(
                         &raw_expr,
                         m,
                         pe.as_mut_ptr,
                         lhs_inner_ty,
                         rhs_inner_ty,
+                        len,
                     );
                     return PtrKind::Slice(m);
                 }
@@ -4739,7 +4752,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::Raw(m1)) => {
                     // // Raw → slice: delegate via cursor then unwrap.
                     // to keep offsets, we use `e` instead of `pe.base`
-                    *ptr = self.slice_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty);
+                    *ptr = self.slice_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty, None);
                     return PtrKind::Slice(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::Ref(m1)) => {
@@ -5102,7 +5115,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 PtrKind::SliceCursor(m)
             }
             PtrCtx::Rhs(PtrKind::Slice(m)) => {
-                *ptr = self.slice_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty);
+                *ptr = self.slice_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty, None);
                 PtrKind::Slice(m)
             }
         }
@@ -6440,6 +6453,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         m1: bool,
         lhs_inner_ty: ty::Ty<'tcx>,
         rhs_inner_ty: ty::Ty<'tcx>,
+        proven_len: Option<String>,
     ) -> Expr {
         let need_cast = lhs_inner_ty != rhs_inner_ty;
         let cast_mut = if m && !m1 { " as *mut _" } else { "" };
@@ -6448,20 +6462,25 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             && (name == "offset" || name == "as_mut_ptr" || name == "as_ptr")
         {
             // we assume that the pointer is not null when such methods are called
+            let len = proven_len
+                .or_else(|| self.raw_parts_len_from_as_ptr_receiver(e, lhs_inner_ty))
+                .unwrap_or_else(|| "1_000_000".to_string());
             if !need_cast {
                 utils::expr!(
-                    "std::slice::from_raw_parts{}(({}){}, 1_000_000)",
+                    "std::slice::from_raw_parts{}(({}){}, {})",
                     if m { "_mut" } else { "" },
                     pprust::expr_to_string(e),
                     cast_mut,
+                    len,
                 )
             } else {
                 utils::expr!(
-                    "std::slice::from_raw_parts{}(({}){} as *{} _, 1_000_000)",
+                    "std::slice::from_raw_parts{}(({}){} as *{} _, {})",
                     if m { "_mut" } else { "" },
                     pprust::expr_to_string(e),
                     cast_mut,
                     if m { "mut" } else { "const" },
+                    len,
                 )
             }
         } else if !utils::ast::has_side_effects(e) {
@@ -6525,6 +6544,63 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         }
     }
 
+    fn raw_parts_len_from_ptr_expr(
+        &self,
+        pe: &PtrExpr<'_, 'tcx>,
+        target_inner_ty: ty::Ty<'tcx>,
+    ) -> Option<String> {
+        if !pe.as_ptr
+            || utils::ast::has_side_effects(pe.base)
+            || pe.projs.iter().any(|proj| {
+                matches!(
+                    proj,
+                    PtrExprProj::Offset(_)
+                        | PtrExprProj::IntegerOp(..)
+                        | PtrExprProj::IntegerBinOp(..)
+                )
+            })
+        {
+            return None;
+        }
+        let source_inner_ty = slice_like_container_inner_ty(pe.base_ty, self.tcx)?;
+        Some(format!(
+            "(({}).len() * std::mem::size_of::<{}>()) / std::mem::size_of::<{}>()",
+            pprust::expr_to_string(pe.base),
+            mir_ty_to_string(source_inner_ty, self.tcx),
+            mir_ty_to_string(target_inner_ty, self.tcx),
+        ))
+    }
+
+    fn raw_parts_len_from_as_ptr_receiver(
+        &self,
+        e: &Expr,
+        target_inner_ty: ty::Ty<'tcx>,
+    ) -> Option<String> {
+        let ExprKind::MethodCall(call) = &unwrap_cast_and_paren(e).kind else {
+            return None;
+        };
+        if !matches!(call.seg.ident.name.as_str(), "as_ptr" | "as_mut_ptr")
+            || utils::ast::has_side_effects(&call.receiver)
+        {
+            return None;
+        }
+
+        let hir_e = self.ast_to_hir.get_expr(e.id, self.tcx)?;
+        let hir::ExprKind::MethodCall(_, hir_receiver, _, _) = hir_unwrap_casts(hir_e).kind else {
+            return None;
+        };
+        let typeck = self.tcx.typeck(hir_receiver.hir_id.owner);
+        let source_inner_ty =
+            slice_like_container_inner_ty(typeck.expr_ty(hir_receiver), self.tcx)?;
+
+        Some(format!(
+            "(({}).len() * std::mem::size_of::<{}>()) / std::mem::size_of::<{}>()",
+            pprust::expr_to_string(&call.receiver),
+            mir_ty_to_string(source_inner_ty, self.tcx),
+            mir_ty_to_string(target_inner_ty, self.tcx),
+        ))
+    }
+
     fn slice_from_ref(
         &self,
         e: &Expr,
@@ -6556,7 +6632,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             )
         } else {
             let raw = self.raw_from_ref(e, m, m1, lhs_inner_ty, rhs_inner_ty);
-            self.slice_from_raw(&raw, m, m, lhs_inner_ty, lhs_inner_ty)
+            self.slice_from_raw(&raw, m, m, lhs_inner_ty, lhs_inner_ty, None)
         }
     }
 

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -3883,14 +3883,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     return PtrKind::OptRef(m);
                 }
                 PtrCtx::Rhs(PtrKind::Slice(m)) => {
-                    *ptr = self.slice_from_raw(
-                        e,
-                        m,
-                        rhs_mut.is_mut(),
-                        lhs_inner_ty,
-                        rhs_inner_ty,
-                        None,
-                    );
+                    *ptr = self.slice_from_raw(e, m, rhs_mut.is_mut(), lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::Slice(m);
                 }
                 PtrCtx::Rhs(PtrKind::SliceCursor(m)) => {
@@ -4306,15 +4299,11 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                             pprust::expr_to_string(e),
                         );
                     } else {
-                        let lhs_ty_str = mir_ty_to_string(lhs_inner_ty, self.tcx);
-                        let source_ty_str = mir_ty_to_string(pe.base_ty, self.tcx);
                         *ptr = utils::expr!(
-                            "std::slice::from_raw_parts{0}(&raw {1} ({2}) as *{1} {3}, std::mem::size_of::<{4}>() / std::mem::size_of::<{3}>())",
+                            "std::slice::from_raw_parts{0}(&raw {1} ({2}) as *{1} _, 1_000_000)",
                             if m { "_mut" } else { "" },
                             if m { "mut" } else { "const" },
                             pprust::expr_to_string(e),
-                            lhs_ty_str,
-                            source_ty_str,
                         );
                     }
                     return PtrKind::Slice(m);
@@ -4451,14 +4440,12 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     return PtrKind::SliceCursor(m);
                 }
                 PtrCtx::Rhs(PtrKind::Slice(m)) => {
-                    let len = self.raw_parts_len_from_ptr_expr(&pe, lhs_inner_ty);
                     *ptr = self.slice_from_raw(
                         &raw_expr,
                         m,
                         pe.as_mut_ptr,
                         lhs_inner_ty,
                         rhs_inner_ty,
-                        len,
                     );
                     return PtrKind::Slice(m);
                 }
@@ -4752,7 +4739,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::Raw(m1)) => {
                     // // Raw → slice: delegate via cursor then unwrap.
                     // to keep offsets, we use `e` instead of `pe.base`
-                    *ptr = self.slice_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty, None);
+                    *ptr = self.slice_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty);
                     return PtrKind::Slice(m);
                 }
                 (PtrCtx::Rhs(PtrKind::Slice(m)), PtrKind::Ref(m1)) => {
@@ -5115,7 +5102,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 PtrKind::SliceCursor(m)
             }
             PtrCtx::Rhs(PtrKind::Slice(m)) => {
-                *ptr = self.slice_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty, None);
+                *ptr = self.slice_from_raw(e, m, m1, lhs_inner_ty, rhs_inner_ty);
                 PtrKind::Slice(m)
             }
         }
@@ -6453,7 +6440,6 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         m1: bool,
         lhs_inner_ty: ty::Ty<'tcx>,
         rhs_inner_ty: ty::Ty<'tcx>,
-        proven_len: Option<String>,
     ) -> Expr {
         let need_cast = lhs_inner_ty != rhs_inner_ty;
         let cast_mut = if m && !m1 { " as *mut _" } else { "" };
@@ -6465,25 +6451,20 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             if let Some(slice) = self.plain_slice_from_as_ptr_receiver(e, m, lhs_inner_ty) {
                 return slice;
             }
-            let len = proven_len
-                .or_else(|| self.raw_parts_len_from_as_ptr_receiver(e, lhs_inner_ty))
-                .unwrap_or_else(|| "1_000_000".to_string());
             if !need_cast {
                 utils::expr!(
-                    "std::slice::from_raw_parts{}(({}){}, {})",
+                    "std::slice::from_raw_parts{}(({}){}, 1_000_000)",
                     if m { "_mut" } else { "" },
                     pprust::expr_to_string(e),
                     cast_mut,
-                    len,
                 )
             } else {
                 utils::expr!(
-                    "std::slice::from_raw_parts{}(({}){} as *{} _, {})",
+                    "std::slice::from_raw_parts{}(({}){} as *{} _, 1_000_000)",
                     if m { "_mut" } else { "" },
                     pprust::expr_to_string(e),
                     cast_mut,
                     if m { "mut" } else { "const" },
-                    len,
                 )
             }
         } else if !utils::ast::has_side_effects(e) {
@@ -6588,63 +6569,6 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         }
     }
 
-    fn raw_parts_len_from_ptr_expr(
-        &self,
-        pe: &PtrExpr<'_, 'tcx>,
-        target_inner_ty: ty::Ty<'tcx>,
-    ) -> Option<String> {
-        if !pe.as_ptr
-            || utils::ast::has_side_effects(pe.base)
-            || pe.projs.iter().any(|proj| {
-                matches!(
-                    proj,
-                    PtrExprProj::Offset(_)
-                        | PtrExprProj::IntegerOp(..)
-                        | PtrExprProj::IntegerBinOp(..)
-                )
-            })
-        {
-            return None;
-        }
-        let source_inner_ty = slice_like_container_inner_ty(pe.base_ty, self.tcx)?;
-        Some(format!(
-            "(({}).len() * std::mem::size_of::<{}>()) / std::mem::size_of::<{}>()",
-            pprust::expr_to_string(pe.base),
-            mir_ty_to_string(source_inner_ty, self.tcx),
-            mir_ty_to_string(target_inner_ty, self.tcx),
-        ))
-    }
-
-    fn raw_parts_len_from_as_ptr_receiver(
-        &self,
-        e: &Expr,
-        target_inner_ty: ty::Ty<'tcx>,
-    ) -> Option<String> {
-        let ExprKind::MethodCall(call) = &unwrap_cast_and_paren(e).kind else {
-            return None;
-        };
-        if !matches!(call.seg.ident.name.as_str(), "as_ptr" | "as_mut_ptr")
-            || utils::ast::has_side_effects(&call.receiver)
-        {
-            return None;
-        }
-
-        let hir_e = self.ast_to_hir.get_expr(e.id, self.tcx)?;
-        let hir::ExprKind::MethodCall(_, hir_receiver, _, _) = hir_unwrap_casts(hir_e).kind else {
-            return None;
-        };
-        let typeck = self.tcx.typeck(hir_receiver.hir_id.owner);
-        let source_inner_ty =
-            slice_like_container_inner_ty(typeck.expr_ty(hir_receiver), self.tcx)?;
-
-        Some(format!(
-            "(({}).len() * std::mem::size_of::<{}>()) / std::mem::size_of::<{}>()",
-            pprust::expr_to_string(&call.receiver),
-            mir_ty_to_string(source_inner_ty, self.tcx),
-            mir_ty_to_string(target_inner_ty, self.tcx),
-        ))
-    }
-
     fn slice_from_ref(
         &self,
         e: &Expr,
@@ -6676,7 +6600,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             )
         } else {
             let raw = self.raw_from_ref(e, m, m1, lhs_inner_ty, rhs_inner_ty);
-            self.slice_from_raw(&raw, m, m, lhs_inner_ty, lhs_inner_ty, None)
+            self.slice_from_raw(&raw, m, m, lhs_inner_ty, lhs_inner_ty)
         }
     }
 

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -4141,25 +4141,47 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             }
             match ctx {
                 PtrCtx::Rhs(PtrKind::Slice(m)) => {
-                    if let Some(slice) = self.try_byte_slice_from_addr_of(
-                        e,
-                        pe.base_ty,
-                        lhs_inner_ty,
-                        m,
-                        addr_source_mut,
-                    ) {
+                    if let Some(slice) = self
+                        .try_byte_slice_from_addr_of(
+                            e,
+                            pe.base_ty,
+                            lhs_inner_ty,
+                            m,
+                            addr_source_mut,
+                        )
+                        .or_else(|| {
+                            self.try_bytemuck_slice_from_addr_of(
+                                e,
+                                pe.base_ty,
+                                lhs_inner_ty,
+                                m,
+                                addr_source_mut,
+                            )
+                        })
+                    {
                         *ptr = slice;
                         return PtrKind::Slice(m);
                     }
                 }
                 PtrCtx::Rhs(PtrKind::SliceCursor(m)) => {
-                    if let Some(slice) = self.try_byte_slice_from_addr_of(
-                        e,
-                        pe.base_ty,
-                        lhs_inner_ty,
-                        m,
-                        addr_source_mut,
-                    ) {
+                    if let Some(slice) = self
+                        .try_byte_slice_from_addr_of(
+                            e,
+                            pe.base_ty,
+                            lhs_inner_ty,
+                            m,
+                            addr_source_mut,
+                        )
+                        .or_else(|| {
+                            self.try_bytemuck_slice_from_addr_of(
+                                e,
+                                pe.base_ty,
+                                lhs_inner_ty,
+                                m,
+                                addr_source_mut,
+                            )
+                        })
+                    {
                         let cursor_ty = if m {
                             "crate::slice_cursor::SliceCursorMut"
                         } else {
@@ -5360,14 +5382,32 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             } else {
                 e.clone()
             }
-        } else if lhs_inner_ty.is_numeric() && rhs_inner_ty.is_numeric() {
+        } else if (lhs_inner_ty.is_numeric() && rhs_inner_ty.is_numeric())
+            || (!matches!(e.kind, ExprKind::Index(..))
+                && self.try_require_bytemuck_slice_cast(rhs_inner_ty, lhs_inner_ty, m))
+        {
             self.bytemuck.set(true);
-            utils::expr!(
-                "bytemuck::cast_slice{}::<_, {}>({})",
-                if m { "_mut" } else { "" },
-                lhs_ty,
-                pprust::expr_to_string(e),
-            )
+            let reference = if matches!(e.kind, ExprKind::Index(..)) {
+                if m { "&mut " } else { "&" }
+            } else {
+                ""
+            };
+            if reference.is_empty() {
+                utils::expr!(
+                    "bytemuck::cast_slice{}::<_, {}>({})",
+                    if m { "_mut" } else { "" },
+                    lhs_ty,
+                    pprust::expr_to_string(e),
+                )
+            } else {
+                utils::expr!(
+                    "bytemuck::cast_slice{}::<_, {}>({}({}))",
+                    if m { "_mut" } else { "" },
+                    lhs_ty,
+                    reference,
+                    pprust::expr_to_string(e),
+                )
+            }
         } else {
             let ptr_method = if m { "as_mut_ptr" } else { "as_ptr" };
             utils::expr!(
@@ -5409,6 +5449,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             if self.safe_slice_view_cast_allowed(
                 source_inner_ty,
                 target_inner_ty,
+                want_mut,
                 def_id,
                 allow_resized_numeric_casts,
             ) {
@@ -5436,6 +5477,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     if !self.safe_slice_view_cast_allowed(
                         source_inner_ty,
                         to_ty,
+                        want_mut,
                         def_id,
                         allow_resized_numeric_casts,
                     ) {
@@ -5450,6 +5492,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         if !self.safe_slice_view_cast_allowed(
             source_inner_ty,
             target_inner_ty,
+            want_mut,
             def_id,
             allow_resized_numeric_casts,
         ) {
@@ -5521,6 +5564,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         &self,
         from_ty: ty::Ty<'tcx>,
         to_ty: ty::Ty<'tcx>,
+        mutable: bool,
         def_id: LocalDefId,
         allow_resized_numeric_casts: bool,
     ) -> bool {
@@ -5528,6 +5572,57 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             || (from_ty.is_numeric()
                 && to_ty.is_numeric()
                 && (allow_resized_numeric_casts || self.same_size(from_ty, to_ty, def_id)))
+            || (!(from_ty.is_numeric() && to_ty.is_numeric())
+                && self.bytemuck_slice_cast_allowed(from_ty, to_ty, mutable))
+    }
+
+    fn bytemuck_slice_cast_allowed(
+        &self,
+        from_ty: ty::Ty<'tcx>,
+        to_ty: ty::Ty<'tcx>,
+        mutable: bool,
+    ) -> bool {
+        let (from_requirement, to_requirement) = if mutable {
+            (BytemuckRequirement::Pod, BytemuckRequirement::Pod)
+        } else {
+            (
+                BytemuckRequirement::NoUninit,
+                BytemuckRequirement::AnyBitPattern,
+            )
+        };
+
+        let mut classifier = self.bytemuck_classifier.borrow_mut();
+        classifier.satisfies_requirement(from_ty, from_requirement)
+            && classifier.satisfies_requirement(to_ty, to_requirement)
+    }
+
+    fn try_require_bytemuck_slice_cast(
+        &self,
+        from_ty: ty::Ty<'tcx>,
+        to_ty: ty::Ty<'tcx>,
+        mutable: bool,
+    ) -> bool {
+        if !self.bytemuck_slice_cast_allowed(from_ty, to_ty, mutable) {
+            return false;
+        }
+
+        let (from_requirement, to_requirement) = if mutable {
+            (BytemuckRequirement::Pod, BytemuckRequirement::Pod)
+        } else {
+            (
+                BytemuckRequirement::NoUninit,
+                BytemuckRequirement::AnyBitPattern,
+            )
+        };
+
+        let mut derives = self.bytemuck_derives.borrow_mut();
+        let mut classifier = self.bytemuck_classifier.borrow_mut();
+        let from_required =
+            derives.require_type(self.tcx, &mut classifier, from_ty, from_requirement);
+        let to_required = derives.require_type(self.tcx, &mut classifier, to_ty, to_requirement);
+        debug_assert!(from_required && to_required);
+        self.bytemuck.set(true);
+        true
     }
 
     fn plain_slice_from_safe_view(
@@ -5650,6 +5745,38 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             }
             _ => None,
         }
+    }
+
+    fn try_bytemuck_slice_from_addr_of(
+        &self,
+        pointee: &Expr,
+        pointee_ty: ty::Ty<'tcx>,
+        target_inner_ty: ty::Ty<'tcx>,
+        mutable: bool,
+        source_mut: bool,
+    ) -> Option<Expr> {
+        if mutable && !source_mut {
+            return None;
+        }
+        if place_expr_contains_deref(pointee) {
+            return None;
+        }
+        let ty::TyKind::Array(source_inner_ty, _) = pointee_ty.kind() else {
+            return None;
+        };
+        if *source_inner_ty == target_inner_ty
+            || !self.try_require_bytemuck_slice_cast(*source_inner_ty, target_inner_ty, mutable)
+        {
+            return None;
+        }
+
+        Some(utils::expr!(
+            "bytemuck::cast_slice{}::<_, {}>(&{}({}))",
+            if mutable { "_mut" } else { "" },
+            mir_ty_to_string(target_inner_ty, self.tcx),
+            if mutable { "mut " } else { "" },
+            pprust::expr_to_string(pointee),
+        ))
     }
 
     fn projected_opt_boxed_slice_expr(
@@ -6760,12 +6887,14 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                 pe.base_kind != PtrExprBaseKind::Alloca && !is_rewritten_slice_like_local,
             );
             utils::expr!("{}({})", reference, pprust::expr_to_string(e),)
-        } else if lhs_inner_ty.is_numeric() && rhs_inner_ty.is_numeric() {
+        } else if (lhs_inner_ty.is_numeric() && rhs_inner_ty.is_numeric())
+            || (!matches!(e.kind, ExprKind::Index(..))
+                && self.try_require_bytemuck_slice_cast(rhs_inner_ty, lhs_inner_ty, m))
+        {
             self.bytemuck.set(true);
             let reference = get_reference(
-                !matches!(e.kind, ExprKind::Index(..))
-                    && pe.base_kind != PtrExprBaseKind::Alloca
-                    && !is_rewritten_slice_like_local,
+                matches!(e.kind, ExprKind::Index(..))
+                    || (pe.base_kind != PtrExprBaseKind::Alloca && !is_rewritten_slice_like_local),
             );
             // can be used for deref, so type must be specified
             utils::expr!(

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -5391,8 +5391,8 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
 }
 
 /// Slice q = Slice p, with type cast. Both use .offset() → both Slice.
-/// p is struct Pair (non-numeric), q is c_int. At least one non-numeric type
-/// → non-bytemuck cast via from_raw_parts.
+/// p is a bytemuck-derivable struct Pair, q is c_int, so the reinterpreted
+/// slice view can use bytemuck instead of an open-ended raw-parts fallback.
 /// Conversion: slice_from_slice (pointer-cast else branch).
 #[test]
 fn test_slice_eq_slice_cast() {
@@ -5418,8 +5418,12 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *q.offset(1 as isize);
 }
 "#,
-        &["from_raw_parts_mut", "as *mut i32", "&mut [i32]"],
-        &["bytemuck"],
+        &[
+            "#[derive(bytemuck::Zeroable, bytemuck::Pod)]",
+            "bytemuck::cast_slice_mut::<_, i32>",
+            "&mut [i32]",
+        ],
+        &["from_raw_parts_mut", "1_000_000"],
     );
 }
 
@@ -5693,7 +5697,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
 }
 
 #[test]
-fn test_addr_of_fixed_array_slice_cast_keeps_raw_parts_fallback() {
+fn test_addr_of_fixed_array_slice_cast_uses_bytemuck() {
     run_test(
         r#"
 use ::libc;
@@ -5705,8 +5709,8 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p.offset(0 as isize) as libc::c_int;
 }
 "#,
-        &["from_raw_parts_mut", "&mut [i16]", "1_000_000"],
-        &["bytemuck", "std::mem::size_of::<[i32; 10]>()"],
+        &["bytemuck::cast_slice_mut::<_, i16>", "&mut [i16]"],
+        &["from_raw_parts_mut", "1_000_000", "&raw mut"],
     );
 }
 
@@ -6675,10 +6679,9 @@ pub unsafe fn foo(n: usize) {
     );
 }
 
-/// as_ptr + Slice, non-bytemuck cast: struct array cast to c_int pointer.
-/// Non-numeric rhs_inner_ty keeps the existing raw-parts fallback.
+/// as_ptr + Slice, bytemuck-derivable cast: struct array cast to c_int pointer.
 #[test]
-fn test_as_ptr_slice_raw_parts_keeps_open_fallback_for_reinterpretation() {
+fn test_as_ptr_slice_reinterpretation_uses_bytemuck() {
     run_test(
         r#"
 use ::libc;
@@ -6699,11 +6702,46 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p.offset(0 as isize);
 }
 "#,
-        &["from_raw_parts", "1_000_000"],
         &[
-            "bytemuck",
-            "((arr).len() * std::mem::size_of::<crate::Pair>())",
+            "#[derive(bytemuck::Zeroable, bytemuck::Pod)]",
+            "bytemuck::cast_slice_mut::<_, i32>",
+            "&mut [i32]",
         ],
+        &["from_raw_parts", "1_000_000"],
+    );
+}
+
+#[test]
+fn test_indexed_slice_reinterpretation_avoids_bytemuck_cast() {
+    run_test(
+        r#"
+use ::libc;
+#[repr(C)]
+pub struct Header {
+    pub a: libc::c_int,
+    pub b: libc::c_int,
+}
+impl Copy for Header {}
+impl Clone for Header {
+    fn clone(&self) -> Self { *self }
+}
+#[repr(C)]
+pub struct Chunk {
+    pub a: libc::c_int,
+    pub b: libc::c_int,
+}
+impl Copy for Chunk {}
+impl Clone for Chunk {
+    fn clone(&self) -> Self { *self }
+}
+pub unsafe extern "C" fn foo(data: *const Header) -> libc::c_int {
+    let header: *const Header = data;
+    let chunk: *const Chunk = header.offset(1 as isize) as *const Chunk;
+    return (*chunk).a;
+}
+"#,
+        &["first().map", "_x as *const _ as *const _"],
+        &["bytemuck::cast_slice::<_, crate::Chunk>"],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -6599,6 +6599,31 @@ pub unsafe fn transform(m: *mut Md5) -> u32 {
 }
 
 #[test]
+fn test_raw_root_array_field_as_mut_ptr_slice_arg_uses_direct_borrow() {
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Info {
+    pub data: [i8; 4],
+}
+
+static mut SLOT: *mut Info = 0 as *mut Info;
+
+pub unsafe fn consume(data: *const i8) -> i32 {
+    *data.offset(0) as i32
+}
+
+pub unsafe fn foo() -> i32 {
+    let info = SLOT;
+    consume((*info).data.as_ptr())
+}
+"#,
+        &["consume(&(&((*info).data))[..])"],
+        &["from_raw_parts", ".data.as_ptr()"],
+    );
+}
+
+#[test]
 fn test_array_field_const_offset_raw_arg_uses_slice_suffix_ptr() {
     run_test(
         r#"

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -5692,6 +5692,28 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     );
 }
 
+#[test]
+fn test_addr_of_fixed_array_slice_cast_uses_array_size_len() {
+    run_test(
+        r#"
+use ::libc;
+pub unsafe extern "C" fn foo() -> libc::c_int {
+    let mut arr: [libc::c_int; 10] = [0; 10];
+    let mut p: *mut libc::c_short = &mut arr as *mut [libc::c_int; 10] as *mut libc::c_short;
+    *p.offset(0 as isize) = 10 as libc::c_short;
+    *p.offset(1 as isize) = 20 as libc::c_short;
+    return *p.offset(0 as isize) as libc::c_int;
+}
+"#,
+        &[
+            "from_raw_parts_mut",
+            "std::mem::size_of::<[i32; 10]>() / std::mem::size_of::<i16>()",
+            "&mut [i16]",
+        ],
+        &["bytemuck", "1_000_000"],
+    );
+}
+
 // --- Non-usize cast + offset ---
 
 /// OptRef q = Slice (p as *mut c_uint).offset(2): projected_expr first
@@ -6656,8 +6678,12 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p.offset(0 as isize);
 }
 "#,
-        &["from_raw_parts"],
-        &["bytemuck"],
+        &[
+            "from_raw_parts",
+            "((arr).len() * std::mem::size_of::<crate::Pair>())",
+            "std::mem::size_of::<i32>()",
+        ],
+        &["bytemuck", "1_000_000"],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -5693,7 +5693,7 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
 }
 
 #[test]
-fn test_addr_of_fixed_array_slice_cast_uses_array_size_len() {
+fn test_addr_of_fixed_array_slice_cast_keeps_raw_parts_fallback() {
     run_test(
         r#"
 use ::libc;
@@ -5705,12 +5705,8 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p.offset(0 as isize) as libc::c_int;
 }
 "#,
-        &[
-            "from_raw_parts_mut",
-            "std::mem::size_of::<[i32; 10]>() / std::mem::size_of::<i16>()",
-            "&mut [i16]",
-        ],
-        &["bytemuck", "1_000_000"],
+        &["from_raw_parts_mut", "&mut [i16]", "1_000_000"],
+        &["bytemuck", "std::mem::size_of::<[i32; 10]>()"],
     );
 }
 
@@ -6680,9 +6676,9 @@ pub unsafe fn foo(n: usize) {
 }
 
 /// as_ptr + Slice, non-bytemuck cast: struct array cast to c_int pointer.
-/// Non-numeric rhs_inner_ty → `from_raw_parts_mut`.
+/// Non-numeric rhs_inner_ty keeps the existing raw-parts fallback.
 #[test]
-fn test_as_ptr_slice_raw_parts() {
+fn test_as_ptr_slice_raw_parts_keeps_open_fallback_for_reinterpretation() {
     run_test(
         r#"
 use ::libc;
@@ -6703,12 +6699,11 @@ pub unsafe extern "C" fn foo() -> libc::c_int {
     return *p.offset(0 as isize);
 }
 "#,
+        &["from_raw_parts", "1_000_000"],
         &[
-            "from_raw_parts",
+            "bytemuck",
             "((arr).len() * std::mem::size_of::<crate::Pair>())",
-            "std::mem::size_of::<i32>()",
         ],
-        &["bytemuck", "1_000_000"],
     );
 }
 


### PR DESCRIPTION
## Summary

This PR improves the pointer rewriter’s handling of array-backed slice construction.

For same-element array/slice receivers, the rewriter now skips `from_raw_parts` entirely and directly borrows the receiver slice. For safe reinterpreted array/slice views, the rewriter can use `bytemuck::cast_slice(_mut)` instead of open-ended raw-parts fallbacks. Indexed/open-ended slice reinterpretations remain conservative and keep the existing fallback path.

The branch reduces target unsafe findings by 276 occurrences versus the handoff baseline.

## Change Summary

| Change area | What changed | Improvement type | Before -> After |
| --- | --- | --- | --- |
| Same-element `as_ptr` receivers | Directly borrow the receiver slice instead of round-tripping through `from_raw_parts`. | Count | `from_raw_parts(arr.as_ptr(), arr.len())` -> `&(&(arr))[..]` |
| Reinterpreted array/slice views | Use `bytemuck::cast_slice(_mut)` for whole array-backed or receiver-backed reinterpretations when source and target element types satisfy bytemuck’s safety requirements; keep indexed/open-ended fallbacks raw. | Cleanup | `from_raw_parts_mut(arr.as_mut_ptr() as *mut i32, 1_000_000)` -> `bytemuck::cast_slice_mut::<_, i32>(&mut arr)` |
## Unsafe reductions by kind

| Unsafe kind | Baseline | This branch | Δ |
| --- | ---: | ---: | ---: |
| `DerefOfRawPointer` | 3,614 | 3,599 | -15 |
| `offset` | 3,300 | 3,255 | -45 |
| `from_raw_parts_mut` | 662 | 597 | -65 |
| `from_raw_parts` | 404 | 256 | -148 |
| `as_mut` | 960 | 959 | -1 |
| `as_ref` | 298 | 296 | -2 |

The corpus reductions come from the direct-borrow path for same-element array/slice receivers. The new bytemuck reinterpretation support is covered by unit tests; the current Test-Corpus transform output is unchanged by that follow-up because the only corpus-like candidate was an indexed/open-ended slice case, which intentionally remains conservative.