### PR TITLE
Use safe CStr conversions for IO path calls

### DIFF
--- a/crates/io_replacer/src/tests.rs
+++ b/crates/io_replacer/src/tests.rs
@@ -100,6 +100,57 @@ unsafe fn f() {
 }
 
 #[test]
+fn test_fopen_slice_path() {
+    run_test(
+        r#"
+unsafe fn f(filename: &[libc::c_char]) {
+    let mut stream: *mut FILE = fopen(
+        filename.as_ptr(),
+        b"r\0" as *const u8 as *const libc::c_char,
+    );
+    fgetc(stream);
+    fclose(stream);
+}"#,
+        &[
+            "std::ffi::CStr::from_bytes_until_nul",
+            "bytemuck::cast_slice(&(filename))",
+            "std::fs::File::open",
+            "crate::c_lib::rs_fgetc",
+            "drop",
+        ],
+        &["std::ffi::CStr::from_ptr", "fopen", "fclose"],
+    );
+}
+
+#[test]
+fn test_fopen_u8_array_path() {
+    run_test(
+        r#"
+unsafe fn f() {
+    let filename = [b'a', 0];
+    let mut stream: *mut FILE = fopen(
+        filename.as_ptr() as *const libc::c_char,
+        b"w\0" as *const u8 as *const libc::c_char,
+    );
+    fputc('a' as i32, stream);
+    fclose(stream);
+}"#,
+        &[
+            "std::ffi::CStr::from_bytes_until_nul(&(filename))",
+            "std::fs::File::create",
+            "crate::c_lib::rs_fputc",
+            "drop",
+        ],
+        &[
+            "std::ffi::CStr::from_ptr",
+            "bytemuck::cast_slice",
+            "fopen",
+            "fclose",
+        ],
+    );
+}
+
+#[test]
 fn test_file_buf_read() {
     run_test(
         r#"

--- a/crates/io_replacer/src/tests.rs
+++ b/crates/io_replacer/src/tests.rs
@@ -2,9 +2,12 @@ use lazy_static::lazy_static;
 use utils::compilation;
 
 fn run_test(s: &str, includes: &[&str], excludes: &[&str]) {
+    run_test_with_config(s, super::Config::default(), includes, excludes)
+}
+
+fn run_test_with_config(s: &str, config: super::Config, includes: &[&str], excludes: &[&str]) {
     let mut code = PREAMBLE.to_string();
     code.push_str(s);
-    let config = super::Config::default();
     let res =
         compilation::run_compiler_on_str(&code, |tcx| super::replace_io(config, tcx)).unwrap();
     let stripped = res
@@ -553,6 +556,30 @@ unsafe fn f(mut entry: Entry) {
 }"#,
         &["std::ffi::CStr::from_ptr((entry).key as _)", "write!"],
         &["printf"],
+    );
+}
+
+#[test]
+fn test_printf_assume_to_str_ok_local_array_string() {
+    run_test_with_config(
+        r#"
+unsafe fn f() {
+    let mut buf: [libc::c_char; 10] = [0; 10];
+    printf(
+        b"%s\n\0" as *const u8 as *const libc::c_char,
+        buf.as_mut_ptr(),
+    );
+}"#,
+        super::Config {
+            assume_to_str_ok: true,
+        },
+        &[
+            "std::ffi::CStr::from_bytes_until_nul",
+            "bytemuck::cast_slice",
+            ".to_str().unwrap()",
+            "write!",
+        ],
+        &["std::ffi::CStr::from_ptr", "printf"],
     );
 }
 

--- a/crates/io_replacer/src/tests.rs
+++ b/crates/io_replacer/src/tests.rs
@@ -154,6 +154,59 @@ unsafe fn f() {
 }
 
 #[test]
+fn test_remove_slice_path() {
+    run_test(
+        r#"
+unsafe fn f(path: &mut [libc::c_char]) -> libc::c_int {
+    remove(path.as_mut_ptr())
+}"#,
+        &[
+            "crate::c_lib::rs_remove",
+            "std::ffi::CStr::from_bytes_until_nul",
+            "bytemuck::cast_slice",
+            "pub(crate) fn rs_remove(path: &str)",
+            "std::fs::remove_file(path)",
+        ],
+        &["std::ffi::CStr::from_ptr", "pub(crate) unsafe fn rs_remove"],
+    );
+}
+
+#[test]
+fn test_remove_raw_path_fallback() {
+    run_test(
+        r#"
+unsafe fn f(path: *mut libc::c_char) -> libc::c_int {
+    remove(path)
+}"#,
+        &[
+            "crate::c_lib::rs_remove",
+            "std::ffi::CStr::from_ptr((path) as",
+            ".to_str().unwrap()",
+            "pub(crate) fn rs_remove(path: &str)",
+        ],
+        &["pub(crate) unsafe fn rs_remove"],
+    );
+}
+
+#[test]
+fn test_rename_slice_paths() {
+    run_test(
+        r#"
+unsafe fn f(old_path: &mut [libc::c_char], new_path: &mut [libc::c_char]) -> libc::c_int {
+    rename(old_path.as_mut_ptr(), new_path.as_mut_ptr())
+}"#,
+        &[
+            "crate::c_lib::rs_rename",
+            "std::ffi::CStr::from_bytes_until_nul",
+            "bytemuck::cast_slice",
+            "pub(crate) fn rs_rename(old: &str, new: &str)",
+            "std::fs::rename(old, new)",
+        ],
+        &["std::ffi::CStr::from_ptr", "pub(crate) unsafe fn rs_rename"],
+    );
+}
+
+#[test]
 fn test_file_buf_read() {
     run_test(
         r#"
@@ -580,6 +633,31 @@ unsafe fn f() {
             "write!",
         ],
         &["std::ffi::CStr::from_ptr", "printf"],
+    );
+}
+
+#[test]
+fn test_fprintf_assume_to_str_ok_local_array_string() {
+    run_test_with_config(
+        r#"
+unsafe fn f(stream: *mut FILE) {
+    let mut buf: [libc::c_char; 10] = [0; 10];
+    fprintf(
+        stream,
+        b"%s\n\0" as *const u8 as *const libc::c_char,
+        buf.as_mut_ptr(),
+    );
+}"#,
+        super::Config {
+            assume_to_str_ok: true,
+        },
+        &[
+            "std::ffi::CStr::from_bytes_until_nul",
+            "bytemuck::cast_slice",
+            ".to_str().unwrap()",
+            "write!",
+        ],
+        &["std::ffi::CStr::from_ptr", "fprintf"],
     );
 }
 

--- a/crates/io_replacer/src/transformation/fopen.rs
+++ b/crates/io_replacer/src/transformation/fopen.rs
@@ -44,10 +44,9 @@ impl TransformVisitor<'_, '_, '_> {
     }
 
     fn make_open_expr(&self, open_mode: OpenMode, path: &Expr, mode: &Expr) -> Expr {
-        let path = pprust::expr_to_string(path);
-        let path_str = format!("std::ffi::CStr::from_ptr(({path}) as _).to_str().unwrap()");
         match open_mode {
             OpenMode::Read(plus) => {
+                let path_str = self.path_to_str_expr(path);
                 if plus {
                     expr!(
                         "std::fs::OpenOptions::new()
@@ -62,6 +61,7 @@ impl TransformVisitor<'_, '_, '_> {
                 }
             }
             OpenMode::Write(plus) => {
+                let path_str = self.path_to_str_expr(path);
                 if plus {
                     expr!(
                         "std::fs::OpenOptions::new()
@@ -78,6 +78,7 @@ impl TransformVisitor<'_, '_, '_> {
                 }
             }
             OpenMode::Append(plus) => {
+                let path_str = self.path_to_str_expr(path);
                 if plus {
                     expr!(
                         "std::fs::OpenOptions::new()
@@ -100,6 +101,7 @@ impl TransformVisitor<'_, '_, '_> {
                 }
             }
             OpenMode::Unknown => {
+                let path = pprust::expr_to_string(path);
                 self.lib_items.borrow_mut().insert(LibItem::Fopen);
                 expr!(
                     "crate::c_lib::rs_fopen({}, {})",
@@ -108,6 +110,14 @@ impl TransformVisitor<'_, '_, '_> {
                 )
             }
         }
+    }
+
+    fn path_to_str_expr(&self, path: &Expr) -> String {
+        let path_str = pprust::expr_to_string(path);
+        let cstr = self
+            .cstr_from_as_ptr(path)
+            .unwrap_or_else(|| format!("std::ffi::CStr::from_ptr(({path_str}) as _)"));
+        format!("{cstr}.to_str().unwrap()")
     }
 }
 

--- a/crates/io_replacer/src/transformation/fopen.rs
+++ b/crates/io_replacer/src/transformation/fopen.rs
@@ -46,7 +46,7 @@ impl TransformVisitor<'_, '_, '_> {
     fn make_open_expr(&self, open_mode: OpenMode, path: &Expr, mode: &Expr) -> Expr {
         match open_mode {
             OpenMode::Read(plus) => {
-                let path_str = self.path_to_str_expr(path);
+                let path_str = self.cstr_to_str_expr(path);
                 if plus {
                     expr!(
                         "std::fs::OpenOptions::new()
@@ -61,7 +61,7 @@ impl TransformVisitor<'_, '_, '_> {
                 }
             }
             OpenMode::Write(plus) => {
-                let path_str = self.path_to_str_expr(path);
+                let path_str = self.cstr_to_str_expr(path);
                 if plus {
                     expr!(
                         "std::fs::OpenOptions::new()
@@ -78,7 +78,7 @@ impl TransformVisitor<'_, '_, '_> {
                 }
             }
             OpenMode::Append(plus) => {
-                let path_str = self.path_to_str_expr(path);
+                let path_str = self.cstr_to_str_expr(path);
                 if plus {
                     expr!(
                         "std::fs::OpenOptions::new()
@@ -110,14 +110,6 @@ impl TransformVisitor<'_, '_, '_> {
                 )
             }
         }
-    }
-
-    fn path_to_str_expr(&self, path: &Expr) -> String {
-        let path_str = pprust::expr_to_string(path);
-        let cstr = self
-            .cstr_from_as_ptr(path)
-            .unwrap_or_else(|| format!("std::ffi::CStr::from_ptr(({path_str}) as _)"));
-        format!("{cstr}.to_str().unwrap()")
     }
 }
 

--- a/crates/io_replacer/src/transformation/fprintf.rs
+++ b/crates/io_replacer/src/transformation/fprintf.rs
@@ -2,10 +2,8 @@ use std::{fmt::Write as _, ops::Deref};
 
 use rustc_ast::*;
 use rustc_ast_pretty::pprust;
-use rustc_middle::ty;
 use rustc_span::Symbol;
 use utils::{
-    ast::unwrap_cast_and_paren,
     expr,
     file::fprintf::{self, Conversion, FlagChar, Width},
 };
@@ -112,62 +110,11 @@ impl TransformVisitor<'_, '_, '_> {
             let arg_str = pprust::expr_to_string(arg);
             match cast {
                 "&str" => {
-                    let cstr =
-                        self.cstr_from_as_ptr(arg)
-                            .unwrap_or_else(|| match &unwrap_cast_and_paren(arg).kind {
-                                ExprKind::MethodCall(call)
-                                    if call.seg.ident.name == rustc_span::sym::as_ptr =>
-                                {
-                                    let hir_receiver = self
-                                        .ast_to_hir
-                                        .get_expr(call.receiver.id, self.tcx)
-                                        .unwrap();
-                                    let typeck = self.tcx.typeck(hir_receiver.hir_id.owner);
-                                    let ty = typeck.expr_ty(hir_receiver);
-                                    panic!("{arg_str} {ty}");
-                                }
-                                ExprKind::AddrOf(_, _, pointee) => {
-                                    if let ExprKind::Index(base, idx, _) =
-                                        &unwrap_cast_and_paren(pointee).kind
-                                    {
-                                        let hir_base =
-                                            self.ast_to_hir.get_expr(base.id, self.tcx).unwrap();
-                                        let typeck = self.tcx.typeck(hir_base.hir_id.owner);
-                                        let ty = typeck.expr_ty(hir_base);
-                                        let (ty::TyKind::Array(ety, _) | ty::TyKind::Slice(ety)) =
-                                            ty.peel_refs().kind()
-                                        else {
-                                            panic!("{arg_str} {ty}");
-                                        };
-                                        let base_str = pprust::expr_to_string(base);
-                                        let idx_str = pprust::expr_to_string(idx);
-                                        if *ety == self.tcx.types.u8 {
-                                            format!(
-                                                "
-    std::ffi::CStr::from_bytes_until_nul(&({base_str})[{idx_str}..]).unwrap()"
-                                            )
-                                        } else if ety.is_numeric() {
-                                            self.dependencies.bytemuck.set(true);
-                                            format!(
-                                            "
-    std::ffi::CStr::from_bytes_until_nul(bytemuck::cast_slice(&({base_str})[{idx_str}..])).unwrap()"
-                                        )
-                                        } else {
-                                            panic!("{arg_str} {ty}");
-                                        }
-                                    } else {
-                                        format!("std::ffi::CStr::from_ptr(({arg_str}) as _)")
-                                    }
-                                }
-                                _ => self
-                                    .cstr_from_struct_first_field(arg, &arg_str)
-                                    .unwrap_or_else(|| {
-                                        format!("std::ffi::CStr::from_ptr(({arg_str}) as _)")
-                                    }),
-                            });
                     if self.config.assume_to_str_ok {
-                        write!(args, "{cstr}.to_str().unwrap(), ").unwrap();
+                        let arg = self.cstr_to_str_expr(arg);
+                        write!(args, "{arg}, ").unwrap();
                     } else {
+                        let cstr = self.cstr_expr(arg);
                         write!(
                             args,
                             "{{
@@ -272,30 +219,6 @@ impl TransformVisitor<'_, '_, '_> {
             format!("crate::c_lib::rs_vfprintf({stream_str}, {fmt}, {args})"),
             stream,
         )
-    }
-
-    fn cstr_from_struct_first_field(&self, arg: &Expr, arg_str: &str) -> Option<String> {
-        let hir_arg = self.ast_to_hir.get_expr(arg.id, self.tcx)?;
-        let typeck = self.tcx.typeck(hir_arg.hir_id.owner);
-        let ty = typeck.expr_ty(hir_arg).peel_refs();
-        let ty::TyKind::Adt(adt_def, generic_args) = ty.kind() else {
-            return None;
-        };
-        if !adt_def.is_struct() {
-            return None;
-        }
-        let field = adt_def.all_fields().next()?;
-        let field_ty = field.ty(self.tcx, generic_args);
-        let ty::TyKind::RawPtr(pointee, _) = field_ty.kind() else {
-            return None;
-        };
-        if *pointee != self.tcx.types.i8 && *pointee != self.tcx.types.u8 {
-            return None;
-        }
-        let field_name = field.ident(self.tcx).name;
-        Some(format!(
-            "std::ffi::CStr::from_ptr(({arg_str}).{field_name} as _)"
-        ))
     }
 }
 

--- a/crates/io_replacer/src/transformation/fprintf.rs
+++ b/crates/io_replacer/src/transformation/fprintf.rs
@@ -112,58 +112,59 @@ impl TransformVisitor<'_, '_, '_> {
             let arg_str = pprust::expr_to_string(arg);
             match cast {
                 "&str" => {
-                    let cstr = match &unwrap_cast_and_paren(arg).kind {
-                        ExprKind::MethodCall(call)
-                            if call.seg.ident.name == rustc_span::sym::as_ptr =>
-                        {
-                            self.cstr_from_as_ptr(arg).unwrap_or_else(|| {
-                                let hir_receiver = self
-                                    .ast_to_hir
-                                    .get_expr(call.receiver.id, self.tcx)
-                                    .unwrap();
-                                let typeck = self.tcx.typeck(hir_receiver.hir_id.owner);
-                                let ty = typeck.expr_ty(hir_receiver);
-                                panic!("{arg_str} {ty}");
-                            })
-                        }
-                        ExprKind::AddrOf(_, _, pointee) => {
-                            if let ExprKind::Index(base, idx, _) =
-                                &unwrap_cast_and_paren(pointee).kind
-                            {
-                                let hir_base = self.ast_to_hir.get_expr(base.id, self.tcx).unwrap();
-                                let typeck = self.tcx.typeck(hir_base.hir_id.owner);
-                                let ty = typeck.expr_ty(hir_base);
-                                let (ty::TyKind::Array(ety, _) | ty::TyKind::Slice(ety)) =
-                                    ty.peel_refs().kind()
-                                else {
-                                    panic!("{arg_str} {ty}");
-                                };
-                                let base_str = pprust::expr_to_string(base);
-                                let idx_str = pprust::expr_to_string(idx);
-                                if *ety == self.tcx.types.u8 {
-                                    format!(
-                                        "
-    std::ffi::CStr::from_bytes_until_nul(&({base_str})[{idx_str}..]).unwrap()"
-                                    )
-                                } else if ety.is_numeric() {
-                                    self.dependencies.bytemuck.set(true);
-                                    format!(
-                                    "
-    std::ffi::CStr::from_bytes_until_nul(bytemuck::cast_slice(&({base_str})[{idx_str}..])).unwrap()"
-                                )
-                                } else {
+                    let cstr =
+                        self.cstr_from_as_ptr(arg)
+                            .unwrap_or_else(|| match &unwrap_cast_and_paren(arg).kind {
+                                ExprKind::MethodCall(call)
+                                    if call.seg.ident.name == rustc_span::sym::as_ptr =>
+                                {
+                                    let hir_receiver = self
+                                        .ast_to_hir
+                                        .get_expr(call.receiver.id, self.tcx)
+                                        .unwrap();
+                                    let typeck = self.tcx.typeck(hir_receiver.hir_id.owner);
+                                    let ty = typeck.expr_ty(hir_receiver);
                                     panic!("{arg_str} {ty}");
                                 }
-                            } else {
-                                format!("std::ffi::CStr::from_ptr(({arg_str}) as _)")
-                            }
-                        }
-                        _ => self
-                            .cstr_from_struct_first_field(arg, &arg_str)
-                            .unwrap_or_else(|| {
-                                format!("std::ffi::CStr::from_ptr(({arg_str}) as _)")
-                            }),
-                    };
+                                ExprKind::AddrOf(_, _, pointee) => {
+                                    if let ExprKind::Index(base, idx, _) =
+                                        &unwrap_cast_and_paren(pointee).kind
+                                    {
+                                        let hir_base =
+                                            self.ast_to_hir.get_expr(base.id, self.tcx).unwrap();
+                                        let typeck = self.tcx.typeck(hir_base.hir_id.owner);
+                                        let ty = typeck.expr_ty(hir_base);
+                                        let (ty::TyKind::Array(ety, _) | ty::TyKind::Slice(ety)) =
+                                            ty.peel_refs().kind()
+                                        else {
+                                            panic!("{arg_str} {ty}");
+                                        };
+                                        let base_str = pprust::expr_to_string(base);
+                                        let idx_str = pprust::expr_to_string(idx);
+                                        if *ety == self.tcx.types.u8 {
+                                            format!(
+                                                "
+    std::ffi::CStr::from_bytes_until_nul(&({base_str})[{idx_str}..]).unwrap()"
+                                            )
+                                        } else if ety.is_numeric() {
+                                            self.dependencies.bytemuck.set(true);
+                                            format!(
+                                            "
+    std::ffi::CStr::from_bytes_until_nul(bytemuck::cast_slice(&({base_str})[{idx_str}..])).unwrap()"
+                                        )
+                                        } else {
+                                            panic!("{arg_str} {ty}");
+                                        }
+                                    } else {
+                                        format!("std::ffi::CStr::from_ptr(({arg_str}) as _)")
+                                    }
+                                }
+                                _ => self
+                                    .cstr_from_struct_first_field(arg, &arg_str)
+                                    .unwrap_or_else(|| {
+                                        format!("std::ffi::CStr::from_ptr(({arg_str}) as _)")
+                                    }),
+                            });
                     if self.config.assume_to_str_ok {
                         write!(args, "{cstr}.to_str().unwrap(), ").unwrap();
                     } else {

--- a/crates/io_replacer/src/transformation/fwrite.rs
+++ b/crates/io_replacer/src/transformation/fwrite.rs
@@ -33,7 +33,7 @@ impl TransformVisitor<'_, '_, '_> {
         let ___size = {size};
         crate::c_lib::rs_fwrite(
             bytemuck::cast_slice(&({array})[..(___size * ({nitems})) as usize]),
-            ___size,
+            ___size as _,
             {stream_str}
         )
     }}"
@@ -47,7 +47,7 @@ impl TransformVisitor<'_, '_, '_> {
         let ___size = {size};
         crate::c_lib::rs_fwrite(
             &({array})[..(___size * ({nitems})) as usize],
-            ___size,
+            ___size as _,
             {stream_str}
         )
     }}"
@@ -64,7 +64,7 @@ impl TransformVisitor<'_, '_, '_> {
         let ___size = {size};
         crate::c_lib::rs_fwrite(
             std::slice::from_raw_parts(({ptr_str}) as _, (___size * ({nitems})) as usize),
-            ___size,
+            ___size as _,
             {stream_str}
         )
     }}"

--- a/crates/io_replacer/src/transformation/visitor.rs
+++ b/crates/io_replacer/src/transformation/visitor.rs
@@ -435,6 +435,81 @@ impl<'tcx, 'a> TransformVisitor<'tcx, 'a, '_> {
         ))
     }
 
