### PR TITLE
Fix downgrade freed borrow outputs

### DIFF
--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -3207,6 +3207,9 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         if let Some(field_free) = self.rewrite_owned_field_free_call(hir_expr, args) {
             return Some(field_free);
         }
+        if let Some(call_result_free) = self.rewrite_owned_call_result_free_call(hir_expr) {
+            return Some(call_result_free);
+        }
         if let Some((hir_id, _harg)) =
             hir_free_like_arg_local_id(self.tcx, hir_expr, &self.free_like_wrappers)
         {
@@ -3247,6 +3250,25 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             }
         }
         self.rewrite_scalar_box_from_raw_free_call(hir_expr, args)
+    }
+
+    fn rewrite_owned_call_result_free_call(&self, hir_expr: &'tcx hir::Expr<'tcx>) -> Option<Expr> {
+        if !hir_call_matches_foreign_name(self.tcx, hir_expr, "free") {
+            return None;
+        }
+        let hir::ExprKind::Call(_, hir_args) = hir_expr.kind else {
+            return None;
+        };
+        let [hir_arg] = hir_args else { return None };
+        let hir_arg = hir_unwrap_casts(hir_arg);
+        if !matches!(
+            hir_callee_output_kind(self.tcx, &self.sig_decs, &self.ptr_kinds, hir_arg),
+            Some(PtrKind::Box | PtrKind::OptBox | PtrKind::BoxedSlice | PtrKind::OptBoxedSlice)
+        ) {
+            return None;
+        }
+        let call_expr = hir_expr_snippet(self.tcx, hir_arg)?;
+        Some(utils::expr!("drop({call_expr})"))
     }
 
     fn rewrite_scalar_box_from_raw_free_call(
@@ -10125,7 +10147,9 @@ fn downgrade_freed_borrow_outputs(
         let Some(output_kind) = sig_dec.output_dec else {
             continue;
         };
-        if !is_borrow_like_decision(output_kind) && !output_kind.is_owning_box_like() {
+        let should_downgrade = is_borrow_like_decision(output_kind)
+            || output_kind.is_owning_box_like() && fn_output_may_return_input(tcx, callee_did);
+        if !should_downgrade {
             continue;
         }
         let output_lifetime = sig_dec.output_lifetime;
@@ -10155,6 +10179,55 @@ fn downgrade_freed_borrow_outputs(
         }
     }
     changed
+}
+
+fn fn_output_may_return_input(tcx: TyCtxt<'_>, did: LocalDefId) -> bool {
+    let sig = tcx.fn_sig(did).skip_binder().skip_binder();
+    let input_len = sig.inputs().len();
+    let return_local = rustc_middle::mir::Local::from_u32(0);
+    let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+
+    for bb in body.basic_blocks.iter() {
+        for stmt in &bb.statements {
+            let rustc_middle::mir::StatementKind::Assign(box (place, rvalue)) = &stmt.kind else {
+                continue;
+            };
+            if place.as_local() != Some(return_local) {
+                continue;
+            }
+            if rvalue_uses_input_local(rvalue, input_len) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn rvalue_uses_input_local(rvalue: &rustc_middle::mir::Rvalue<'_>, input_len: usize) -> bool {
+    match rvalue {
+        rustc_middle::mir::Rvalue::Use(operand)
+        | rustc_middle::mir::Rvalue::Cast(_, operand, _) => {
+            operand_uses_input_local(operand, input_len)
+        }
+        rustc_middle::mir::Rvalue::Ref(_, _, place) => place_uses_input_local(place, input_len),
+        _ => false,
+    }
+}
+
+fn operand_uses_input_local(operand: &rustc_middle::mir::Operand<'_>, input_len: usize) -> bool {
+    match operand {
+        rustc_middle::mir::Operand::Copy(place) | rustc_middle::mir::Operand::Move(place) => {
+            place_uses_input_local(place, input_len)
+        }
+        rustc_middle::mir::Operand::Constant(_) => false,
+    }
+}
+
+fn place_uses_input_local(place: &rustc_middle::mir::Place<'_>, input_len: usize) -> bool {
+    place
+        .as_local()
+        .is_some_and(|local| (1..=input_len).contains(&local.as_usize()))
 }
 
 fn downgrade_raw_cast_call_inputs(

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -102,6 +102,8 @@ struct BorrowedRawParamInfo {
 enum LocalRawParamSummary {
     BorrowOnly,
     ReturnedToOwningOutput,
+    ReturnedToBorrowedOutput,
+    Freed,
     Escapes,
 }
 
@@ -109,7 +111,9 @@ impl LocalRawParamSummary {
     fn preserves_owning_call_boundary(self) -> bool {
         matches!(
             self,
-            LocalRawParamSummary::BorrowOnly | LocalRawParamSummary::ReturnedToOwningOutput
+            LocalRawParamSummary::BorrowOnly
+                | LocalRawParamSummary::ReturnedToOwningOutput
+                | LocalRawParamSummary::ReturnedToBorrowedOutput
         )
     }
 }
@@ -1554,6 +1558,12 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             DecisionReason::UnsupportedAllocatorRoot,
         );
         normalize_forced_raw_bindings(rust_program.tcx, &mut ptr_kinds, &forced_raw_bindings);
+        normalize_owning_call_result_bindings(
+            rust_program.tcx,
+            &sig_decs,
+            &mut ptr_kinds,
+            &forced_raw_bindings,
+        );
         loop {
             let mut changed = false;
             let local_struct_downgrades =
@@ -1634,8 +1644,12 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             if box_input_changed {
                 changed = true;
             }
-            let unsupported_box_outputs =
-                downgrade_unsupported_box_outputs(rust_program.tcx, &mut sig_decs, &ptr_kinds);
+            let unsupported_box_outputs = downgrade_unsupported_box_outputs(
+                rust_program.tcx,
+                &mut sig_decs,
+                &ptr_kinds,
+                &config.c_exposed_fns,
+            );
             for did in &unsupported_box_outputs {
                 record_signature_output_event(
                     &mut diagnostics,
@@ -1784,6 +1798,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             let unsupported_box_usage_subreasons = if diagnostics.is_enabled() {
                 collect_unsupported_box_usage_subreasons(
                     rust_program.tcx,
+                    &sig_decs,
                     &ptr_kinds,
                     &free_like_wrappers,
                     &local_raw_param_summaries,
@@ -1793,6 +1808,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             };
             let unsupported_box_usage_bindings = collect_unsupported_box_usage_bindings(
                 rust_program.tcx,
+                &sig_decs,
                 &ptr_kinds,
                 &free_like_wrappers,
                 &local_raw_param_summaries,
@@ -1835,12 +1851,24 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     &mut ptr_kinds,
                     &forced_raw_bindings,
                 );
+                normalize_owning_call_result_bindings(
+                    rust_program.tcx,
+                    &sig_decs,
+                    &mut ptr_kinds,
+                    &forced_raw_bindings,
+                );
             }
             if !changed {
                 break;
             }
             ptr_kinds = collect_diffs(rust_program, analysis, &sig_decs, &fn_ptr_groups);
             normalize_forced_raw_bindings(rust_program.tcx, &mut ptr_kinds, &forced_raw_bindings);
+            normalize_owning_call_result_bindings(
+                rust_program.tcx,
+                &sig_decs,
+                &mut ptr_kinds,
+                &forced_raw_bindings,
+            );
         }
 
         let alloc_wrappers = collect_local_allocator_wrappers(rust_program.tcx);
@@ -1900,6 +1928,12 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             ptr_kinds = collect_diffs(rust_program, analysis, &sig_decs, &fn_ptr_groups);
         }
         normalize_forced_raw_bindings(rust_program.tcx, &mut ptr_kinds, &forced_raw_bindings);
+        normalize_owning_call_result_bindings(
+            rust_program.tcx,
+            &sig_decs,
+            &mut ptr_kinds,
+            &forced_raw_bindings,
+        );
         apply_field_storage_input_lifetimes(
             rust_program.tcx,
             analysis,
@@ -3444,16 +3478,14 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         }
 
         let callee_output = self.forced_local_callee_output_kind(hir_expr);
-        if callee_output == Some(target_kind)
-            || callee_output == Some(target_kind.optional_variant())
-        {
+        if callee_output.is_some_and(|kind| ptr_kind_supports_box_target(kind, target_kind)) {
             return true;
         }
 
         if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_expr.kind
             && let Res::Local(hir_id) = path.res
             && let Some(rhs_kind) = self.effective_ptr_kind(hir_id)
-            && (rhs_kind == target_kind || rhs_kind == target_kind.optional_variant())
+            && ptr_kind_supports_box_target(rhs_kind, target_kind)
         {
             return true;
         }
@@ -8510,7 +8542,9 @@ fn fn_tail_returns_unsupported_box_binding<'tcx>(
         target_kind: PtrKind,
         lhs_inner_ty: ty::Ty<'tcx>,
     ) -> bool {
-        if !hir_rhs_supports_box_target(tcx, sig_decs, ptr_kinds, expr, target_kind, lhs_inner_ty) {
+        if !hir_rhs_supports_box_target(tcx, sig_decs, ptr_kinds, expr, target_kind, lhs_inner_ty)
+            && !hir_rhs_supports_optional_box_return(tcx, sig_decs, ptr_kinds, expr, target_kind)
+        {
             return true;
         }
         let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_unwrap_casts(expr).kind else {
@@ -8596,6 +8630,79 @@ fn normalize_forced_raw_bindings(
                 .unwrap_or_else(|| kind.is_mut());
             *kind = PtrKind::Raw(raw_mut);
         }
+    }
+}
+
+fn normalize_owning_call_result_bindings(
+    tcx: TyCtxt<'_>,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &mut FxHashMap<HirId, PtrKind>,
+    forced_raw_bindings: &FxHashSet<HirId>,
+) {
+    struct OwningCallResultVisitor<'a, 'tcx> {
+        tcx: TyCtxt<'tcx>,
+        sig_decs: &'a SigDecisions,
+        ptr_kinds: &'a mut FxHashMap<HirId, PtrKind>,
+        forced_raw_bindings: &'a FxHashSet<HirId>,
+    }
+
+    impl<'tcx> OwningCallResultVisitor<'_, 'tcx> {
+        fn normalize_binding(&mut self, hir_id: HirId, rhs: &'tcx hir::Expr<'tcx>) {
+            if self.forced_raw_bindings.contains(&hir_id) {
+                return;
+            }
+            let Some(output_kind) =
+                hir_callee_output_kind(self.tcx, self.sig_decs, self.ptr_kinds, rhs)
+            else {
+                return;
+            };
+            if output_kind.is_owning_box_like() {
+                self.ptr_kinds.insert(hir_id, output_kind);
+            }
+        }
+    }
+
+    impl<'tcx> Visitor<'tcx> for OwningCallResultVisitor<'_, 'tcx> {
+        fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) -> Self::Result {
+            if let hir::StmtKind::Let(let_stmt) = stmt.kind
+                && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
+                && let Some(init) = let_stmt.init
+            {
+                self.normalize_binding(hir_id, init);
+            }
+            intravisit::walk_stmt(self, stmt);
+        }
+
+        fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
+            if let hir::ExprKind::Assign(lhs, rhs, _) = expr.kind
+                && let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = lhs.kind
+                && let Res::Local(hir_id) = path.res
+            {
+                self.normalize_binding(hir_id, rhs);
+            }
+            intravisit::walk_expr(self, expr);
+        }
+    }
+
+    let crate_hir = tcx.hir_crate(());
+    for maybe_owner in crate_hir.owners.iter() {
+        let Some(owner) = maybe_owner.as_owner() else {
+            continue;
+        };
+        let hir::OwnerNode::Item(item) = owner.node() else {
+            continue;
+        };
+        let hir::ItemKind::Fn { body, .. } = item.kind else {
+            continue;
+        };
+        let body = tcx.hir_body(body);
+        let mut visitor = OwningCallResultVisitor {
+            tcx,
+            sig_decs,
+            ptr_kinds,
+            forced_raw_bindings,
+        };
+        visitor.visit_body(body);
     }
 }
 
@@ -9402,6 +9509,22 @@ fn is_borrow_like_decision(kind: PtrKind) -> bool {
         kind,
         PtrKind::Ref(_) | PtrKind::OptRef(_) | PtrKind::Slice(_) | PtrKind::SliceCursor(_)
     )
+}
+
+fn local_callee_arg_preserves_owning_usage(
+    sig_decs: &SigDecisions,
+    local_raw_param_summaries: &FxHashMap<(LocalDefId, usize), LocalRawParamSummary>,
+    callee: LocalDefId,
+    arg_index: usize,
+) -> bool {
+    if let Some(summary) = local_raw_param_summaries.get(&(callee, arg_index)).copied() {
+        return summary.preserves_owning_call_boundary();
+    }
+    sig_decs
+        .data
+        .get(&callee)
+        .and_then(|sig_dec| sig_dec.input_decs.get(arg_index).copied().flatten())
+        .is_some_and(is_borrow_like_decision)
 }
 
 fn is_mutable_borrow_like_decision(kind: PtrKind) -> bool {
@@ -10696,6 +10819,7 @@ fn downgrade_unsupported_box_outputs<'tcx>(
     tcx: TyCtxt<'tcx>,
     sig_decs: &mut SigDecisions,
     ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    c_exposed_fns: &FxHashSet<String>,
 ) -> FxHashSet<LocalDefId> {
     let mut to_raw = Vec::new();
     for (did, sig_dec) in &sig_decs.data {
@@ -10711,14 +10835,16 @@ fn downgrade_unsupported_box_outputs<'tcx>(
         else {
             continue;
         };
-        if fn_tail_returns_unsupported_box_binding(
-            tcx,
-            sig_decs,
-            ptr_kinds,
-            *did,
-            output_kind,
-            inner_ty,
-        ) || fn_output_has_nonowning_local_consumers(tcx, ptr_kinds, *did, output_kind)
+        if is_c_exposed_fn(tcx, *did, c_exposed_fns)
+            || fn_tail_returns_unsupported_box_binding(
+                tcx,
+                sig_decs,
+                ptr_kinds,
+                *did,
+                output_kind,
+                inner_ty,
+            )
+            || fn_output_has_unsupported_nonlocal_consumers(tcx, ptr_kinds, *did, output_kind)
         {
             to_raw.push(*did);
         }
@@ -10733,13 +10859,13 @@ fn downgrade_unsupported_box_outputs<'tcx>(
     changed
 }
 
-fn fn_output_has_nonowning_local_consumers(
+fn fn_output_has_unsupported_nonlocal_consumers(
     tcx: TyCtxt<'_>,
     ptr_kinds: &FxHashMap<HirId, PtrKind>,
     callee_did: LocalDefId,
     output_kind: PtrKind,
 ) -> bool {
-    struct NonOwningCallConsumerVisitor<'a, 'tcx> {
+    struct NonlocalCallConsumerVisitor<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
         ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
         callee_did: LocalDefId,
@@ -10747,25 +10873,7 @@ fn fn_output_has_nonowning_local_consumers(
         found: bool,
     }
 
-    impl<'tcx> NonOwningCallConsumerVisitor<'_, 'tcx> {
-        fn local_target_kind(&self, hir_id: HirId) -> Option<PtrKind> {
-            self.ptr_kinds.get(&hir_id).copied().or_else(|| {
-                let ty = self.tcx.typeck(hir_id.owner).node_type(hir_id);
-                unwrap_ptr_from_mir_ty(ty).map(|(_, m)| PtrKind::Raw(m.is_mut()))
-            })
-        }
-
-        fn expr_target_kind(&self, expr: &'tcx hir::Expr<'tcx>) -> Option<PtrKind> {
-            let expr = hir_unwrap_casts(expr);
-            if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = expr.kind
-                && let Res::Local(hir_id) = path.res
-            {
-                return self.local_target_kind(hir_id);
-            }
-            let ty = self.tcx.typeck(expr.hir_id.owner).expr_ty(expr);
-            unwrap_ptr_from_mir_ty(ty).map(|(_, m)| PtrKind::Raw(m.is_mut()))
-        }
-
+    impl<'tcx> NonlocalCallConsumerVisitor<'_, 'tcx> {
         fn call_targets_callee(&self, expr: &'tcx hir::Expr<'tcx>) -> bool {
             let expr = hir_unwrap_casts(expr);
             let hir::ExprKind::Call(func, _) = expr.kind else {
@@ -10781,38 +10889,43 @@ fn fn_output_has_nonowning_local_consumers(
             def_id.as_local() == Some(self.callee_did)
         }
 
-        fn target_kind_is_nonowning(&self, kind: Option<PtrKind>) -> bool {
-            kind != Some(self.output_kind)
+        fn expr_target_kind(&self, expr: &'tcx hir::Expr<'tcx>) -> Option<PtrKind> {
+            let expr = hir_unwrap_casts(expr);
+            if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = expr.kind
+                && let Res::Local(hir_id) = path.res
+            {
+                return self.ptr_kinds.get(&hir_id).copied();
+            }
+            let ty = self.tcx.typeck(expr.hir_id.owner).expr_ty(expr);
+            unwrap_ptr_from_mir_ty(ty).map(|(_, m)| PtrKind::Raw(m.is_mut()))
         }
     }
 
-    impl<'tcx> Visitor<'tcx> for NonOwningCallConsumerVisitor<'_, 'tcx> {
-        fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) -> Self::Result {
-            if self.found {
-                return;
-            }
-            if let hir::StmtKind::Let(let_stmt) = stmt.kind
-                && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
-                && let Some(init) = let_stmt.init
-                && self.call_targets_callee(init)
-                && self.target_kind_is_nonowning(self.local_target_kind(hir_id))
-            {
-                self.found = true;
-                return;
-            }
-            intravisit::walk_stmt(self, stmt);
-        }
-
+    impl<'tcx> Visitor<'tcx> for NonlocalCallConsumerVisitor<'_, 'tcx> {
         fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
             if self.found {
                 return;
             }
             if let hir::ExprKind::Assign(lhs, rhs, _) = expr.kind
                 && self.call_targets_callee(rhs)
-                && self.target_kind_is_nonowning(self.expr_target_kind(lhs))
             {
-                self.found = true;
-                return;
+                if matches!(
+                    hir_unwrap_casts(lhs).kind,
+                    hir::ExprKind::Path(hir::QPath::Resolved(
+                        _,
+                        hir::Path {
+                            res: Res::Local(_),
+                            ..
+                        }
+                    ))
+                ) {
+                    intravisit::walk_expr(self, expr);
+                    return;
+                }
+                if self.expr_target_kind(lhs) != Some(self.output_kind) {
+                    self.found = true;
+                    return;
+                }
             }
             intravisit::walk_expr(self, expr);
         }
@@ -10830,7 +10943,7 @@ fn fn_output_has_nonowning_local_consumers(
             continue;
         };
         let body = tcx.hir_body(body);
-        let mut visitor = NonOwningCallConsumerVisitor {
+        let mut visitor = NonlocalCallConsumerVisitor {
             tcx,
             ptr_kinds,
             callee_did,
@@ -10864,24 +10977,11 @@ fn local_called_fn_def_id(tcx: TyCtxt<'_>, hir_expr: &hir::Expr<'_>) -> Option<L
 fn effective_callee_output_kind(
     tcx: TyCtxt<'_>,
     sig_decs: &SigDecisions,
-    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    _ptr_kinds: &FxHashMap<HirId, PtrKind>,
     def_id: LocalDefId,
 ) -> Option<PtrKind> {
     let sig_dec = sig_decs.data.get(&def_id)?;
     if let Some(output_dec) = sig_dec.output_dec {
-        let body = tcx.mir_drops_elaborated_and_const_checked(def_id).borrow();
-        let Some((inner_ty, _)) =
-            unwrap_ptr_from_mir_ty(body.local_decls[rustc_middle::mir::Local::from_u32(0)].ty)
-        else {
-            return Some(output_dec);
-        };
-        if output_dec.is_owning_box_like()
-            && (fn_tail_returns_unsupported_box_binding(
-                tcx, sig_decs, ptr_kinds, def_id, output_dec, inner_ty,
-            ) || fn_output_has_nonowning_local_consumers(tcx, ptr_kinds, def_id, output_dec))
-        {
-            return Some(PtrKind::Raw(true));
-        }
         return Some(output_dec);
     }
     let sig = tcx.fn_sig(def_id).skip_binder().skip_binder();
@@ -10951,6 +11051,7 @@ fn hir_is_borrow_only_foreign_buffer_arg(
     };
     match name.as_str() {
         "memcpy" | "memmove" => arg_index < 2,
+        "memchr" => arg_index == 0,
         "memset" => arg_index == 0,
         "strncpy" => arg_index < 2,
         _ => false,
@@ -12143,8 +12244,10 @@ fn collect_local_raw_param_summaries(
 ) -> FxHashMap<(LocalDefId, usize), LocalRawParamSummary> {
     #[derive(Default)]
     struct ParamFacts {
+        direct_free: bool,
         direct_escape: bool,
         returned_to_owning_output: bool,
+        returned_to_borrowed_output: bool,
         deps: FxHashSet<(LocalDefId, usize)>,
     }
 
@@ -12187,7 +12290,8 @@ fn collect_local_raw_param_summaries(
         free_like_wrappers: &'a FxHashSet<LocalDefId>,
         raw_params_by_fn: &'a FxHashMap<LocalDefId, FxHashMap<HirId, usize>>,
         current_raw_params: &'a FxHashMap<HirId, usize>,
-        returns_owning_output: bool,
+        output_dec: Option<PtrKind>,
+        local_storage_params: FxHashMap<HirId, FxHashSet<usize>>,
         facts: FxHashMap<usize, ParamFacts>,
     }
 
@@ -12197,8 +12301,43 @@ fn collect_local_raw_param_summaries(
             self.current_raw_params.get(&hir_id).copied()
         }
 
+        fn param_indices_in_expr(&self, expr: &'tcx hir::Expr<'tcx>) -> FxHashSet<usize> {
+            let mut params = FxHashSet::default();
+            if let Some(param_index) = self.param_index(expr) {
+                params.insert(param_index);
+            }
+            if let Some(root) = hir_local_place_root_without_deref(expr)
+                && let Some(stored_params) = self.local_storage_params.get(&root)
+            {
+                params.extend(stored_params.iter().copied());
+            }
+            params
+        }
+
+        fn track_local_storage(
+            &mut self,
+            lhs: &'tcx hir::Expr<'tcx>,
+            params: &FxHashSet<usize>,
+        ) -> bool {
+            let Some(root) = hir_local_place_root_without_deref(lhs) else {
+                return false;
+            };
+            if self.current_raw_params.contains_key(&root) {
+                return false;
+            }
+            self.local_storage_params
+                .entry(root)
+                .or_default()
+                .extend(params.iter().copied());
+            true
+        }
+
         fn mark_escape(&mut self, param_index: usize) {
             self.facts.entry(param_index).or_default().direct_escape = true;
+        }
+
+        fn mark_free(&mut self, param_index: usize) {
+            self.facts.entry(param_index).or_default().direct_free = true;
         }
 
         fn mark_returned_to_owning_output(&mut self, param_index: usize) {
@@ -12206,6 +12345,25 @@ fn collect_local_raw_param_summaries(
                 .entry(param_index)
                 .or_default()
                 .returned_to_owning_output = true;
+        }
+
+        fn mark_returned_to_borrowed_output(&mut self, param_index: usize) {
+            self.facts
+                .entry(param_index)
+                .or_default()
+                .returned_to_borrowed_output = true;
+        }
+
+        fn mark_return(&mut self, param_index: usize) {
+            match self.output_dec {
+                Some(kind) if kind.is_owning_box_like() => {
+                    self.mark_returned_to_owning_output(param_index);
+                }
+                Some(kind) if is_borrow_bridgeable_source_decision(kind) => {
+                    self.mark_returned_to_borrowed_output(param_index);
+                }
+                _ => self.mark_escape(param_index),
+            }
         }
 
         fn add_dep(&mut self, param_index: usize, dep: (LocalDefId, usize)) {
@@ -12216,10 +12374,16 @@ fn collect_local_raw_param_summaries(
     impl<'tcx> Visitor<'tcx> for RawParamSummaryVisitor<'_, 'tcx> {
         fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) -> Self::Result {
             if let hir::StmtKind::Let(let_stmt) = stmt.kind
+                && let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind
                 && let Some(init) = let_stmt.init
-                && let Some(param_index) = self.param_index(init)
             {
-                self.mark_escape(param_index);
+                let params = self.param_indices_in_expr(init);
+                if !params.is_empty() {
+                    self.local_storage_params
+                        .entry(hir_id)
+                        .or_default()
+                        .extend(params);
+                }
             }
             intravisit::walk_stmt(self, stmt);
         }
@@ -12227,17 +12391,19 @@ fn collect_local_raw_param_summaries(
         fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Self::Result {
             match expr.kind {
                 hir::ExprKind::Assign(_, rhs, _) => {
-                    if let Some(param_index) = self.param_index(rhs) {
-                        self.mark_escape(param_index);
+                    let params = self.param_indices_in_expr(rhs);
+                    if !params.is_empty()
+                        && let hir::ExprKind::Assign(lhs, _, _) = expr.kind
+                        && !self.track_local_storage(lhs, &params)
+                    {
+                        for param_index in params {
+                            self.mark_escape(param_index);
+                        }
                     }
                 }
                 hir::ExprKind::Ret(Some(ret)) => {
-                    if let Some(param_index) = self.param_index(ret) {
-                        if self.returns_owning_output {
-                            self.mark_returned_to_owning_output(param_index);
-                        } else {
-                            self.mark_escape(param_index);
-                        }
+                    for param_index in self.param_indices_in_expr(ret) {
+                        self.mark_return(param_index);
                     }
                 }
                 hir::ExprKind::Call(_, args) => {
@@ -12246,34 +12412,42 @@ fn collect_local_raw_param_summaries(
                             .map(|(hir_id, _)| hir_id);
                     let local_callee = hir_called_local_fn(self.tcx, expr);
                     for (arg_index, arg) in args.iter().enumerate() {
-                        let Some(hir_id) = hir_unwrapped_local_id(arg) else {
+                        let params = self.param_indices_in_expr(arg);
+                        if params.is_empty() {
                             continue;
-                        };
-                        let Some(param_index) = self.current_raw_params.get(&hir_id).copied()
-                        else {
-                            continue;
-                        };
-                        if Some(hir_id) == free_arg {
-                            self.mark_escape(param_index);
+                        }
+                        let arg_hir_id = hir_unwrapped_local_id(arg);
+                        if arg_hir_id == free_arg {
+                            for param_index in params {
+                                self.mark_free(param_index);
+                            }
                             continue;
                         }
                         match local_callee {
                             Some(callee) => {
                                 let Some(callee_raw_params) = self.raw_params_by_fn.get(&callee)
                                 else {
-                                    self.mark_escape(param_index);
+                                    for param_index in params {
+                                        self.mark_escape(param_index);
+                                    }
                                     continue;
                                 };
                                 if callee_raw_params.values().any(|idx| *idx == arg_index) {
-                                    self.add_dep(param_index, (callee, arg_index));
+                                    for param_index in params {
+                                        self.add_dep(param_index, (callee, arg_index));
+                                    }
                                 } else {
-                                    self.mark_escape(param_index);
+                                    for param_index in params {
+                                        self.mark_escape(param_index);
+                                    }
                                 }
                             }
                             None => {
                                 if !hir_is_borrow_only_foreign_buffer_arg(self.tcx, expr, arg_index)
                                 {
-                                    self.mark_escape(param_index);
+                                    for param_index in params {
+                                        self.mark_escape(param_index);
+                                    }
                                 }
                             }
                         }
@@ -12293,12 +12467,8 @@ fn collect_local_raw_param_summaries(
                 };
                 tail = expr;
             }
-            if let Some(param_index) = self.param_index(tail) {
-                if self.returns_owning_output {
-                    self.mark_returned_to_owning_output(param_index);
-                } else {
-                    self.mark_escape(param_index);
-                }
+            for param_index in self.param_indices_in_expr(tail) {
+                self.mark_return(param_index);
             }
         }
     }
@@ -12315,21 +12485,25 @@ fn collect_local_raw_param_summaries(
             continue;
         };
         let body = tcx.hir_body(body);
-        let returns_owning_output = sig_decs.data.get(def_id).is_some_and(|sig_dec| {
-            sig_dec
-                .output_dec
-                .is_some_and(|kind| kind.is_owning_box_like())
-        });
+        let output_dec = sig_decs
+            .data
+            .get(def_id)
+            .and_then(|sig_dec| sig_dec.output_dec);
         let mut visitor = RawParamSummaryVisitor {
             tcx,
             free_like_wrappers,
             raw_params_by_fn: &raw_params_by_fn,
             current_raw_params: raw_params,
-            returns_owning_output,
+            output_dec,
+            local_storage_params: FxHashMap::default(),
             facts: FxHashMap::default(),
         };
         visitor.visit_body(body);
         for (param_index, facts) in visitor.facts {
+            facts_by_param
+                .entry((*def_id, param_index))
+                .or_default()
+                .direct_free |= facts.direct_free;
             facts_by_param
                 .entry((*def_id, param_index))
                 .or_default()
@@ -12338,6 +12512,10 @@ fn collect_local_raw_param_summaries(
                 .entry((*def_id, param_index))
                 .or_default()
                 .returned_to_owning_output |= facts.returned_to_owning_output;
+            facts_by_param
+                .entry((*def_id, param_index))
+                .or_default()
+                .returned_to_borrowed_output |= facts.returned_to_borrowed_output;
             facts_by_param
                 .entry((*def_id, param_index))
                 .or_default()
@@ -12354,7 +12532,9 @@ fn collect_local_raw_param_summaries(
     loop {
         let mut changed = false;
         for (key, facts) in &facts_by_param {
-            let next = if facts.direct_escape
+            let next = if facts.direct_free {
+                LocalRawParamSummary::Freed
+            } else if facts.direct_escape
                 || facts
                     .deps
                     .iter()
@@ -12363,6 +12543,8 @@ fn collect_local_raw_param_summaries(
                 LocalRawParamSummary::Escapes
             } else if facts.returned_to_owning_output {
                 LocalRawParamSummary::ReturnedToOwningOutput
+            } else if facts.returned_to_borrowed_output {
+                LocalRawParamSummary::ReturnedToBorrowedOutput
             } else {
                 LocalRawParamSummary::BorrowOnly
             };
@@ -13017,7 +13199,7 @@ fn hir_rhs_supports_box_target<'tcx>(
 
     if let hir::ExprKind::Call(..) = hir_expr.kind
         && let Some(output_kind) = hir_callee_output_kind(tcx, sig_decs, ptr_kinds, hir_expr)
-        && (output_kind == target_kind || output_kind == target_kind.optional_variant())
+        && ptr_kind_supports_box_target(output_kind, target_kind)
     {
         return true;
     }
@@ -13025,11 +13207,39 @@ fn hir_rhs_supports_box_target<'tcx>(
     if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_expr.kind
         && let Res::Local(hir_id) = path.res
         && let Some(rhs_kind) = ptr_kinds.get(&hir_id).copied()
-        && (rhs_kind == target_kind || rhs_kind == target_kind.optional_variant())
+        && ptr_kind_supports_box_target(rhs_kind, target_kind)
     {
         return true;
     }
 
+    false
+}
+
+fn ptr_kind_supports_box_target(source_kind: PtrKind, target_kind: PtrKind) -> bool {
+    source_kind == target_kind || source_kind == target_kind.optional_variant()
+}
+
+fn hir_rhs_supports_optional_box_return(
+    tcx: TyCtxt<'_>,
+    sig_decs: &SigDecisions,
+    ptr_kinds: &FxHashMap<HirId, PtrKind>,
+    hir_expr: &hir::Expr<'_>,
+    target_kind: PtrKind,
+) -> bool {
+    if !matches!(target_kind, PtrKind::OptBox | PtrKind::OptBoxedSlice) {
+        return false;
+    }
+    if let hir::ExprKind::Call(..) = hir_expr.kind
+        && let Some(output_kind) = hir_callee_output_kind(tcx, sig_decs, ptr_kinds, hir_expr)
+    {
+        return output_kind.optional_variant() == target_kind;
+    }
+    if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_expr.kind
+        && let Res::Local(hir_id) = path.res
+        && let Some(rhs_kind) = ptr_kinds.get(&hir_id).copied()
+    {
+        return rhs_kind.optional_variant() == target_kind;
+    }
     false
 }
 
@@ -13120,16 +13330,19 @@ fn collect_unsupported_box_target_bindings(
 
 fn collect_unsupported_box_usage_bindings(
     tcx: TyCtxt<'_>,
+    sig_decs: &SigDecisions,
     ptr_kinds: &FxHashMap<HirId, PtrKind>,
     free_like_wrappers: &FxHashSet<LocalDefId>,
     local_raw_param_summaries: &FxHashMap<(LocalDefId, usize), LocalRawParamSummary>,
 ) -> FxHashSet<HirId> {
     struct UnsupportedBoxUsageVisitor<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
+        sig_decs: &'a SigDecisions,
         ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
         free_like_wrappers: &'a FxHashSet<LocalDefId>,
         local_raw_param_summaries: &'a FxHashMap<(LocalDefId, usize), LocalRawParamSummary>,
         byte_view_roots: FxHashMap<HirId, HirId>,
+        returned_alias_roots: FxHashMap<HirId, HirId>,
         bindings: FxHashSet<HirId>,
     }
 
@@ -13141,6 +13354,8 @@ fn collect_unsupported_box_usage_bindings(
                 .is_some_and(PtrKind::is_owning_box_like)
             {
                 Some(hir_id)
+            } else if let Some(root) = self.returned_alias_roots.get(&hir_id).copied() {
+                Some(root)
             } else {
                 self.byte_view_roots.get(&hir_id).copied()
             }
@@ -13173,6 +13388,36 @@ fn collect_unsupported_box_usage_bindings(
             }
             self.byte_view_roots.insert(lhs_hir_id, root);
             self.bindings.insert(root);
+        }
+
+        fn maybe_mark_returned_alias(&mut self, lhs_hir_id: HirId, rhs: &'tcx hir::Expr<'tcx>) {
+            let Some(local_callee) = hir_called_local_fn(self.tcx, rhs) else {
+                return;
+            };
+            let hir::ExprKind::Call(_, args) = rhs.kind else {
+                return;
+            };
+            let mut roots = FxHashSet::default();
+            for (arg_index, arg) in args.iter().enumerate() {
+                let Some(arg_hir_id) = hir_unwrapped_local_id(arg) else {
+                    continue;
+                };
+                let Some(root) = self.owning_root_of(arg_hir_id) else {
+                    continue;
+                };
+                if self
+                    .local_raw_param_summaries
+                    .get(&(local_callee, arg_index))
+                    == Some(&LocalRawParamSummary::ReturnedToBorrowedOutput)
+                {
+                    roots.insert(root);
+                }
+            }
+            if roots.len() == 1
+                && let Some(root) = roots.into_iter().next()
+            {
+                self.returned_alias_roots.insert(lhs_hir_id, root);
+            }
         }
 
         fn collect_owning_roots_in_expr(&self, expr: &'tcx hir::Expr<'tcx>) -> FxHashSet<HirId> {
@@ -13209,6 +13454,7 @@ fn collect_unsupported_box_usage_bindings(
             {
                 let lhs_ty = self.tcx.typeck(hir_id.owner).node_type(hir_id);
                 self.maybe_mark_byte_view_alias(hir_id, lhs_ty, init);
+                self.maybe_mark_returned_alias(hir_id, init);
             }
             intravisit::walk_stmt(self, stmt);
         }
@@ -13220,6 +13466,7 @@ fn collect_unsupported_box_usage_bindings(
             {
                 let lhs_ty = self.tcx.typeck(expr.hir_id.owner).expr_ty(lhs);
                 self.maybe_mark_byte_view_alias(lhs_hir_id, lhs_ty, rhs);
+                self.maybe_mark_returned_alias(lhs_hir_id, rhs);
             }
 
             if let Some(local_callee) = hir_called_local_fn(self.tcx, expr)
@@ -13232,12 +13479,12 @@ fn collect_unsupported_box_usage_bindings(
                     let Some(root) = self.owning_root_of(hir_id) else {
                         continue;
                     };
-                    if !self
-                        .local_raw_param_summaries
-                        .get(&(local_callee, arg_index))
-                        .copied()
-                        .is_some_and(LocalRawParamSummary::preserves_owning_call_boundary)
-                    {
+                    if !local_callee_arg_preserves_owning_usage(
+                        self.sig_decs,
+                        self.local_raw_param_summaries,
+                        local_callee,
+                        arg_index,
+                    ) {
                         self.bindings.insert(root);
                     }
                 }
@@ -13285,10 +13532,12 @@ fn collect_unsupported_box_usage_bindings(
         let body = tcx.hir_body(body);
         let mut visitor = UnsupportedBoxUsageVisitor {
             tcx,
+            sig_decs,
             ptr_kinds,
             free_like_wrappers,
             local_raw_param_summaries,
             byte_view_roots: FxHashMap::default(),
+            returned_alias_roots: FxHashMap::default(),
             bindings: FxHashSet::default(),
         };
         visitor.visit_body(body);
@@ -13300,12 +13549,14 @@ fn collect_unsupported_box_usage_bindings(
 
 fn collect_unsupported_box_usage_subreasons(
     tcx: TyCtxt<'_>,
+    sig_decs: &SigDecisions,
     ptr_kinds: &FxHashMap<HirId, PtrKind>,
     free_like_wrappers: &FxHashSet<LocalDefId>,
     local_raw_param_summaries: &FxHashMap<(LocalDefId, usize), LocalRawParamSummary>,
 ) -> FxHashMap<HirId, Vec<DecisionReason>> {
     struct UsageSubreasonVisitor<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
+        sig_decs: &'a SigDecisions,
         ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
         free_like_wrappers: &'a FxHashSet<LocalDefId>,
         local_raw_param_summaries: &'a FxHashMap<(LocalDefId, usize), LocalRawParamSummary>,
@@ -13391,12 +13642,12 @@ fn collect_unsupported_box_usage_subreasons(
                     let Some(root) = self.owning_root_of(hir_id) else {
                         continue;
                     };
-                    if !self
-                        .local_raw_param_summaries
-                        .get(&(local_callee, arg_index))
-                        .copied()
-                        .is_some_and(LocalRawParamSummary::preserves_owning_call_boundary)
-                    {
+                    if !local_callee_arg_preserves_owning_usage(
+                        self.sig_decs,
+                        self.local_raw_param_summaries,
+                        local_callee,
+                        arg_index,
+                    ) {
                         self.record(
                             root,
                             DecisionReason::UnsupportedBoxUsageLocalCalleeNonBorrowOnly,
@@ -13427,6 +13678,7 @@ fn collect_unsupported_box_usage_subreasons(
 
     let mut visitor = UsageSubreasonVisitor {
         tcx,
+        sig_decs,
         ptr_kinds,
         free_like_wrappers,
         local_raw_param_summaries,
@@ -15329,6 +15581,19 @@ fn hir_projection_root_local_id(hir_expr: &hir::Expr<'_>) -> Option<HirId> {
     }
 }
 
+fn hir_local_place_root_without_deref(hir_expr: &hir::Expr<'_>) -> Option<HirId> {
+    match hir_unwrap_casts(hir_expr).kind {
+        hir::ExprKind::Path(hir::QPath::Resolved(_, path)) => match path.res {
+            Res::Local(hir_id) => Some(hir_id),
+            _ => None,
+        },
+        hir::ExprKind::Field(base, _) | hir::ExprKind::Index(base, _, _) => {
+            hir_local_place_root_without_deref(base)
+        }
+        _ => None,
+    }
+}
+
 fn hir_field_access_expr_string(tcx: TyCtxt<'_>, hir_expr: &hir::Expr<'_>) -> Option<String> {
     match hir_unwrap_casts(hir_expr).kind {
         hir::ExprKind::Path(hir::QPath::Resolved(_, path)) => match path.res {
@@ -16954,6 +17219,7 @@ pub unsafe fn assign(mut p: *mut core::ffi::c_void, q: *mut core::ffi::c_void) {
                 .push("unsupported_allocator_root");
         }
         normalize_forced_raw_bindings(tcx, &mut ptr_kinds, &forced_raw_bindings);
+        normalize_owning_call_result_bindings(tcx, &sig_decs, &mut ptr_kinds, &forced_raw_bindings);
 
         loop {
             let mut changed = false;
@@ -16967,7 +17233,14 @@ pub unsafe fn assign(mut p: *mut core::ffi::c_void, q: *mut core::ffi::c_void) {
             if box_input_changed {
                 changed = true;
             }
-            if !downgrade_unsupported_box_outputs(tcx, &mut sig_decs, &ptr_kinds).is_empty() {
+            if !downgrade_unsupported_box_outputs(
+                tcx,
+                &mut sig_decs,
+                &ptr_kinds,
+                &FxHashSet::default(),
+            )
+            .is_empty()
+            {
                 changed = true;
             }
             if downgrade_freed_borrow_outputs(tcx, &mut sig_decs, &free_like_wrappers).changed() {
@@ -16978,6 +17251,12 @@ pub unsafe fn assign(mut p: *mut core::ffi::c_void, q: *mut core::ffi::c_void) {
             {
                 changed = true;
             }
+            normalize_owning_call_result_bindings(
+                tcx,
+                &sig_decs,
+                &mut ptr_kinds,
+                &forced_raw_bindings,
+            );
 
             let raw_call_result_bindings =
                 collect_raw_call_result_bindings(tcx, &sig_decs, &ptr_kinds);
@@ -16987,12 +17266,14 @@ pub unsafe fn assign(mut p: *mut core::ffi::c_void, q: *mut core::ffi::c_void) {
                 collect_unsupported_box_target_bindings(tcx, &sig_decs, &ptr_kinds);
             let unsupported_box_usage_subreasons = collect_unsupported_box_usage_subreasons(
                 tcx,
+                &sig_decs,
                 &ptr_kinds,
                 &free_like_wrappers,
                 &local_raw_param_summaries,
             );
             let unsupported_box_usage_bindings = collect_unsupported_box_usage_bindings(
                 tcx,
+                &sig_decs,
                 &ptr_kinds,
                 &free_like_wrappers,
                 &local_raw_param_summaries,
@@ -17065,6 +17346,12 @@ pub unsafe fn assign(mut p: *mut core::ffi::c_void, q: *mut core::ffi::c_void) {
             if forced_raw_bindings.len() != old_len {
                 changed = true;
                 normalize_forced_raw_bindings(tcx, &mut ptr_kinds, &forced_raw_bindings);
+                normalize_owning_call_result_bindings(
+                    tcx,
+                    &sig_decs,
+                    &mut ptr_kinds,
+                    &forced_raw_bindings,
+                );
             }
 
             if !changed {
@@ -17077,12 +17364,14 @@ pub unsafe fn assign(mut p: *mut core::ffi::c_void, q: *mut core::ffi::c_void) {
 
     fn collect_unsupported_box_usage_subreasons(
         tcx: TyCtxt<'_>,
+        sig_decs: &SigDecisions,
         ptr_kinds: &FxHashMap<HirId, PtrKind>,
         free_like_wrappers: &FxHashSet<LocalDefId>,
         local_raw_param_summaries: &FxHashMap<(LocalDefId, usize), LocalRawParamSummary>,
     ) -> FxHashMap<HirId, Vec<&'static str>> {
         struct UsageSubreasonVisitor<'a, 'tcx> {
             tcx: TyCtxt<'tcx>,
+            sig_decs: &'a SigDecisions,
             ptr_kinds: &'a FxHashMap<HirId, PtrKind>,
             free_like_wrappers: &'a FxHashSet<LocalDefId>,
             local_raw_param_summaries: &'a FxHashMap<(LocalDefId, usize), LocalRawParamSummary>,
@@ -17170,12 +17459,12 @@ pub unsafe fn assign(mut p: *mut core::ffi::c_void, q: *mut core::ffi::c_void) {
                         let Some(root) = self.owning_root_of(hir_id) else {
                             continue;
                         };
-                        if !self
-                            .local_raw_param_summaries
-                            .get(&(local_callee, arg_index))
-                            .copied()
-                            .is_some_and(LocalRawParamSummary::preserves_owning_call_boundary)
-                        {
+                        if !local_callee_arg_preserves_owning_usage(
+                            self.sig_decs,
+                            self.local_raw_param_summaries,
+                            local_callee,
+                            arg_index,
+                        ) {
                             self.record(root, "local_callee_non_borrow_only");
                         }
                     }
@@ -17194,6 +17483,7 @@ pub unsafe fn assign(mut p: *mut core::ffi::c_void, q: *mut core::ffi::c_void) {
 
         let mut visitor = UsageSubreasonVisitor {
             tcx,
+            sig_decs,
             ptr_kinds,
             free_like_wrappers,
             local_raw_param_summaries,

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -3861,6 +3861,205 @@ pub unsafe fn baz() {
 }
 
 #[test]
+fn test_rewriter_keeps_nullable_owned_returner_boxed_when_result_is_freed() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe fn make_owned(flag: i32) -> *mut i32 {
+    if flag == 0 {
+        return std::ptr::null_mut();
+    }
+    let p: *mut i32 = malloc(std::mem::size_of::<i32>()) as *mut i32;
+    p
+}
+
+pub unsafe fn cleanup(flag: i32) {
+    let p: *mut i32 = make_owned(flag);
+    if !p.is_null() {
+        free(p as *mut core::ffi::c_void);
+    }
+}
+"#,
+        &[
+            "pub unsafe fn make_owned(flag: i32) -> Option<Box<i32>>",
+            "let mut p: Option<Box<i32>>",
+            "if !p.is_none()",
+            "drop((p).take());",
+        ],
+        &[
+            "pub unsafe fn make_owned(flag: i32) -> *mut i32",
+            "free(p as *mut core::ffi::c_void);",
+            "Box::into_raw(",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_c_exposed_owned_returner_raw() {
+    let mut config = Config::default();
+    config.c_exposed_fns.insert("make_owned".to_string());
+    run_test_with_config(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn make_owned(flag: i32) -> *mut i32 {
+    if flag == 0 {
+        return std::ptr::null_mut();
+    }
+    let p: *mut i32 = malloc(std::mem::size_of::<i32>()) as *mut i32;
+    p
+}
+"#,
+        &config,
+        &[
+            "pub unsafe extern \"C\" fn make_owned(flag: i32) -> *mut i32",
+            "Box::into_raw(",
+        ],
+        &["pub unsafe extern \"C\" fn make_owned(flag: i32) -> Option<Box<i32>>"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_predeclared_nullable_owned_call_result_boxed() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe fn make_buffer(flag: i32) -> *mut i8 {
+    if flag == 0 {
+        return std::ptr::null_mut();
+    }
+    let p: *mut i8 = malloc(4) as *mut i8;
+    p
+}
+
+pub unsafe fn first_byte(buffer: *const i8) -> *const i8 {
+    if buffer.is_null() {
+        return std::ptr::null();
+    }
+    buffer
+}
+
+pub unsafe fn cleanup(flag: i32) {
+    let mut buffer: *mut i8 = std::ptr::null_mut();
+    let mut found: *const i8 = std::ptr::null();
+    buffer = make_buffer(flag);
+    if !buffer.is_null() {
+        found = first_byte(buffer);
+        if !found.is_null() {
+            let _offset = found.offset_from(buffer);
+        }
+        free(buffer as *mut core::ffi::c_void);
+        buffer = std::ptr::null_mut();
+    }
+}
+"#,
+        &[
+            "pub unsafe fn make_buffer(flag: i32) -> Option<Box<[i8]>>",
+            "let mut buffer: Option<Box<[i8]>> = None;",
+            "buffer = make_buffer(flag);",
+            "if !buffer.is_none()",
+            "drop((buffer).take());",
+            "buffer = None;",
+        ],
+        &[
+            "pub unsafe fn make_buffer(flag: i32) -> *mut i8",
+            "let mut buffer: *mut i8",
+            "free(buffer as *mut core::ffi::c_void);",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_does_not_move_box_into_later_freed_alias() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe fn compare_allocations(val: i32) -> i32 {
+    let ptr1: *mut i32 = malloc(std::mem::size_of::<i32>()) as *mut i32;
+    let mut alias: *mut i32 = std::ptr::null_mut();
+    if ptr1.is_null() {
+        free(ptr1 as *mut core::ffi::c_void);
+        return -1;
+    }
+    *ptr1 = val;
+    alias = ptr1;
+    let result = *alias;
+    free(ptr1 as *mut core::ffi::c_void);
+    result
+}
+"#,
+        &["drop(ptr1);"],
+        &["alias = Some(ptr1);"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_wrapper_freed_local_raw() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe fn cleanup_resources(ptr: *mut i8) {
+    if !ptr.is_null() {
+        free(ptr as *mut core::ffi::c_void);
+    }
+}
+
+pub unsafe fn cleanup() {
+    let mut dynamic_str: *mut i8 = std::ptr::null_mut();
+    dynamic_str = malloc(50) as *mut i8;
+    cleanup_resources(dynamic_str);
+}
+"#,
+        &[
+            "let mut dynamic_str: *mut i8 = std::ptr::null_mut();",
+            "cleanup_resources((dynamic_str).as_ref());",
+        ],
+        &["let mut dynamic_str: Option<Box<[i8]>>"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_raw_storage_call_result_raw() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+}
+
+pub unsafe fn dup() -> *mut i8 {
+    let p: *mut i8 = malloc(8) as *mut i8;
+    p
+}
+
+pub unsafe fn store(slot: *mut *mut i8) {
+    *slot = dup();
+}
+"#,
+        &["pub unsafe fn dup() -> *mut i8", "*slot = dup();"],
+        &["pub unsafe fn dup() -> Option<Box<[i8]>>"],
+    );
+}
+
+#[test]
 fn test_rewriter_consumes_direct_owned_call_result_free() {
     run_test(
         r#"
@@ -4311,11 +4510,18 @@ pub unsafe fn helper() -> i32 {
     result
 }
 "#,
-        &["Box::leak(Box::new(", "Box::from_raw("],
+        &[
+            "let mut s: Box<crate::State>",
+            "unsafe fn touch_with_alias(mut state: &mut crate::State) -> i32",
+            "let result = touch_with_alias((Some(&mut *((s).as_mut()))).unwrap());",
+            "drop(s);",
+        ],
         &[
             "calloc(1, std::mem::size_of::<State>())",
             "free(s as *mut core::ffi::c_void);",
             "Box::into_raw(",
+            "Box::leak(",
+            "Box::from_raw(",
         ],
     );
 }
@@ -4476,11 +4682,18 @@ pub unsafe fn helper() -> i32 {
     result
 }
 "#,
-        &["Box::leak(Box::new(", "Box::from_raw("],
+        &[
+            "let mut s: Box<crate::State>",
+            "unsafe fn print_preallocated_like(mut buffer: *mut crate::State,",
+            "print_preallocated_like(((s).as_mut()) as *mut crate::State, 1)",
+            "drop(s);",
+        ],
         &[
             "calloc(1, std::mem::size_of::<State>())",
             "free(s as *mut core::ffi::c_void);",
             "Box::into_raw(",
+            "Box::leak(",
+            "Box::from_raw(",
         ],
     );
 }
@@ -4600,7 +4813,7 @@ pub unsafe fn driver_like(length: usize) -> i32 {
             "malloc(length.wrapping_add(1))",
             "free(task as *mut core::ffi::c_void);",
         ],
-        &["Box::into_raw(", "Box::leak("],
+        &["Box::into_raw(", "Box::leak(", "Box::from_raw("],
     );
 }
 

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -3804,17 +3804,13 @@ fn test_rewriter_box_from_raw_free_evaluates_argument_once() {
     run_test(
         r#"
 extern "C" {
-    fn malloc(size: usize) -> *mut core::ffi::c_void;
     fn free(ptr: *mut core::ffi::c_void);
+    fn alloc_node() -> *mut Node;
 }
 
 #[repr(C)]
 pub struct Node {
     pub value: i32,
-}
-
-pub unsafe fn alloc_node() -> *mut Node {
-    malloc(std::mem::size_of::<Node>()) as *mut Node
 }
 
 pub unsafe fn cleanup() {
@@ -3823,6 +3819,75 @@ pub unsafe fn cleanup() {
 "#,
         &["let __crat_raw_free =", "Box::from_raw((__crat_raw_free)"],
         &["Box::from_raw((alloc_node()", "unsafe {"],
+    );
+}
+
+#[test]
+fn test_rewriter_keeps_owned_returners_boxed_when_one_result_is_freed() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe fn foo() -> *mut i32 {
+    let p: *mut i32 = malloc(std::mem::size_of::<i32>()) as *mut i32;
+    p
+}
+
+pub unsafe fn bar() -> *mut i32 {
+    let p: *mut i32 = malloc(std::mem::size_of::<i32>()) as *mut i32;
+    p
+}
+
+pub unsafe fn baz() {
+    let p: *mut i32 = bar();
+    free(p as *mut core::ffi::c_void);
+}
+"#,
+        &[
+            "pub unsafe fn foo() -> Box<i32>",
+            "pub unsafe fn bar() -> Box<i32>",
+            "let mut p: Box<i32>",
+            "drop(p);",
+        ],
+        &[
+            "pub unsafe fn bar() -> *mut i32",
+            "free(p as *mut core::ffi::c_void);",
+            "Box::into_raw(",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_consumes_direct_owned_call_result_free() {
+    run_test(
+        r#"
+extern "C" {
+    fn malloc(size: usize) -> *mut core::ffi::c_void;
+    fn free(ptr: *mut core::ffi::c_void);
+}
+
+pub unsafe fn make_owned() -> *mut i32 {
+    let p: *mut i32 = malloc(std::mem::size_of::<i32>()) as *mut i32;
+    p
+}
+
+pub unsafe fn cleanup() {
+    free(make_owned() as *mut core::ffi::c_void);
+}
+"#,
+        &[
+            "pub unsafe fn make_owned() -> Box<i32>",
+            "drop(make_owned());",
+        ],
+        &[
+            "pub unsafe fn make_owned() -> *mut i32",
+            "free(make_owned() as *mut core::ffi::c_void);",
+            "Box::from_raw(",
+            "Box::into_raw(",
+        ],
     );
 }
 


### PR DESCRIPTION
## Summary

This PR improves the pointer rewriter’s handling of freshly owned local return values.

When a local helper returns a newly owned allocation and the caller later frees or consumes it, the rewriter can now preserve that value as `Box` / `Option<Box>` instead of downgrading the flow back to raw pointers. C-exposed functions remain raw at the exported ABI boundary.

Against the latest `origin/master` (`99cd730`), the branch reduces pointer-stage unsafe findings by 11 occurrences.

## Change Summary

| Change area | What changed | Improvement type | Before -> After |
| --- | --- | --- | --- |
| Owned local returns | Preserve owned local call results as `Box` / `Option<Box>` when the caller consumes or frees the allocation. | Count | `ptr = make(); free(ptr)` -> `buf = make(); drop(buf.take())` |
| Local callee summaries | Distinguish borrow-only, returned, freed, and escaping raw-parameter behavior. | Count | borrow-only wrapper forces owner raw -> owner can remain boxed |
| Returned borrowed aliases | Track returned aliases that are later freed so boxed owners are not moved into separately freed alias paths. | Correctness | boxed owner + freed alias -> owner stays raw where needed |
| C-exposed outputs | Keep owning returns raw only for configured C-exposed functions or unsupported consumers. | ABI safety | `extern "C" -> Option<Box<[T]>>` -> `extern "C" -> *mut T` |

## Unsafe reductions by kind

| Unsafe kind | Baseline | This branch | Δ |
| --- | ---: | ---: | ---: |
| `free` | 83 | 75 | -8 |
| `malloc` | 28 | 26 | -2 |
| `as_ref` | 296 | 295 | -1 |

The corpus reductions come from `cJSON_lib` and `charinbuf_lib`, where temporary returned buffers now remain boxed and are cleaned up with Rust ownership instead of `malloc` / `free`.

`rdg_genstdout_lib` changes in the opposite direction for `FIO_createFilename_fromOutDir`: it is listed in `c_exposed_fns`, so the exported `extern "C"` function must return `*mut i8`. The previous `Option<Box<[i8]>>` return passed vectors by platform-specific ABI accident, but Rust still warns that it is not FFI-safe. The ideal future shape is a boxed `FIO_createFilename_fromOutDir_internal(...) -> Option<Box<[i8]>>` plus a raw C wrapper; this PR keeps the exported ABI correct, even though that internal-wrapper split is still future work.