### PR TITLE
Clean up translated assertions and simple generated patterns

### DIFF
--- a/crates/passes/src/libc_replacer/mod.rs
+++ b/crates/passes/src/libc_replacer/mod.rs
@@ -149,6 +149,9 @@ struct TransformVisitor<'tcx> {
 impl MutVisitor for TransformVisitor<'_> {
     fn flat_map_stmt(&mut self, stmt: Stmt) -> smallvec::SmallVec<[Stmt; 1]> {
         let mut stmts = mut_visit::walk_flat_map_stmt(self, stmt);
+        for stmt in &mut stmts {
+            replace_assert_stmt(stmt);
+        }
         stmts.retain(|stmt| {
             if let StmtKind::Semi(expr) = &stmt.kind
                 && let Some(hir_id) = self.ast_to_hir.local_map.get(&expr.id)
@@ -610,6 +613,47 @@ fn fn_body_has_raw_deref(body: &Block, ast_to_hir: &utils::ir::AstToHir, tcx: Ty
     };
     finder.visit_block(body);
     finder.found
+}
+
+fn replace_assert_stmt(stmt: &mut Stmt) {
+    let Some(condition) = assert_condition(stmt).map(pprust::expr_to_string) else {
+        return;
+    };
+    *stmt = utils::stmt!("assert!({condition});");
+}
+
+fn assert_condition(stmt: &Stmt) -> Option<&Expr> {
+    let StmtKind::Expr(expr) = &stmt.kind else {
+        return None;
+    };
+    let ExprKind::If(condition, then_block, else_expr) = &expr.kind else {
+        return None;
+    };
+    if !then_block.stmts.is_empty() {
+        return None;
+    }
+    let ExprKind::Block(else_block, None) = &else_expr.as_ref()?.kind else {
+        return None;
+    };
+    let [else_stmt] = else_block.stmts.as_slice() else {
+        return None;
+    };
+    let StmtKind::Semi(else_expr) = &else_stmt.kind else {
+        return None;
+    };
+    let ExprKind::Call(callee, _) = &unwrap_paren(else_expr).kind else {
+        return None;
+    };
+    let ExprKind::Path(_, path) = &unwrap_paren(callee).kind else {
+        return None;
+    };
+    let [segment] = path.segments.as_slice() else {
+        return None;
+    };
+    if segment.ident.as_str() != "__assert_fail" {
+        return None;
+    }
+    Some(condition)
 }
 
 impl TransformVisitor<'_> {

--- a/crates/passes/src/libc_replacer/tests.rs
+++ b/crates/passes/src/libc_replacer/tests.rs
@@ -660,6 +660,67 @@ pub unsafe fn foo() -> time_t {
 }
 
 #[test]
+fn test_assert_fail_block_rewrites_to_assert_statement() {
+    run_test(
+        r#"
+extern "C" {
+    fn __assert_fail(
+        __assertion: *const core::ffi::c_char,
+        __file: *const core::ffi::c_char,
+        __line: core::ffi::c_uint,
+        __function: *const core::ffi::c_char,
+    ) -> !;
+}
+
+pub unsafe fn foo(mut x: core::ffi::c_int) {
+    if x != 0 {} else {
+        __assert_fail(
+            b"x\0" as *const u8 as *const core::ffi::c_char,
+            b"a.c\0" as *const u8 as *const core::ffi::c_char,
+            5 as core::ffi::c_uint,
+            b"foo\0" as *const u8 as *const core::ffi::c_char,
+        );
+    }
+    x += 1;
+}
+        "#,
+        &["assert!(x != 0);", "x += 1;"],
+        &["b\"x\\0\""],
+    );
+}
+
+#[test]
+fn test_assert_fail_block_with_non_empty_then_is_left_alone() {
+    run_test(
+        r#"
+extern "C" {
+    fn __assert_fail(
+        __assertion: *const core::ffi::c_char,
+        __file: *const core::ffi::c_char,
+        __line: core::ffi::c_uint,
+        __function: *const core::ffi::c_char,
+    ) -> !;
+}
+
+pub unsafe fn foo(mut x: core::ffi::c_int) {
+    if x != 0 {
+        x += 1;
+    } else {
+        __assert_fail(
+            b"x\0" as *const u8 as *const core::ffi::c_char,
+            b"a.c\0" as *const u8 as *const core::ffi::c_char,
+            5 as core::ffi::c_uint,
+            b"foo\0" as *const u8 as *const core::ffi::c_char,
+        );
+    }
+}
+        "#,
+        &["__assert_fail", "x += 1;"],
+        &["assert!"],
+    );
+}
+
+#[test]
 fn test_trig_abs_and_difftime_calls_use_safe_replacements() {
     run_test(
         r#"

--- a/crates/passes/src/simplifier.rs
+++ b/crates/passes/src/simplifier.rs
@@ -62,7 +62,9 @@ impl mut_visit::MutVisitor for AstVisitor<'_> {
     fn flat_map_stmt(&mut self, s: Stmt) -> smallvec::SmallVec<[Stmt; 1]> {
         let mut stmts = mut_visit::walk_flat_map_stmt(self, s);
         stmts.retain(|stmt| {
-            if let StmtKind::Semi(e) = &stmt.kind
+            if is_empty_block_stmt(stmt) {
+                false
+            } else if let StmtKind::Semi(e) = &stmt.kind
                 && let ExprKind::Assign(_, r, _) | ExprKind::AssignOp(_, _, r) = &e.kind
                 && !utils::ast::has_side_effects(r)
                 && let Some(hir_stmt) = self.ast_to_hir.get_stmt(stmt.id, self.tcx)
@@ -475,6 +477,16 @@ fn try_simplify_ref_deref(expr: &mut Expr) -> bool {
     true
 }
 
+fn is_empty_block_stmt(stmt: &Stmt) -> bool {
+    let (StmtKind::Expr(expr) | StmtKind::Semi(expr)) = &stmt.kind else {
+        return false;
+    };
+    let ExprKind::Block(block, _) = &expr.kind else {
+        return false;
+    };
+    block.stmts.is_empty()
+}
+
 fn is_libc_ty(ty: &str) -> bool {
     if ty.starts_with("c_") {
         return true;
@@ -839,6 +851,29 @@ mod tests {
             &["x.0"],
             &["((x.0))"],
         )
+    }
+
+    #[test]
+    fn test_empty_block_stmt() {
+        run_test(
+            r#"extern "C" { fn g(); } unsafe fn f() { {} 'a: {} {}; 'b: {}; g(); }"#,
+            &["g();"],
+            &["{}", "'a", "'b"],
+        )
+    }
+
+    #[test]
+    fn test_nested_empty_block_stmt() {
+        run_test(
+            r#"extern "C" { fn g(); } unsafe fn f() { { {}; } g(); }"#,
+            &["g();"],
+            &["{}"],
+        )
+    }
+
+    #[test]
+    fn test_keep_empty_block_value() {
+        run_test("fn f() { let _ = {}; }", &["let _ = {};"], &[])
     }
 
     #[test]

--- a/crates/passes/src/simplifier.rs
+++ b/crates/passes/src/simplifier.rs
@@ -12,9 +12,9 @@ use rustc_middle::{
     thir,
     ty::{self, TyCtxt},
 };
-use rustc_span::Symbol;
+use rustc_span::{Symbol, sym};
 use utils::{
-    ast::unwrap_cast_and_paren_mut,
+    ast::{unwrap_cast_and_paren_mut, unwrap_paren_mut},
     ir::{AstToHir, HirToThir, ThirToMir},
 };
 
@@ -269,6 +269,10 @@ impl<'tcx> AstVisitor<'tcx> {
             _ => {}
         }
 
+        if self.try_simplify_some_unwrap(expr) || try_simplify_ref_deref(expr) {
+            return;
+        }
+
         match &mut expr.kind {
             ExprKind::Paren(e) => {
                 if is_atomic(e) {
@@ -309,6 +313,72 @@ impl<'tcx> AstVisitor<'tcx> {
             }
             _ => {}
         }
+    }
+
+    fn try_simplify_some_unwrap(&self, expr: &mut Expr) -> bool {
+        if !self.is_option_some_unwrap(expr.id) {
+            return false;
+        }
+
+        let ExprKind::MethodCall(call) = &mut expr.kind else {
+            return false;
+        };
+        if call.seg.ident.name != sym::unwrap || !call.args.is_empty() {
+            return false;
+        }
+
+        let receiver = unwrap_paren_mut(&mut call.receiver);
+        let ExprKind::Call(callee, args) = &mut receiver.kind else {
+            return false;
+        };
+        if !matches!(&callee.kind, ExprKind::Path(_, _)) {
+            return false;
+        }
+        let [arg] = &mut args[..] else {
+            return false;
+        };
+
+        *expr = utils::ast::take_expr(arg);
+        true
+    }
+
+    fn is_option_some_unwrap(&self, node_id: NodeId) -> bool {
+        let Some(hir_expr) = self.ast_to_hir.get_expr(node_id, self.tcx) else {
+            return false;
+        };
+        let hir::ExprKind::MethodCall(seg, receiver, [], _) = hir_expr.kind else {
+            return false;
+        };
+        if seg.ident.name != sym::unwrap {
+            return false;
+        }
+
+        let typeck = self.tcx.typeck(hir_expr.hir_id.owner);
+        let ty::TyKind::Adt(receiver_def, _) = typeck.expr_ty(receiver).kind() else {
+            return false;
+        };
+        if !self
+            .tcx
+            .is_lang_item(receiver_def.did(), hir::LangItem::Option)
+        {
+            return false;
+        }
+
+        let hir::ExprKind::Call(callee, [_]) = receiver.kind else {
+            return false;
+        };
+        let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = callee.kind else {
+            return false;
+        };
+        let Res::Def(hir::def::DefKind::Ctor(hir::def::CtorOf::Variant, _), def_id) = path.res
+        else {
+            return false;
+        };
+        let variant_def_id = self.tcx.parent(def_id);
+        self.tcx.item_name(variant_def_id) == sym::Some
+            && self
+                .tcx
+                .is_lang_item(self.tcx.parent(variant_def_id), hir::LangItem::Option)
     }
 
     fn eval_lit_cast(&self, expr: &hir::Expr) -> Option<Int> {
@@ -390,6 +460,19 @@ impl<'tcx> AstVisitor<'tcx> {
             _ => Some(vec![ty]),
         }
     }
+}
+
+fn try_simplify_ref_deref(expr: &mut Expr) -> bool {
+    let ExprKind::Unary(UnOp::Deref, inner) = &mut expr.kind else {
+        return false;
+    };
+    let inner = unwrap_paren_mut(inner);
+    let ExprKind::AddrOf(BorrowKind::Ref, _, borrowed) = &mut inner.kind else {
+        return false;
+    };
+
+    *expr = utils::ast::take_expr(borrowed);
+    true
 }
 
 fn is_libc_ty(ty: &str) -> bool {
@@ -755,6 +838,60 @@ mod tests {
             "struct S(i32); fn f(x: S) { ((x.0)); }",
             &["x.0"],
             &["((x.0))"],
+        )
+    }
+
+    #[test]
+    fn test_some_unwrap_ref_arg() {
+        run_test(
+            "fn g(_: &mut i32) {} fn f() { let mut x = 0; g(Some(&mut x).unwrap()); }",
+            &["g(&mut x)"],
+            &["Some(&mut x).unwrap()"],
+        )
+    }
+
+    #[test]
+    fn test_some_unwrap_deref_assignment() {
+        run_test(
+            "fn f() -> i32 { let mut x = 0; *Some(&mut x).unwrap() = 1; x }",
+            &["x = 1; x"],
+            &["*Some(&mut x).unwrap()"],
+        )
+    }
+
+    #[test]
+    fn test_some_unwrap_deref_call_result() {
+        run_test(
+            "fn cast_ref<T>(x: &T) -> &T { x } fn f(x: i32) -> i32 { *Some(cast_ref(&x)).unwrap() }",
+            &["*cast_ref(&x)"],
+            &["Some(cast_ref(&x)).unwrap()"],
+        )
+    }
+
+    #[test]
+    fn test_ref_deref() {
+        run_test(
+            "fn f(seed: &mut i32) -> i32 { *seed = 69069 * *&*seed + 1; *&*seed }",
+            &["*seed = 69069 * *seed + 1", "; *seed }"],
+            &["*&"],
+        )
+    }
+
+    #[test]
+    fn test_do_not_simplify_shadowed_some_unwrap() {
+        run_test(
+            "struct W(i32); impl W { fn unwrap(self) -> i32 { self.0 } } fn Some(x: i32) -> W { W(x) } fn f() -> i32 { Some(1).unwrap() }",
+            &["Some(1).unwrap()"],
+            &[],
+        )
+    }
+
+    #[test]
+    fn test_do_not_simplify_raw_ref_deref() {
+        run_test(
+            "unsafe fn f(x: *mut i32) -> i32 { *(&raw const *x) }",
+            &["&raw const"],
+            &[],
         )
     }
 

--- a/crates/passes/src/unexpander.rs
+++ b/crates/passes/src/unexpander.rs
@@ -206,6 +206,12 @@ impl MutVisitor for AstVisitor<'_> {
     }
 
     fn flat_map_stmt(&mut self, stmt: Stmt) -> SmallVec<[Stmt; 1]> {
+        if let Some(mut condition) = expanded_assert_condition(&stmt) {
+            self.visit_expr(&mut condition);
+            let condition = pprust::expr_to_string(&condition);
+            return smallvec![utils::stmt!("assert!({condition});")];
+        }
+
         let mut stmts = mut_visit::walk_flat_map_stmt(self, stmt);
         for stmt in &mut stmts {
             // { use std::io::Write; print!(..) }; => print!(..);
@@ -332,6 +338,49 @@ impl MutVisitor for AstVisitor<'_> {
         }
         mut_visit::walk_expr(self, expr);
     }
+}
+
+fn expanded_assert_condition(stmt: &Stmt) -> Option<Expr> {
+    let StmtKind::Semi(expr) = &stmt.kind else {
+        return None;
+    };
+    let ExprKind::If(condition, then_block, else_expr) = &expr.kind else {
+        return None;
+    };
+    if else_expr.is_some() {
+        return None;
+    }
+    let ExprKind::Unary(UnOp::Not, condition) = &unwrap_paren(condition).kind else {
+        return None;
+    };
+    let [panic_stmt] = then_block.stmts.as_slice() else {
+        return None;
+    };
+    let StmtKind::Expr(panic_expr) = &panic_stmt.kind else {
+        return None;
+    };
+    let ExprKind::Call(callee, args) = &panic_expr.kind else {
+        return None;
+    };
+    let ExprKind::Path(None, path) = &callee.kind else {
+        return None;
+    };
+    let [.., module, func] = path.segments.as_slice() else {
+        return None;
+    };
+    if module.ident.name != sym::panicking || func.ident.name != sym::panic {
+        return None;
+    }
+    let [arg] = args.as_slice() else {
+        return None;
+    };
+    let ExprKind::Lit(lit) = &arg.kind else {
+        return None;
+    };
+    if !lit.symbol.as_str().starts_with("assertion failed:") {
+        return None;
+    }
+    Some(unwrap_paren(condition).clone())
 }
 
 fn unwrap_addr_of(expr: &Expr) -> &Expr {
@@ -618,6 +667,19 @@ fn f() {
             "#,
             &["eprint!"],
             &["stdout", "write_fmt", "format_args"],
+        )
+    }
+
+    #[test]
+    fn test_assert() {
+        run_test(
+            r#"
+fn f(x: i32) {
+    assert!(x != 0);
+}
+            "#,
+            &["assert!(x != 0);"],
+            &["panicking", "assertion failed"],
         )
     }
 

--- a/crates/passes/src/unexpander.rs
+++ b/crates/passes/src/unexpander.rs
@@ -57,6 +57,7 @@ pub fn unexpand(config: Config, tcx: TyCtxt<'_>) -> String {
         "builtin_syntax",
         "rt",
         "libstd_sys_internals",
+        "structural_match",
     ]
     .into_iter()
     .collect();


### PR DESCRIPTION
## Summary

- Rewrite C2Rust `__assert_fail` assertion blocks to `assert!` in the libc pass, and fold re-expanded assert panics back to `assert!` in unexpand.
- Extend simpl cleanup for generated `Some(...).unwrap()`, `*&` patterns, and empty block statements such as `{}` / `'l: {};`.
- Drop the unnecessary `structural_match` feature during unexpand cleanup.