+    pub(super) fn cstr_expr(&self, e: &Expr) -> String {
+        let e_str = pprust::expr_to_string(e);
+        self.cstr_from_as_ptr(e)
+            .unwrap_or_else(|| self.cstr_expr_fallback(e, &e_str))
+    }
+
+    pub(super) fn cstr_to_str_expr(&self, e: &Expr) -> String {
+        let cstr = self.cstr_expr(e);
+        format!("{cstr}.to_str().unwrap()")
+    }
+
+    fn cstr_expr_fallback(&self, e: &Expr, e_str: &str) -> String {
+        match &utils::ast::unwrap_cast_and_paren(e).kind {
+            ExprKind::AddrOf(_, _, pointee) => {
+                if let ExprKind::Index(base, idx, _) =
+                    &utils::ast::unwrap_cast_and_paren(pointee).kind
+                {
+                    let hir_base = self.ast_to_hir.get_expr(base.id, self.tcx).unwrap();
+                    let typeck = self.tcx.typeck(hir_base.hir_id.owner);
+                    let ty = typeck.expr_ty(hir_base);
+                    let (ty::TyKind::Array(ety, _) | ty::TyKind::Slice(ety)) =
+                        ty.peel_refs().kind()
+                    else {
+                        panic!("{e_str} {ty}");
+                    };
+                    let base_str = pprust::expr_to_string(base);
+                    let idx_str = pprust::expr_to_string(idx);
+                    if *ety == self.tcx.types.u8 {
+                        format!(
+                            "
+    std::ffi::CStr::from_bytes_until_nul(&({base_str})[{idx_str}..]).unwrap()"
+                        )
+                    } else if ety.is_numeric() {
+                        self.dependencies.bytemuck.set(true);
+                        format!(
+                            "
+    std::ffi::CStr::from_bytes_until_nul(bytemuck::cast_slice(&({base_str})[{idx_str}..])).unwrap()"
+                        )
+                    } else {
+                        panic!("{e_str} {ty}");
+                    }
+                } else {
+                    format!("std::ffi::CStr::from_ptr(({e_str}) as _)")
+                }
+            }
+            _ => self
+                .cstr_from_struct_first_field(e, e_str)
+                .unwrap_or_else(|| format!("std::ffi::CStr::from_ptr(({e_str}) as _)")),
+        }
+    }
+
+    fn cstr_from_struct_first_field(&self, arg: &Expr, arg_str: &str) -> Option<String> {
+        let hir_arg = self.ast_to_hir.get_expr(arg.id, self.tcx)?;
+        let typeck = self.tcx.typeck(hir_arg.hir_id.owner);
+        let ty = typeck.expr_ty(hir_arg).peel_refs();
+        let ty::TyKind::Adt(adt_def, generic_args) = ty.kind() else {
+            return None;
+        };
+        if !adt_def.is_struct() {
+            return None;
+        }
+        let field = adt_def.all_fields().next()?;
+        let field_ty = field.ty(self.tcx, generic_args);
+        let ty::TyKind::RawPtr(pointee, _) = field_ty.kind() else {
+            return None;
+        };
+        if *pointee != self.tcx.types.i8 && *pointee != self.tcx.types.u8 {
+            return None;
+        }
+        let field_name = field.ident(self.tcx).name;
+        Some(format!(
+            "std::ffi::CStr::from_ptr(({arg_str}).{field_name} as _)"
+        ))
+    }
+
     fn byte_slice_from_as_ptr(&self, e: &Expr) -> Option<(String, ty::Ty<'tcx>)> {
         if let Some((array, elem_ty)) = self.array_of_as_ptr(e) {
             return Some((format!("&({})", pprust::expr_to_string(array)), elem_ty));
@@ -1332,14 +1407,17 @@ impl MutVisitor for TransformVisitor<'_, '_, '_> {
                             self.replace_expr(expr, new_expr);
                         }
                         "rename" => {
-                            let new_expr = expr!("crate::c_lib::rs_rename");
+                            let old = self.cstr_to_str_expr(&args[0]);
+                            let new = self.cstr_to_str_expr(&args[1]);
+                            let new_expr = expr!("crate::c_lib::rs_rename({}, {})", old, new);
                             self.lib_items.borrow_mut().insert(LibItem::Rename);
-                            self.replace_expr(callee, new_expr);
+                            self.replace_expr(expr, new_expr);
                         }
                         "remove" => {
-                            let new_expr = expr!("crate::c_lib::rs_remove");
+                            let path = self.cstr_to_str_expr(&args[0]);
+                            let new_expr = expr!("crate::c_lib::rs_remove({})", path);
                             self.lib_items.borrow_mut().insert(LibItem::Remove);
-                            self.replace_expr(callee, new_expr);
+                            self.replace_expr(expr, new_expr);
                         }
                         "setvbuf" | "setbuf" => {
                             if let Some(loc) = self.loc_if_unsupported(&args[0]) {
@@ -1832,17 +1910,14 @@ pub(super) struct IndicatorCheck<'a> {
 
 pub(super) const RENAME: &str = r#"
 #[inline]
-pub(crate) unsafe fn rs_rename(old: *const i8, new: *const i8) -> i32 {
-    let old = std::ffi::CStr::from_ptr(old as _).to_str().unwrap();
-    let new = std::ffi::CStr::from_ptr(new as _).to_str().unwrap();
+pub(crate) fn rs_rename(old: &str, new: &str) -> i32 {
     std::fs::rename(old, new).map_or(-1, |_| 0)
 }
 "#;
 
 pub(super) const REMOVE: &str = r#"
 #[inline]
-pub(crate) unsafe fn rs_remove(path: *const i8) -> i32 {
-    let path = std::ffi::CStr::from_ptr(path as _).to_str().unwrap();
+pub(crate) fn rs_remove(path: &str) -> i32 {
     match std::fs::remove_file(path) {
         Ok(()) => 0,
         Err(e) => {

--- a/crates/pointer_replacer/src/analyses/type_qualifier/foster/fatness/libc.rs
+++ b/crates/pointer_replacer/src/analyses/type_qualifier/foster/fatness/libc.rs
@@ -55,11 +55,11 @@ pub fn libc_call<'tcx>(
             );
         }
         // all ptr args are fat, no dest effect
-        "strcmp" | "strcasecmp" | "strcspn" => {
+        "strcmp" | "strcasecmp" | "strcspn" | "fopen" => {
             mark_args_bottom(args, local_decls, locals, struct_fields, database);
         }
-        // first 2 ptr args are fat (third arg is size_t), no dest effect
-        "strncmp" | "strncasecmp" | "memcmp" => {
+        // first 2 ptr args are fat, no dest effect
+        "strncmp" | "strncasecmp" | "memcmp" | "setenv" | "rename" => {
             mark_args_bottom(
                 &args[..2.min(args.len())],
                 local_decls,
@@ -70,7 +70,7 @@ pub fn libc_call<'tcx>(
         }
         // first ptr arg is fat, no dest effect
         "strlen" | "strdup" | "atoi" | "atof" | "fgets" | "fputs" | "puts" | "fread" | "fwrite"
-        | "getenv" => {
+        | "getenv" | "remove" | "chmod" | "mkdir" | "rmdir" | "unlink" => {
             mark_args_bottom(
                 &args[..1.min(args.len())],
                 local_decls,


### PR DESCRIPTION
- Reuse shared C string conversion helpers for IO path and printf-style string arguments.
- Convert `fopen`, `remove`, and `rename` replacements to handle slice-backed C strings before falling back to raw pointers.
- Adjust `fwrite` size casts, libc pointer fatness rules, and IO replacement tests for these cases.