### PR TITLE
Extend array index rewrite to fields

### DIFF
--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -600,6 +600,17 @@ pub fn select_rewrite_groups<'a, 'tcx>(
         if !has_conflict {
             continue;
         }
+        if !member_pointer_elements_match_base_element(
+            body,
+            context.tcx,
+            base_local,
+            base_slot_offset,
+            &local_name,
+            &members,
+            provenance,
+        ) {
+            continue;
+        }
 
         // condition 2: the base variable binding must be stable for selection
         let stability_context = BaseStabilityContext {
@@ -635,6 +646,210 @@ pub fn select_rewrite_groups<'a, 'tcx>(
     }
 
     groups
+}
+
+fn member_pointer_elements_match_base_element<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    base_local: Local,
+    base_slot_offset: usize,
+    local_name: &FxHashMap<Local, &str>,
+    members: &[SlotIdx],
+    provenance: &ArrayLocalProvenance,
+) -> bool {
+    let Some(base_element_ty) =
+        slot_element_ty(body, tcx, provenance, base_local, base_slot_offset)
+    else {
+        return true;
+    };
+    members.iter().all(|&slot_idx| {
+        let Some(info) = provenance.slot_table.slot_infos.get(slot_idx) else {
+            return true;
+        };
+        if info.root == base_local || !info.path.is_empty() {
+            return true;
+        }
+        if !local_name.contains_key(&info.root) {
+            return true;
+        }
+        slot_ty(body, tcx, info)
+            .and_then(pointer_element_ty)
+            .is_none_or(|member_element_ty| {
+                if member_element_ty == base_element_ty {
+                    return true;
+                }
+                if matches!(
+                    base_element_ty.kind(),
+                    ty::TyKind::Adt(adt_def, _) if adt_def.is_struct()
+                ) {
+                    return local_origin_uses_pointer_arithmetic(body, tcx, info.root);
+                }
+                local_origin_uses_pointer_arithmetic(body, tcx, info.root)
+                    || local_origin_uses_pointer_cast(body, tcx, info.root)
+            })
+    })
+}
+
+#[derive(Clone, Copy)]
+struct PointerOrigin {
+    source: Local,
+    uses_pointer_arithmetic: bool,
+    uses_pointer_cast: bool,
+}
+
+fn local_origin_uses_pointer_arithmetic<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    local: Local,
+) -> bool {
+    let origins = pointer_origin_map(body, tcx);
+    let mut visited = FxHashSet::default();
+    local_origin_uses_pointer_arithmetic_inner(local, &origins, &mut visited)
+}
+
+fn local_origin_uses_pointer_arithmetic_inner(
+    local: Local,
+    origins: &FxHashMap<Local, Vec<PointerOrigin>>,
+    visited: &mut FxHashSet<Local>,
+) -> bool {
+    if !visited.insert(local) {
+        return false;
+    }
+    origins.get(&local).is_some_and(|edges| {
+        edges.iter().any(|edge| {
+            edge.uses_pointer_arithmetic
+                || local_origin_uses_pointer_arithmetic_inner(edge.source, origins, visited)
+        })
+    })
+}
+
+fn local_origin_uses_pointer_cast<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    local: Local,
+) -> bool {
+    let origins = pointer_origin_map(body, tcx);
+    let mut visited = FxHashSet::default();
+    local_origin_uses_pointer_cast_inner(local, &origins, &mut visited)
+}
+
+fn local_origin_uses_pointer_cast_inner(
+    local: Local,
+    origins: &FxHashMap<Local, Vec<PointerOrigin>>,
+    visited: &mut FxHashSet<Local>,
+) -> bool {
+    if !visited.insert(local) {
+        return false;
+    }
+    origins.get(&local).is_some_and(|edges| {
+        edges.iter().any(|edge| {
+            edge.uses_pointer_cast
+                || local_origin_uses_pointer_cast_inner(edge.source, origins, visited)
+        })
+    })
+}
+
+fn pointer_origin_map<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> FxHashMap<Local, Vec<PointerOrigin>> {
+    let mut origins: FxHashMap<Local, Vec<PointerOrigin>> = FxHashMap::default();
+    for block_data in body.basic_blocks.iter() {
+        for statement in &block_data.statements {
+            let StatementKind::Assign(box (lhs, rvalue)) = &statement.kind else {
+                continue;
+            };
+            let Some(dst) = lhs.as_local() else { continue };
+            let source = match rvalue {
+                Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) => Some(PointerOrigin {
+                    source: place.local,
+                    uses_pointer_arithmetic: false,
+                    uses_pointer_cast: false,
+                }),
+                Rvalue::Use(Operand::Copy(place) | Operand::Move(place))
+                | Rvalue::CopyForDeref(place) => Some(PointerOrigin {
+                    source: place.local,
+                    uses_pointer_arithmetic: false,
+                    uses_pointer_cast: false,
+                }),
+                Rvalue::Cast(_, Operand::Copy(place) | Operand::Move(place), _) => {
+                    Some(PointerOrigin {
+                        source: place.local,
+                        uses_pointer_arithmetic: false,
+                        uses_pointer_cast: true,
+                    })
+                }
+                _ => None,
+            };
+            if let Some(source) = source {
+                origins.entry(dst).or_default().push(source);
+            }
+        }
+
+        let Some(terminator) = &block_data.terminator else {
+            continue;
+        };
+        let TerminatorKind::Call {
+            func,
+            args,
+            destination,
+            ..
+        } = &terminator.kind
+        else {
+            continue;
+        };
+        let Some(dst) = destination.as_local() else {
+            continue;
+        };
+        if let Some((_, name)) = call_name(tcx, func)
+            && (is_pointer_arithmetic(&name) || is_as_ptr(&name))
+            && let Some(arg) = args.first()
+            && let Some(place) = operand_place(&arg.node)
+        {
+            origins.entry(dst).or_default().push(PointerOrigin {
+                source: place.local,
+                uses_pointer_arithmetic: is_pointer_arithmetic(&name),
+                uses_pointer_cast: false,
+            });
+        }
+    }
+    origins
+}
+
+fn slot_element_ty<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    provenance: &ArrayLocalProvenance,
+    local: Local,
+    slot_offset: usize,
+) -> Option<Ty<'tcx>> {
+    let slots = provenance.slot_table.local_slots(local);
+    let slot = slots.start.checked_add(slot_offset)?;
+    let info = provenance.slot_table.slot_infos.get(slot)?;
+    slot_ty(body, tcx, info).and_then(cursor_element_ty)
+}
+
+fn cursor_element_ty<'tcx>(ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+    match ty.kind() {
+        ty::TyKind::RawPtr(pointee, _) => Some(*pointee),
+        ty::TyKind::Ref(_, referent, _) => sequence_element_ty(*referent),
+        ty::TyKind::Array(element, _) | ty::TyKind::Slice(element) => Some(*element),
+        _ => None,
+    }
+}
+
+fn pointer_element_ty<'tcx>(ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+    match ty.kind() {
+        ty::TyKind::RawPtr(pointee, _) => Some(*pointee),
+        _ => None,
+    }
+}
+
+fn sequence_element_ty<'tcx>(ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+    match ty.kind() {
+        ty::TyKind::Array(element, _) | ty::TyKind::Slice(element) => Some(*element),
+        _ => None,
+    }
 }
 
 fn compute_live_after_by_location<'tcx>(
@@ -769,6 +984,13 @@ fn is_param_base_stable_for_selection(
                 );
                 if is_direct {
                     has_direct_write = true;
+                } else if location_writes_through_dependent_member(
+                    context.body,
+                    context.tcx,
+                    location,
+                    &dependent_locals,
+                ) {
+                    continue;
                 } else {
                     // only run alias/call sub-checks when the direct check did not
                     // already account for the write; Andersen's all_writes includes
@@ -818,6 +1040,13 @@ fn is_param_base_stable_for_selection(
                 );
                 if is_direct {
                     has_direct_write = true;
+                } else if location_writes_through_dependent_member(
+                    context.body,
+                    context.tcx,
+                    location,
+                    &dependent_locals,
+                ) {
+                    continue;
                 } else {
                     let is_alias = base_locs.as_ref().is_some_and(|base_locs| {
                         location_writes_base_storage(
@@ -1015,6 +1244,20 @@ fn aggregate_arg_may_write_base_storage<'tcx>(
     }
 
     false
+}
+
+fn location_writes_through_dependent_member<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    location: Location,
+    dependent_locals: &FxHashSet<Local>,
+) -> bool {
+    let Some(place) = written_place_at(body, location) else {
+        return false;
+    };
+    dependent_locals.contains(&place.local)
+        && slot_path_from_place(place).is_some_and(|path| path.contains(&SlotPathElem::Pointee))
+        && place.ty(body, tcx).ty.builtin_deref(true).is_none()
 }
 
 fn slot_path_from_place<'tcx>(place: Place<'tcx>) -> Option<Vec<SlotPathElem>> {

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -464,7 +464,7 @@ fn source_var_identity_for_slot<'tcx, S: AsRef<str>>(
     saw_named_field.then_some(identity)
 }
 
-fn named_struct_field<'tcx>(
+pub(crate) fn named_struct_field<'tcx>(
     tcx: TyCtxt<'tcx>,
     ty: Ty<'tcx>,
     field: FieldIdx,
@@ -1176,8 +1176,7 @@ fn dependent_member_locals(
         .collect()
 }
 
-#[allow(dead_code)]
-fn base_slot_info<'a>(
+pub(crate) fn base_slot_info<'a>(
     provenance: &'a ArrayLocalProvenance,
     group: &RewriteGroup,
 ) -> Option<&'a SlotInfo> {

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -1481,6 +1481,42 @@ fn array_local_provenance_cast_single_slot_slot0_preserves_param_provenance() {
 }
 
 #[test]
+fn select_rewrite_groups_selects_cast_cursor_over_param_base() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        fn parse_bool(c: i8) -> bool {
+            c == 89 || c == 121
+        }
+
+        pub unsafe fn f(sequence: *mut i8, len: usize) -> i32 {
+            let bools = sequence as *mut bool;
+            let mut i: usize = 0;
+            while i < len {
+                let val = parse_bool(*sequence.offset(i as isize));
+                *bools.offset(i as isize) = val;
+                i = i.wrapping_add(1);
+            }
+            if !*bools.offset(0) {
+                return -10;
+            }
+            0
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.base_name.as_deref() == Some("sequence")
+                && group.member_names.contains("bools")
+                && group.has_rewritable_binding
+        }),
+        "cast cursor over param base should be selected: {f_groups:#?}"
+    );
+}
+
+#[test]
 fn array_local_provenance_rawptr_double_ptr_tail_slot_preserves_param_provenance() {
     let map = run_analysis(
         r#"
@@ -1534,6 +1570,33 @@ fn array_local_provenance_struct_field_array_offset_pointers_share_base() {
     assert!(
         matches!(current.unique, Some(BaseId::LocalArray { .. })),
         "the shared base should be LocalArray: {current:#?}"
+    );
+}
+
+#[test]
+fn select_rewrite_groups_reject_struct_pointer_base_for_field_array_pointers() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub struct Info {
+            pub steps: *mut u32,
+            pub leaf_addr: [u32; 8],
+            pub pk_addr: [u32; 8],
+        }
+
+        pub unsafe fn f(v_info: *mut Info) {
+            let info = v_info;
+            let leaf_addr = ((*info).leaf_addr).as_mut_ptr();
+            let pk_addr = ((*info).pk_addr).as_mut_ptr();
+            *leaf_addr = 1;
+            *pk_addr = 2;
+        }
+        "#,
+    );
+
+    let selected = groups.get("f").cloned().unwrap_or_default();
+    assert!(
+        selected.is_empty(),
+        "field-array pointers must not be selected as cursors over the enclosing struct pointer: {selected:#?}"
     );
 }
 

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -6,7 +6,8 @@ use utils::ty_shape;
 
 use super::{BaseAdmissibility, BaseId, PfgNode, analyze_body};
 use crate::{
-    analyses::type_qualifier::foster::mutability::mutability_analysis, utils::rustc::RustProgram,
+    analyses::type_qualifier::foster::mutability::mutability_analysis,
+    rewriter::array_local_index_rewriter::group_has_rewritable_binding, utils::rustc::RustProgram,
 };
 
 fn build_rust_program(tcx: rustc_middle::ty::TyCtxt<'_>) -> RustProgram<'_> {
@@ -112,6 +113,7 @@ struct RewriteGroupFacts {
     member_names: FxHashSet<String>,
     member_root_names: FxHashSet<String>,
     index_tracked: bool,
+    has_rewritable_binding: bool,
 }
 
 fn run_rewrite_groups_with_points_to(code: &str) -> FxHashMap<String, Vec<RewriteGroupFacts>> {
@@ -157,9 +159,14 @@ fn run_rewrite_groups_with_points_to(code: &str) -> FxHashMap<String, Vec<Rewrit
                 }
             }
 
+            let rewritable: Vec<bool> = groups
+                .iter()
+                .map(|g| group_has_rewritable_binding(tcx, did, &body, &result, g))
+                .collect();
             let group_facts = groups
                 .into_iter()
-                .map(|group| {
+                .zip(rewritable)
+                .map(|(group, has_rewritable_binding)| {
                     let member_names = group
                         .members
                         .iter()
@@ -187,6 +194,7 @@ fn run_rewrite_groups_with_points_to(code: &str) -> FxHashMap<String, Vec<Rewrit
                         member_names,
                         member_root_names,
                         index_tracked: group.index_tracked,
+                        has_rewritable_binding,
                     }
                 })
                 .collect();
@@ -1685,5 +1693,34 @@ fn liveness_gate_accepts_group_when_mut_and_imm_locals_simultaneously_live() {
             .iter()
             .any(|g| { g.member_names.contains("q") && g.member_names.contains("r") }),
         "q (*mut) and r (*const) are simultaneously live — group must be selected: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn group_has_rewritable_binding_for_field_base_group() {
+    let code = r#"
+        #[repr(C)]
+        pub struct Img {
+            pub pix: *mut u8,
+        }
+        pub unsafe fn process(mut img: *mut Img) {
+            let mut pix: *mut u8 = (*img).pix;
+            let mut a: *mut u8 = pix.offset(3);
+            let mut b: *mut u8 = pix.offset(5);
+            *a = *b;
+            a = a.offset(1);
+            b = b.offset(1);
+        }
+    "#;
+
+    let facts = run_rewrite_groups_with_points_to(code);
+    let process_groups = facts.get("process").expect("process not found");
+    assert!(
+        !process_groups.is_empty(),
+        "expected at least one rewrite group for process"
+    );
+    assert!(
+        process_groups.iter().any(|g| g.has_rewritable_binding),
+        "expected has_rewritable_binding=true for the field-base group, got: {process_groups:?}"
     );
 }

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -11,7 +11,7 @@ use rustc_hir::{
     self as hir, HirId, def::Res, def_id::LocalDefId, intravisit::Visitor as HirVisitor,
 };
 use rustc_middle::{
-    mir::Local,
+    mir::{Local, TerminatorKind},
     ty::{self, TyCtxt},
 };
 use rustc_span::Symbol;
@@ -24,7 +24,8 @@ use crate::{
     analyses::{
         self,
         array_local_provenance::{
-            ArrayLocalProvenance, PfgNode, RewriteGroup, RewriteSelectionContext,
+            ArrayLocalProvenance, PfgNode, RewriteGroup, RewriteSelectionContext, SlotPathElem,
+            named_struct_field,
         },
         type_qualifier::foster::mutability::MutabilityResult,
     },
@@ -42,6 +43,7 @@ struct BindingRewrite {
     nullable: bool,
     ptr_ty: String,
     ptr_mut: bool,
+    base_proxy_hir_ids: FxHashSet<HirId>,
 }
 
 #[derive(Clone, Debug)]
@@ -92,6 +94,61 @@ pub(crate) fn apply_array_local_index_rewrite<'tcx>(
     };
     visitor.visit_crate(krate);
     visitor.changed
+}
+
+#[allow(dead_code)]
+pub(crate) fn group_has_rewritable_binding<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+    body: &rustc_middle::mir::Body<'tcx>,
+    provenance: &ArrayLocalProvenance,
+    group: &RewriteGroup,
+) -> bool {
+    // index_tracked with a field base is unsupported.
+    if group.base_slot_offset != 0 && group.index_tracked {
+        return false;
+    }
+    let hir_to_mir = utils::ir::map_thir_to_mir(def_id, false, tcx);
+    let local_to_hir: FxHashMap<Local, HirId> = hir_to_mir
+        .binding_to_local
+        .iter()
+        .map(|(hir_id, local)| (*local, *hir_id))
+        .collect();
+    if !local_to_hir.contains_key(&group.base_local) {
+        return false;
+    }
+    if group.index_tracked
+        && !matches!(
+            body.local_decls[group.base_local].ty.kind(),
+            ty::TyKind::RawPtr(..)
+        )
+    {
+        return false;
+    }
+
+    group.members.iter().any(|&slot_idx| {
+        let Some(info) = provenance.slot_table.slot_infos.get(slot_idx) else {
+            return false;
+        };
+        if info.root == group.base_local || !info.path.is_empty() {
+            return false;
+        }
+        if !local_to_hir.contains_key(&info.root) {
+            return false;
+        }
+        if !matches!(
+            body.local_decls[info.root].ty.kind(),
+            ty::TyKind::RawPtr(..)
+        ) {
+            return false;
+        }
+        // for field-base groups, a member is rewritable only if it is NOT a proxy
+        // (proxies hold the base at offset 0 and are left unchanged).
+        if group.base_slot_offset > 0 {
+            return !local_only_directly_assigned(body, info.root);
+        }
+        true
+    })
 }
 
 fn build_rewrite_plan<'tcx>(
@@ -318,13 +375,56 @@ struct GroupPlanContext<'a, 'tcx> {
 }
 
 fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGroup) {
-    if group.base_slot_offset != 0 {
+    // index_tracked with a field base is unsupported.
+    if group.base_slot_offset != 0 && group.index_tracked {
         return;
     }
     let Some(&base_hir_id) = context.local_to_hir.get(&group.base_local) else {
         return;
     };
-    let base_name = context.tcx.hir_name(base_hir_id).to_string();
+
+    // Compute (base_name, proxy_hir_ids) depending on whether the base is a
+    // direct local (offset 0) or a field path (offset > 0).
+    let (base_name, proxy_hir_ids): (String, FxHashSet<HirId>) = if group.base_slot_offset == 0 {
+        (
+            context.tcx.hir_name(base_hir_id).to_string(),
+            FxHashSet::default(),
+        )
+    } else {
+        let Some(base_slot_info) =
+            analyses::array_local_provenance::base_slot_info(context.provenance, group)
+        else {
+            return;
+        };
+        let local_name = context.tcx.hir_name(base_hir_id).to_string();
+        let base_ty = context.body.local_decls[group.base_local].ty;
+        let Some(name) =
+            slot_path_to_expr_string(&local_name, &base_slot_info.path, base_ty, context.tcx)
+        else {
+            return;
+        };
+        // proxies: direct-local RawPtr members never assigned via a Call
+        let proxies = group
+            .members
+            .iter()
+            .filter_map(|&slot_idx| {
+                let info = context.provenance.slot_table.slot_infos.get(slot_idx)?;
+                if !info.path.is_empty() || info.root == group.base_local {
+                    return None;
+                }
+                if !matches!(
+                    context.body.local_decls[info.root].ty.kind(),
+                    ty::TyKind::RawPtr(..)
+                ) {
+                    return None;
+                }
+                let &hir_id = context.local_to_hir.get(&info.root)?;
+                local_only_directly_assigned(context.body, info.root).then_some(hir_id)
+            })
+            .collect();
+        (name, proxies)
+    };
+
     let base_is_raw_ptr = matches!(
         context.body.local_decls[group.base_local].ty.kind(),
         ty::TyKind::RawPtr(..)
@@ -379,6 +479,10 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
         let Some(&source_hir_id) = context.local_to_hir.get(&info.root) else {
             continue;
         };
+        // skip proxy locals — they hold the base at offset 0 and stay as-is.
+        if proxy_hir_ids.contains(&source_hir_id) {
+            continue;
+        }
         if context.plan.by_hir_id.contains_key(&source_hir_id) {
             continue;
         }
@@ -418,6 +522,7 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                 nullable,
                 ptr_ty,
                 ptr_mut: mutability.is_mut(),
+                base_proxy_hir_ids: proxy_hir_ids.clone(),
             },
         );
     }
@@ -432,6 +537,42 @@ fn fresh_index_name(source_name: &str, existing_names: &mut FxHashSet<String>) -
     }
     existing_names.insert(candidate.clone());
     candidate
+}
+
+fn slot_path_to_expr_string<'tcx>(
+    local_name: &str,
+    path: &[SlotPathElem],
+    mut ty: ty::Ty<'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> Option<String> {
+    let mut expr = local_name.to_string();
+    for elem in path {
+        match elem {
+            SlotPathElem::Pointee => {
+                ty = ty.builtin_deref(true)?;
+                expr = format!("(*{expr})");
+            }
+            SlotPathElem::Field(field) => {
+                let (field_name, field_ty) = named_struct_field(tcx, ty, *field)?;
+                expr = format!("{expr}.{field_name}");
+                ty = field_ty;
+            }
+            SlotPathElem::Element => return None,
+        }
+    }
+    Some(expr)
+}
+
+fn local_only_directly_assigned(body: &rustc_middle::mir::Body<'_>, local: Local) -> bool {
+    for block_data in body.basic_blocks.iter() {
+        if let Some(terminator) = &block_data.terminator
+            && let TerminatorKind::Call { destination, .. } = &terminator.kind
+            && destination.local == local
+        {
+            return false;
+        }
+    }
+    true
 }
 
 fn prune_unsupported_direct_place_uses(
@@ -642,7 +783,8 @@ fn assignment_index_arg_contains_planned_local(
     let receiver = unwrap_cast_and_paren(&call.receiver);
     let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
     let receiver_is_base = receiver_hir_id == Some(rewrite.base_hir_id)
-        || receiver_is_base_as_ptr(receiver, ast_to_hir, tcx, rewrite);
+        || receiver_is_base_as_ptr(receiver, ast_to_hir, tcx, rewrite)
+        || receiver_hir_id.is_some_and(|id| rewrite.base_proxy_hir_ids.contains(&id));
     if !receiver_is_base && receiver_hir_id != Some(rewrite.source_hir_id) {
         return false;
     }
@@ -813,8 +955,10 @@ fn receiver_is_base_pointer_expr(
     tcx: TyCtxt<'_>,
     rewrite: &BindingRewrite,
 ) -> bool {
-    hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) == Some(rewrite.base_hir_id)
+    let hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
+    hir_id == Some(rewrite.base_hir_id)
         || receiver_is_base_as_ptr(receiver, ast_to_hir, tcx, rewrite)
+        || hir_id.is_some_and(|id| rewrite.base_proxy_hir_ids.contains(&id))
 }
 
 fn offset_from_base_expr(
@@ -827,7 +971,10 @@ fn offset_from_base_expr(
         return IndexExpr::Null;
     }
     let expr = unwrap_cast_and_paren(expr);
-    if hir_id_of_ast_expr(ast_to_hir, tcx, expr.id) == Some(rewrite.base_hir_id) {
+    let expr_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, expr.id);
+    if expr_hir_id == Some(rewrite.base_hir_id)
+        || expr_hir_id.is_some_and(|id| rewrite.base_proxy_hir_ids.contains(&id))
+    {
         return IndexExpr::Plain(match base_current_index_expr(rewrite) {
             Some(base_index_name) => utils::expr!("{}", base_index_name),
             None => utils::expr!("0isize"),

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -95,9 +95,11 @@ struct BindingUseSummary {
     comparison_count: usize,
     offset_from_count: usize,
     call_arg_count: usize,
+    inlineable_memory_call_count: usize,
     address_taken_count: usize,
     unsupported_escape: bool,
     writes_through_pointer: bool,
+    multi_cursor_deref_expr_count: usize,
 }
 
 impl BindingUseSummary {
@@ -171,6 +173,74 @@ mod binding_use_summary_tests {
             summary.materialization_kind(false),
             Some(MaterializationKind::RawPtr)
         );
+    }
+
+    #[test]
+    fn memchr_pointer_argument_does_not_force_materialization() {
+        let summaries = classifier_summaries(
+            r#"
+unsafe extern "C" {
+    fn memchr(ptr: *const core::ffi::c_void, ch: i32, n: usize) -> *mut core::ffi::c_void;
+}
+
+pub unsafe fn foo(mut p: *mut i8, n: usize) {
+    let mut q: *mut i8 = p.offset(1);
+    let _found = memchr(q as *const core::ffi::c_void, 0, n);
+}
+"#,
+            &["q"],
+        );
+        let q = summaries.get("q").expect("expected q summary");
+
+        assert_eq!(q.call_arg_count, 0);
+        assert_eq!(q.inlineable_memory_call_count, 1);
+        assert_eq!(q.pointer_value_count, 0);
+        assert_eq!(q.materialization_kind(false), None);
+    }
+
+    #[test]
+    fn memset_pointer_argument_does_not_force_materialization() {
+        let summaries = classifier_summaries(
+            r#"
+unsafe extern "C" {
+    fn memset(ptr: *mut core::ffi::c_void, value: i32, n: usize) -> *mut core::ffi::c_void;
+}
+
+pub unsafe fn foo(mut p: *mut u8, n: usize) {
+    let mut q: *mut u8 = p.offset(1);
+    memset(q as *mut core::ffi::c_void, 0, n);
+}
+"#,
+            &["q"],
+        );
+        let q = summaries.get("q").expect("expected q summary");
+
+        assert_eq!(q.call_arg_count, 0);
+        assert_eq!(q.inlineable_memory_call_count, 1);
+        assert_eq!(q.pointer_value_count, 0);
+        assert_eq!(q.materialization_kind(true), None);
+    }
+
+    #[test]
+    fn memory_call_deref_argument_marks_cursor_inlineable() {
+        let summaries = classifier_summaries(
+            r#"
+unsafe extern "C" {
+    fn memset(ptr: *mut core::ffi::c_void, value: i32, n: usize) -> *mut core::ffi::c_void;
+}
+
+pub unsafe fn foo(mut p: *mut i8, mut q: *mut i8, n: usize) {
+    memset(q as *mut core::ffi::c_void, (*p) as i32, n);
+}
+"#,
+            &["p", "q"],
+        );
+        let p = summaries.get("p").expect("expected p summary");
+        let q = summaries.get("q").expect("expected q summary");
+
+        assert_eq!(p.inlineable_memory_call_count, 1);
+        assert_eq!(q.inlineable_memory_call_count, 1);
+        assert_eq!(q.call_arg_count, 0);
     }
 
     #[test]
@@ -664,6 +734,26 @@ fn ast_ty_is_raw_ptr(ty: &Ty) -> bool {
     }
 }
 
+fn call_path_last_segment(expr: &Expr) -> Option<&str> {
+    let ExprKind::Path(_, path) = &unwrap_cast_and_paren(expr).kind else {
+        return None;
+    };
+    path.segments
+        .last()
+        .map(|segment| segment.ident.name.as_str())
+}
+
+fn inlineable_memory_pointer_arg(callee: &Expr, arg_index: usize) -> bool {
+    match call_path_last_segment(callee) {
+        Some("memchr" | "memset") => arg_index == 0,
+        _ => false,
+    }
+}
+
+fn inlineable_memory_call(callee: &Expr) -> bool {
+    matches!(call_path_last_segment(callee), Some("memchr" | "memset"))
+}
+
 fn binding_names_in_body(tcx: TyCtxt<'_>, def_id: LocalDefId) -> FxHashSet<String> {
     struct NameVisitor {
         names: FxHashSet<String>,
@@ -1127,6 +1217,16 @@ fn choose_binding_representations(
         let summary = summaries.remove(hir_id).unwrap_or_default();
         rewrite.has_index_benefit = summary.has_index_benefit();
         if let Some(kind) = summary.materialization_kind(rewrite.ptr_mut) {
+            if rewrite.field_base
+                && summary.inlineable_memory_call_count > 0
+                && summary.field_or_index_count == 0
+                && summary.pointer_value_count == 0
+                && summary.call_arg_count == 0
+                && summary.multi_cursor_deref_expr_count == 0
+            {
+                rewrite.representation = BindingRepresentation::IndexOnly;
+                continue;
+            }
             if matches!(kind, MaterializationKind::RawPtr)
                 && summary.writes_through_pointer
                 && summary.call_arg_count == 0
@@ -1408,6 +1508,7 @@ impl AstVisitor<'_> for BindingUseClassifier<'_, '_> {
                 return;
             }
             ExprKind::Assign(lhs, rhs, _) => {
+                self.record_multi_cursor_deref_expr([&**lhs, &**rhs]);
                 if let Some(hir_id) = self.direct_planned_local_hir_id(lhs) {
                     self.summaries.entry(hir_id).or_default().movement_count += 1;
                 }
@@ -1416,6 +1517,7 @@ impl AstVisitor<'_> for BindingUseClassifier<'_, '_> {
                 return;
             }
             ExprKind::AssignOp(_, lhs, rhs) => {
+                self.record_multi_cursor_deref_expr([&**lhs, &**rhs]);
                 self.record_write_through_pointer(lhs);
                 self.visit_expr(rhs);
                 return;
@@ -1432,21 +1534,34 @@ impl AstVisitor<'_> for BindingUseClassifier<'_, '_> {
                     return;
                 }
             }
-            ExprKind::Call(_, args) => {
+            ExprKind::Call(callee, args) => {
                 let mut handled_arg = false;
-                for arg in args {
+                for (index, arg) in args.iter().enumerate() {
                     if let Some(hir_id) = self.direct_planned_local_hir_id(arg) {
-                        self.summaries.entry(hir_id).or_default().call_arg_count += 1;
+                        if !inlineable_memory_pointer_arg(callee, index) {
+                            self.summaries.entry(hir_id).or_default().call_arg_count += 1;
+                        } else {
+                            self.summaries
+                                .entry(hir_id)
+                                .or_default()
+                                .inlineable_memory_call_count += 1;
+                        }
                         handled_arg = true;
+                    }
+                    if inlineable_memory_call(callee) {
+                        for hir_id in self.direct_pointer_deref_hir_ids(arg) {
+                            self.summaries
+                                .entry(hir_id)
+                                .or_default()
+                                .inlineable_memory_call_count += 1;
+                        }
                     }
                 }
                 if handled_arg {
-                    if let ExprKind::Call(callee, args) = &expr.kind {
-                        self.visit_expr(callee);
-                        for arg in args {
-                            if self.direct_planned_local_hir_id(arg).is_none() {
-                                self.visit_expr(arg);
-                            }
+                    self.visit_expr(callee);
+                    for arg in args {
+                        if self.direct_planned_local_hir_id(arg).is_none() {
+                            self.visit_expr(arg);
                         }
                     }
                     return;
@@ -1503,6 +1618,22 @@ impl BindingUseClassifier<'_, '_> {
                 .entry(hir_id)
                 .or_default()
                 .writes_through_pointer = true;
+        }
+    }
+
+    fn record_multi_cursor_deref_expr<const N: usize>(&mut self, exprs: [&Expr; N]) {
+        let mut hir_ids = FxHashSet::default();
+        for expr in exprs {
+            hir_ids.extend(self.direct_pointer_deref_hir_ids(expr));
+        }
+        if hir_ids.len() <= 1 {
+            return;
+        }
+        for hir_id in hir_ids {
+            self.summaries
+                .entry(hir_id)
+                .or_default()
+                .multi_cursor_deref_expr_count += 1;
         }
     }
 

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -11,7 +11,10 @@ use rustc_hir::{
     self as hir, HirId, def::Res, def_id::LocalDefId, intravisit::Visitor as HirVisitor,
 };
 use rustc_middle::{
-    mir::{Local, TerminatorKind},
+    mir::{
+        Local, Location, Rvalue, Statement, StatementKind, Terminator, TerminatorKind,
+        visit::{PlaceContext, Visitor as MirVisitor},
+    },
     ty::{self, TyCtxt},
 };
 use rustc_span::Symbol;
@@ -24,8 +27,8 @@ use crate::{
     analyses::{
         self,
         array_local_provenance::{
-            ArrayLocalProvenance, PfgNode, RewriteGroup, RewriteSelectionContext, SlotPathElem,
-            named_struct_field,
+            ArrayLocalProvenance, PfgNode, RewriteGroup, RewriteSelectionContext, SlotInfo,
+            SlotPathElem, named_struct_field,
         },
         type_qualifier::foster::mutability::MutabilityResult,
     },
@@ -43,7 +46,9 @@ struct BindingRewrite {
     nullable: bool,
     ptr_ty: String,
     ptr_mut: bool,
+    field_base: bool,
     base_proxy_hir_ids: FxHashSet<HirId>,
+    group_member_hir_ids: FxHashSet<HirId>,
 }
 
 #[derive(Clone, Debug)]
@@ -54,12 +59,15 @@ struct BaseCursorRewrite {
     index_name: String,
     base_is_raw_ptr: bool,
     ptr_ty: String,
+    field_base: bool,
 }
+
+type BaseCursorKey = (HirId, String);
 
 #[derive(Default)]
 struct RewritePlan {
     by_hir_id: FxHashMap<HirId, BindingRewrite>,
-    base_by_hir_id: FxHashMap<HirId, BaseCursorRewrite>,
+    base_by_key: FxHashMap<BaseCursorKey, BaseCursorRewrite>,
     index_names_by_fn: FxHashMap<LocalDefId, FxHashSet<String>>,
 }
 
@@ -145,7 +153,7 @@ pub(crate) fn group_has_rewritable_binding<'tcx>(
         // for field-base groups, a member is rewritable only if it is NOT a proxy
         // (proxies hold the base at offset 0 and are left unchanged).
         if group.base_slot_offset > 0 {
-            return !local_only_directly_assigned(body, info.root);
+            return !local_is_pure_field_base_proxy(body, info.root);
         }
         true
     })
@@ -219,14 +227,14 @@ fn refine_base_pointer_kinds_from_ast(
         .by_hir_id
         .values()
         .map(|rewrite| rewrite.base_hir_id)
-        .chain(plan.base_by_hir_id.keys().copied())
+        .chain(plan.base_by_key.values().map(|rewrite| rewrite.base_hir_id))
         .collect();
     let base_names = plan
         .by_hir_id
         .values()
         .map(|rewrite| rewrite.base_name.clone())
         .chain(
-            plan.base_by_hir_id
+            plan.base_by_key
                 .values()
                 .map(|rewrite| rewrite.base_name.clone()),
         )
@@ -250,7 +258,7 @@ fn refine_base_pointer_kinds_from_ast(
             rewrite.base_is_raw_ptr = *base_is_raw_ptr;
         }
     }
-    for rewrite in plan.base_by_hir_id.values_mut() {
+    for rewrite in plan.base_by_key.values_mut() {
         if let Some(&base_is_raw_ptr) = visitor.base_is_raw_ptr_by_hir_id.get(&rewrite.base_hir_id)
         {
             rewrite.base_is_raw_ptr = base_is_raw_ptr;
@@ -375,10 +383,6 @@ struct GroupPlanContext<'a, 'tcx> {
 }
 
 fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGroup) {
-    // index_tracked with a field base is unsupported.
-    if group.base_slot_offset != 0 && group.index_tracked {
-        return;
-    }
     let Some(&base_hir_id) = context.local_to_hir.get(&group.base_local) else {
         return;
     };
@@ -419,7 +423,8 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                     return None;
                 }
                 let &hir_id = context.local_to_hir.get(&info.root)?;
-                local_only_directly_assigned(context.body, info.root).then_some(hir_id)
+                (!group.index_tracked && local_is_pure_field_base_proxy(context.body, info.root))
+                    .then_some(hir_id)
             })
             .collect();
         (name, proxies)
@@ -429,16 +434,51 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
         context.body.local_decls[group.base_local].ty.kind(),
         ty::TyKind::RawPtr(..)
     );
+    let base_cursor_key = base_cursor_key(base_hir_id, &base_name);
+    let group_member_hir_ids = group
+        .members
+        .iter()
+        .filter_map(|&slot_idx| {
+            let info = context.provenance.slot_table.slot_infos.get(slot_idx)?;
+            if !info.path.is_empty() || info.root == group.base_local {
+                return None;
+            }
+            if !matches!(
+                context.body.local_decls[info.root].ty.kind(),
+                ty::TyKind::RawPtr(..)
+            ) {
+                return None;
+            }
+            context.local_to_hir.get(&info.root).copied()
+        })
+        .collect::<FxHashSet<_>>();
     let base_index_name = if group.index_tracked {
-        if let Some(rewrite) = context.plan.base_by_hir_id.get(&base_hir_id) {
+        if let Some(rewrite) = context.plan.base_by_key.get(&base_cursor_key) {
             Some(rewrite.index_name.clone())
         } else {
-            let ty::TyKind::RawPtr(pointee, mutability) =
-                context.body.local_decls[group.base_local].ty.kind()
+            let Some(base_info) =
+                analyses::array_local_provenance::base_slot_info(context.provenance, group)
             else {
                 return;
             };
-            let index_name = fresh_index_name(&base_name, context.existing_names);
+            let Some(base_ptr_ty) = slot_ty(context.body, context.tcx, base_info) else {
+                return;
+            };
+            let ty::TyKind::RawPtr(pointee, mutability) = base_ptr_ty.kind() else {
+                return;
+            };
+            let index_stem = if group.base_slot_offset == 0 {
+                base_name.clone()
+            } else {
+                slot_path_to_index_stem(
+                    &context.tcx.hir_name(base_hir_id).to_string(),
+                    &base_info.path,
+                    context.body.local_decls[group.base_local].ty,
+                    context.tcx,
+                )
+                .unwrap_or_else(|| context.tcx.hir_name(base_hir_id).to_string())
+            };
+            let index_name = fresh_index_name(&index_stem, context.existing_names);
             let pointee = utils::ir::mir_ty_to_string(*pointee, context.tcx);
             let ptr_ty = format!(
                 "*{} {}",
@@ -451,8 +491,8 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                 .entry(context.def_id)
                 .or_default()
                 .insert(index_name.clone());
-            context.plan.base_by_hir_id.insert(
-                base_hir_id,
+            context.plan.base_by_key.insert(
+                base_cursor_key,
                 BaseCursorRewrite {
                     fn_def_id: context.def_id,
                     base_hir_id,
@@ -460,6 +500,7 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                     index_name: index_name.clone(),
                     base_is_raw_ptr,
                     ptr_ty,
+                    field_base: group.base_slot_offset != 0,
                 },
             );
             Some(index_name)
@@ -522,10 +563,45 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                 nullable,
                 ptr_ty,
                 ptr_mut: mutability.is_mut(),
+                field_base: group.base_slot_offset != 0,
                 base_proxy_hir_ids: proxy_hir_ids.clone(),
+                group_member_hir_ids: group_member_hir_ids.clone(),
             },
         );
     }
+}
+
+fn slot_ty<'tcx>(
+    body: &rustc_middle::mir::Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    info: &SlotInfo,
+) -> Option<ty::Ty<'tcx>> {
+    let mut ty = body.local_decls[info.root].ty;
+
+    for elem in &info.path {
+        match elem {
+            SlotPathElem::Pointee => {
+                ty = ty.builtin_deref(true)?;
+            }
+            SlotPathElem::Field(field) => {
+                ty = match ty.kind() {
+                    ty::TyKind::Adt(adt_def, args) => {
+                        if !adt_def.is_struct() || adt_def.is_union() {
+                            return None;
+                        }
+                        adt_def.all_fields().nth(field.index())?.ty(tcx, args)
+                    }
+                    ty::TyKind::Tuple(tys) => tys.iter().nth(field.index())?,
+                    _ => return None,
+                };
+            }
+            SlotPathElem::Element => {
+                ty = ty.builtin_index()?;
+            }
+        }
+    }
+
+    Some(ty)
 }
 
 fn fresh_index_name(source_name: &str, existing_names: &mut FxHashSet<String>) -> String {
@@ -537,6 +613,33 @@ fn fresh_index_name(source_name: &str, existing_names: &mut FxHashSet<String>) -
     }
     existing_names.insert(candidate.clone());
     candidate
+}
+
+fn slot_path_to_index_stem<'tcx>(
+    local_name: &str,
+    path: &[SlotPathElem],
+    mut ty: ty::Ty<'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> Option<String> {
+    let mut parts = Vec::new();
+    for elem in path {
+        match elem {
+            SlotPathElem::Pointee => {
+                ty = ty.builtin_deref(true)?;
+            }
+            SlotPathElem::Field(field) => {
+                let (field_name, field_ty) = named_struct_field(tcx, ty, *field)?;
+                parts.push(field_name);
+                ty = field_ty;
+            }
+            SlotPathElem::Element => return None,
+        }
+    }
+    if parts.is_empty() {
+        Some(local_name.to_string())
+    } else {
+        Some(parts.join("_"))
+    }
 }
 
 fn slot_path_to_expr_string<'tcx>(
@@ -563,16 +666,91 @@ fn slot_path_to_expr_string<'tcx>(
     Some(expr)
 }
 
-fn local_only_directly_assigned(body: &rustc_middle::mir::Body<'_>, local: Local) -> bool {
-    for block_data in body.basic_blocks.iter() {
+fn local_is_pure_field_base_proxy(body: &rustc_middle::mir::Body<'_>, local: Local) -> bool {
+    let mut has_call_destination = false;
+    let mut has_non_assignment_use = false;
+
+    for (block, block_data) in body.basic_blocks.iter_enumerated() {
+        for (statement_index, statement) in block_data.statements.iter().enumerate() {
+            let location = Location {
+                block,
+                statement_index,
+            };
+            if let StatementKind::Assign(box (lhs, rvalue)) = &statement.kind {
+                if lhs.local == local && lhs.projection.is_empty() {
+                    if rvalue_mentions_local(rvalue, local, location) {
+                        has_non_assignment_use = true;
+                    }
+                    continue;
+                }
+            }
+            if statement_mentions_local(statement, local, location) {
+                has_non_assignment_use = true;
+            }
+        }
         if let Some(terminator) = &block_data.terminator
             && let TerminatorKind::Call { destination, .. } = &terminator.kind
-            && destination.local == local
         {
-            return false;
+            if destination.local == local {
+                has_call_destination = true;
+            }
+        }
+        if let Some(terminator) = &block_data.terminator {
+            let location = Location {
+                block,
+                statement_index: block_data.statements.len(),
+            };
+            if terminator_mentions_local(terminator, local, location) {
+                has_non_assignment_use = true;
+            }
         }
     }
-    true
+
+    !has_call_destination && !has_non_assignment_use
+}
+
+struct LocalMentionVisitor {
+    local: Local,
+    found: bool,
+}
+
+impl<'tcx> MirVisitor<'tcx> for LocalMentionVisitor {
+    fn visit_local(&mut self, local: Local, context: PlaceContext, _location: Location) {
+        if local == self.local && !matches!(context, PlaceContext::NonUse(_)) {
+            self.found = true;
+        }
+    }
+}
+
+fn rvalue_mentions_local(rvalue: &Rvalue<'_>, local: Local, location: Location) -> bool {
+    let mut visitor = LocalMentionVisitor {
+        local,
+        found: false,
+    };
+    visitor.visit_rvalue(rvalue, location);
+    visitor.found
+}
+
+fn statement_mentions_local(statement: &Statement<'_>, local: Local, location: Location) -> bool {
+    let mut visitor = LocalMentionVisitor {
+        local,
+        found: false,
+    };
+    visitor.visit_statement(statement, location);
+    visitor.found
+}
+
+fn terminator_mentions_local(
+    terminator: &Terminator<'_>,
+    local: Local,
+    location: Location,
+) -> bool {
+    let mut visitor = LocalMentionVisitor {
+        local,
+        found: false,
+    };
+    visitor.visit_terminator(terminator, location);
+    visitor.found
 }
 
 fn prune_unsupported_direct_place_uses(
@@ -589,7 +767,7 @@ fn prune_unsupported_direct_place_uses(
         ast_to_hir,
         tcx,
         planned_rewrites: plan.by_hir_id.clone(),
-        base_rewrites: plan.base_by_hir_id.clone(),
+        base_rewrites: plan.base_by_key.clone(),
         unsupported_hir_ids: FxHashSet::default(),
     };
     visitor.visit_crate(krate);
@@ -601,21 +779,21 @@ fn prune_unsupported_direct_place_uses(
 }
 
 fn prune_orphan_base_cursors(plan: &mut RewritePlan) {
-    let live_base_hir_ids = plan
+    let live_base_keys = plan
         .by_hir_id
         .values()
         .filter(|rewrite| rewrite.base_index_name.is_some())
-        .map(|rewrite| rewrite.base_hir_id)
+        .map(|rewrite| base_cursor_key(rewrite.base_hir_id, &rewrite.base_name))
         .collect::<FxHashSet<_>>();
-    plan.base_by_hir_id
-        .retain(|base_hir_id, _| live_base_hir_ids.contains(base_hir_id));
+    plan.base_by_key
+        .retain(|base_key, _| live_base_keys.contains(base_key));
 }
 
 struct UnsupportedDirectPlaceUseVisitor<'a, 'tcx> {
     ast_to_hir: &'a AstToHir,
     tcx: TyCtxt<'tcx>,
     planned_rewrites: FxHashMap<HirId, BindingRewrite>,
-    base_rewrites: FxHashMap<HirId, BaseCursorRewrite>,
+    base_rewrites: FxHashMap<BaseCursorKey, BaseCursorRewrite>,
     unsupported_hir_ids: FxHashSet<HirId>,
 }
 
@@ -648,8 +826,10 @@ impl AstVisitor<'_> for UnsupportedDirectPlaceUseVisitor<'_, '_> {
 
 impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
     fn check_assignment(&mut self, lhs: &Expr, rhs: &Expr) {
-        if let Some(base_hir_id) = direct_local_hir_id(self.ast_to_hir, self.tcx, lhs) {
-            if let Some(base_rewrite) = self.base_rewrites.get(&base_hir_id) {
+        if let Some(base_key) =
+            direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.base_rewrites, lhs)
+        {
+            if let Some(base_rewrite) = self.base_rewrites.get(&base_key) {
                 let index = base_assignment_index_expr(
                     rhs,
                     self.ast_to_hir,
@@ -666,11 +846,11 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
                         base_rewrite,
                     );
                 if unsupported {
-                    self.mark_rewrites_for_base_unsupported(base_hir_id);
+                    self.mark_rewrites_for_base_unsupported(&base_key);
                 }
                 return;
             } else {
-                self.mark_rewrites_for_base_unsupported(base_hir_id);
+                self.mark_rewrites_for_base_unsupported(&base_key);
             }
         }
 
@@ -683,7 +863,14 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
         let Some(rewrite) = self.planned_rewrites.get(&hir_id) else {
             return;
         };
-        let index = assignment_index_expr(rhs, self.ast_to_hir, self.tcx, rewrite);
+        let index = assignment_index_expr(
+            rhs,
+            self.ast_to_hir,
+            self.tcx,
+            &self.planned_rewrites,
+            None,
+            rewrite,
+        );
         if index_init_expr(index, rewrite.nullable).is_none()
             || assignment_index_arg_contains_planned_local(
                 rhs,
@@ -697,19 +884,20 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
         }
     }
 
-    fn mark_rewrites_for_base_unsupported(&mut self, base_hir_id: HirId) {
+    fn mark_rewrites_for_base_unsupported(&mut self, base_key: &BaseCursorKey) {
         for rewrite in self.planned_rewrites.values() {
-            if rewrite.base_hir_id == base_hir_id {
+            if base_cursor_key(rewrite.base_hir_id, &rewrite.base_name) == *base_key {
                 self.unsupported_hir_ids.insert(rewrite.source_hir_id);
             }
         }
     }
 
     fn mark_direct_base_cursor(&mut self, expr: &Expr) -> Option<HirId> {
-        let hir_id = direct_local_hir_id(self.ast_to_hir, self.tcx, expr)?;
-        if self.base_rewrites.contains_key(&hir_id) {
-            self.mark_rewrites_for_base_unsupported(hir_id);
-            Some(hir_id)
+        let base_key =
+            direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.base_rewrites, expr)?;
+        if self.base_rewrites.contains_key(&base_key) {
+            self.mark_rewrites_for_base_unsupported(&base_key);
+            Some(base_key.0)
         } else {
             None
         }
@@ -784,7 +972,10 @@ fn assignment_index_arg_contains_planned_local(
     let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
     let receiver_is_base = receiver_hir_id == Some(rewrite.base_hir_id)
         || receiver_is_base_as_ptr(receiver, ast_to_hir, tcx, rewrite)
-        || receiver_hir_id.is_some_and(|id| rewrite.base_proxy_hir_ids.contains(&id));
+        || receiver_hir_id.is_some_and(|id| {
+            rewrite.base_proxy_hir_ids.contains(&id)
+                || (rewrite.field_base && rewrite.group_member_hir_ids.contains(&id))
+        });
     if !receiver_is_base && receiver_hir_id != Some(rewrite.source_hir_id) {
         return false;
     }
@@ -808,13 +999,22 @@ fn base_assignment_index_arg_contains_planned_local(
     }
     let receiver = unwrap_cast_and_paren(&call.receiver);
     let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
-    let receiver_is_base = receiver_hir_id == Some(base_rewrite.base_hir_id)
-        || receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, base_rewrite.base_hir_id);
+    let receiver_is_base = (!base_rewrite.field_base
+        && receiver_hir_id == Some(base_rewrite.base_hir_id))
+        || receiver_is_base_as_ptr_for_context(
+            receiver,
+            ast_to_hir,
+            tcx,
+            base_rewrite.base_hir_id,
+            &base_rewrite.base_name,
+            base_rewrite.field_base,
+        )
+        || (base_rewrite.field_base && expr_matches_base_name(receiver, &base_rewrite.base_name));
     if !receiver_is_base
         && !receiver_hir_id.is_some_and(|hir_id| {
             planned_rewrites
                 .get(&hir_id)
-                .is_some_and(|rewrite| rewrite.base_hir_id == base_rewrite.base_hir_id)
+                .is_some_and(|rewrite| same_rewrite_base(rewrite, base_rewrite))
         })
     {
         return false;
@@ -832,14 +1032,41 @@ fn direct_planned_local_hir_id(
     planned_rewrites.contains_key(&hir_id).then_some(hir_id)
 }
 
+fn same_rewrite_base(rewrite: &BindingRewrite, base_rewrite: &BaseCursorRewrite) -> bool {
+    rewrite.base_hir_id == base_rewrite.base_hir_id && rewrite.base_name == base_rewrite.base_name
+}
+
+fn base_cursor_key(base_hir_id: HirId, base_name: &str) -> BaseCursorKey {
+    (base_hir_id, base_name.to_string())
+}
+
 fn direct_base_cursor_hir_id(
     ast_to_hir: &AstToHir,
     tcx: TyCtxt<'_>,
-    base_rewrites: &FxHashMap<HirId, BaseCursorRewrite>,
+    base_rewrites: &FxHashMap<BaseCursorKey, BaseCursorRewrite>,
     expr: &Expr,
-) -> Option<HirId> {
+) -> Option<BaseCursorKey> {
     let hir_id = direct_local_hir_id(ast_to_hir, tcx, expr)?;
-    base_rewrites.contains_key(&hir_id).then_some(hir_id)
+    base_rewrites.iter().find_map(|(key, rewrite)| {
+        (!rewrite.field_base && rewrite.base_hir_id == hir_id).then_some(key.clone())
+    })
+}
+
+fn direct_base_cursor_key(
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    base_rewrites: &FxHashMap<BaseCursorKey, BaseCursorRewrite>,
+    expr: &Expr,
+) -> Option<BaseCursorKey> {
+    if let Some(base_key) = direct_base_cursor_hir_id(ast_to_hir, tcx, base_rewrites, expr) {
+        return Some(base_key);
+    }
+    base_rewrites.iter().find_map(|(key, rewrite)| {
+        (rewrite.field_base
+            && expr_matches_base_name(expr, &rewrite.base_name)
+            && expr_is_projection_from_base_hir(expr, ast_to_hir, tcx, rewrite.base_hir_id))
+        .then_some(key.clone())
+    })
 }
 
 fn direct_local_hir_id(ast_to_hir: &AstToHir, tcx: TyCtxt<'_>, expr: &Expr) -> Option<HirId> {
@@ -902,6 +1129,25 @@ fn is_null_expr(expr: &Expr) -> bool {
     }
 }
 
+fn unwrap_pointer_producing_expr(expr: &Expr) -> &Expr {
+    let expr = unwrap_cast_and_paren(expr);
+    match &expr.kind {
+        ExprKind::AddrOf(_, _, inner) => {
+            let inner = unwrap_cast_and_paren(inner);
+            if let ExprKind::Unary(UnOp::Deref, deref_inner) = &inner.kind {
+                return unwrap_pointer_producing_expr(deref_inner);
+            }
+            expr
+        }
+        _ => expr,
+    }
+}
+
+fn expr_matches_base_name(expr: &Expr, base_name: &str) -> bool {
+    pprust::expr_to_string(unwrap_cast_and_paren(expr)).replace(' ', "")
+        == base_name.replace(' ', "")
+}
+
 fn offset_index_arg_expr(name: &str, arg: &Expr) -> Expr {
     if name == "add" || matches!(unwrap_cast_and_paren(arg).kind, ExprKind::Lit(_)) {
         utils::expr!("({}) as isize", pprust::expr_to_string(arg))
@@ -923,6 +1169,26 @@ fn base_current_index_expr(rewrite: &BindingRewrite) -> Option<&str> {
     rewrite.base_index_name.as_deref()
 }
 
+fn expr_is_projection_from_base_hir(
+    expr: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    base_hir_id: HirId,
+) -> bool {
+    let expr = unwrap_cast_and_paren(expr);
+    if hir_id_of_ast_expr(ast_to_hir, tcx, expr.id) == Some(base_hir_id) {
+        return true;
+    }
+    match &expr.kind {
+        ExprKind::AddrOf(_, _, inner)
+        | ExprKind::Field(inner, _)
+        | ExprKind::Unary(UnOp::Deref, inner) => {
+            expr_is_projection_from_base_hir(inner, ast_to_hir, tcx, base_hir_id)
+        }
+        _ => false,
+    }
+}
+
 fn receiver_is_base_as_ptr_hir(
     receiver: &Expr,
     ast_to_hir: &AstToHir,
@@ -936,8 +1202,33 @@ fn receiver_is_base_as_ptr_hir(
     if !matches!(name, "as_ptr" | "as_mut_ptr") || !call.args.is_empty() {
         return false;
     }
-    hir_id_of_ast_expr(ast_to_hir, tcx, unwrap_cast_and_paren(&call.receiver).id)
-        == Some(base_hir_id)
+    expr_is_projection_from_base_hir(&call.receiver, ast_to_hir, tcx, base_hir_id)
+}
+
+fn receiver_is_field_base_as_ptr(receiver: &Expr, base_name: &str) -> bool {
+    let ExprKind::MethodCall(call) = &receiver.kind else {
+        return false;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "as_ptr" | "as_mut_ptr") || !call.args.is_empty() {
+        return false;
+    }
+    expr_matches_base_name(&call.receiver, base_name)
+}
+
+fn receiver_is_base_as_ptr_for_context(
+    receiver: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    base_hir_id: HirId,
+    base_name: &str,
+    field_base: bool,
+) -> bool {
+    if field_base {
+        receiver_is_field_base_as_ptr(receiver, base_name)
+    } else {
+        receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, base_hir_id)
+    }
 }
 
 fn receiver_is_base_as_ptr(
@@ -946,19 +1237,56 @@ fn receiver_is_base_as_ptr(
     tcx: TyCtxt<'_>,
     rewrite: &BindingRewrite,
 ) -> bool {
-    receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, rewrite.base_hir_id)
+    receiver_is_base_as_ptr_for_context(
+        receiver,
+        ast_to_hir,
+        tcx,
+        rewrite.base_hir_id,
+        &rewrite.base_name,
+        rewrite.field_base,
+    )
 }
 
-fn receiver_is_base_pointer_expr(
-    receiver: &Expr,
+fn slice_base_expr_from_as_ptr_receiver(receiver: &Expr) -> &Expr {
+    let receiver = unwrap_cast_and_paren(receiver);
+    if let ExprKind::AddrOf(_, _, inner) = &receiver.kind {
+        unwrap_cast_and_paren(inner)
+    } else {
+        receiver
+    }
+}
+
+fn projected_as_ptr_receiver_base_name(
+    expr: &Expr,
     ast_to_hir: &AstToHir,
     tcx: TyCtxt<'_>,
     rewrite: &BindingRewrite,
-) -> bool {
-    let hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
-    hir_id == Some(rewrite.base_hir_id)
-        || receiver_is_base_as_ptr(receiver, ast_to_hir, tcx, rewrite)
-        || hir_id.is_some_and(|id| rewrite.base_proxy_hir_ids.contains(&id))
+) -> Option<String> {
+    if rewrite.field_base {
+        return None;
+    }
+    let expr = unwrap_pointer_producing_expr(expr);
+    let ExprKind::MethodCall(offset_call) = &expr.kind else {
+        return None;
+    };
+    let name = offset_call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || offset_call.args.len() != 1 {
+        return None;
+    }
+    let receiver = unwrap_cast_and_paren(&offset_call.receiver);
+    let ExprKind::MethodCall(as_ptr_call) = &receiver.kind else {
+        return None;
+    };
+    let as_ptr_name = as_ptr_call.seg.ident.name.as_str();
+    if !matches!(as_ptr_name, "as_ptr" | "as_mut_ptr") || !as_ptr_call.args.is_empty() {
+        return None;
+    }
+    let base_expr = slice_base_expr_from_as_ptr_receiver(&as_ptr_call.receiver);
+    if hir_id_of_ast_expr(ast_to_hir, tcx, base_expr.id) == Some(rewrite.base_hir_id) {
+        return None;
+    }
+    expr_is_projection_from_base_hir(base_expr, ast_to_hir, tcx, rewrite.base_hir_id)
+        .then(|| pprust::expr_to_string(base_expr))
 }
 
 fn offset_from_base_expr(
@@ -967,19 +1295,44 @@ fn offset_from_base_expr(
     tcx: TyCtxt<'_>,
     rewrite: &BindingRewrite,
 ) -> IndexExpr {
+    pointer_index_from_base_expr(
+        expr,
+        ast_to_hir,
+        tcx,
+        rewrite.base_hir_id,
+        &rewrite.base_name,
+        rewrite.field_base,
+        &rewrite.base_proxy_hir_ids,
+        base_current_index_expr(rewrite),
+    )
+}
+
+fn pointer_index_from_base_expr(
+    expr: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    base_hir_id: HirId,
+    base_name: &str,
+    field_base: bool,
+    base_proxy_hir_ids: &FxHashSet<HirId>,
+    base_index_name: Option<&str>,
+) -> IndexExpr {
     if is_null_expr(expr) {
         return IndexExpr::Null;
     }
-    let expr = unwrap_cast_and_paren(expr);
+
+    let expr = unwrap_pointer_producing_expr(expr);
     let expr_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, expr.id);
-    if expr_hir_id == Some(rewrite.base_hir_id)
-        || expr_hir_id.is_some_and(|id| rewrite.base_proxy_hir_ids.contains(&id))
+    if (!field_base && expr_hir_id == Some(base_hir_id))
+        || expr_hir_id.is_some_and(|id| base_proxy_hir_ids.contains(&id))
+        || (field_base && expr_matches_base_name(expr, base_name))
     {
-        return IndexExpr::Plain(match base_current_index_expr(rewrite) {
-            Some(base_index_name) => utils::expr!("{}", base_index_name),
+        return IndexExpr::Plain(match base_index_name {
+            Some(index_name) => utils::expr!("{}", index_name),
             None => utils::expr!("0isize"),
         });
     }
+
     let ExprKind::MethodCall(call) = &expr.kind else {
         return IndexExpr::Unsupported;
     };
@@ -988,29 +1341,35 @@ fn offset_from_base_expr(
         return IndexExpr::Unsupported;
     }
     let receiver = unwrap_cast_and_paren(&call.receiver);
-    if !receiver_is_base_pointer_expr(receiver, ast_to_hir, tcx, rewrite) {
+    let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
+    let receiver_is_base = (!field_base && receiver_hir_id == Some(base_hir_id))
+        || receiver_is_base_as_ptr_for_context(
+            receiver,
+            ast_to_hir,
+            tcx,
+            base_hir_id,
+            base_name,
+            field_base,
+        )
+        || (field_base && expr_matches_base_name(receiver, base_name))
+        || receiver_hir_id.is_some_and(|id| base_proxy_hir_ids.contains(&id));
+    if !receiver_is_base {
         return IndexExpr::Unsupported;
     }
     let offset = offset_index_arg_expr(name, &call.args[0]);
-    if let Some(base_index_name) = base_current_index_expr(rewrite) {
-        IndexExpr::Plain(add_index_expr(base_index_name, &offset))
-    } else {
-        IndexExpr::Plain(offset)
+    match base_index_name {
+        Some(index_name) => IndexExpr::Plain(add_index_expr(index_name, &offset)),
+        None => IndexExpr::Plain(offset),
     }
 }
 
-fn assignment_index_expr(
+fn group_member_pointer_assignment_index_expr(
     rhs: &Expr,
     ast_to_hir: &AstToHir,
     tcx: TyCtxt<'_>,
     rewrite: &BindingRewrite,
 ) -> IndexExpr {
-    match offset_from_base_expr(rhs, ast_to_hir, tcx, rewrite) {
-        IndexExpr::Unsupported => {}
-        index => return index,
-    }
-
-    let rhs = unwrap_paren(rhs);
+    let rhs = unwrap_pointer_producing_expr(rhs);
     let ExprKind::MethodCall(call) = &rhs.kind else {
         return IndexExpr::Unsupported;
     };
@@ -1018,9 +1377,95 @@ fn assignment_index_expr(
     if !matches!(name, "offset" | "add") || call.args.len() != 1 {
         return IndexExpr::Unsupported;
     }
-    let receiver = unwrap_paren(&call.receiver);
-    if hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) != Some(rewrite.source_hir_id) {
+    let receiver = unwrap_pointer_producing_expr(&call.receiver);
+    let Some(receiver_hir_id) = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) else {
         return IndexExpr::Unsupported;
+    };
+    if !rewrite.group_member_hir_ids.contains(&receiver_hir_id) {
+        return IndexExpr::Unsupported;
+    }
+
+    let rhs_ptr = pprust::expr_to_string(rhs);
+    let base_index = base_current_index_expr(rewrite).unwrap_or("0isize");
+    let base_ptr = base_offset_expr_for_index(rewrite, base_index);
+    let relative = utils::expr!("({}).offset_from({})", rhs_ptr, base_ptr);
+    match base_current_index_expr(rewrite) {
+        Some(index_name) => IndexExpr::Plain(add_index_expr(index_name, &relative)),
+        None => IndexExpr::Plain(relative),
+    }
+}
+
+fn introduced_group_member_assignment_index_expr(
+    rhs: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+    introduced_hir_ids: &FxHashSet<HirId>,
+    rewrite: &BindingRewrite,
+) -> IndexExpr {
+    let rhs = unwrap_pointer_producing_expr(rhs);
+    let ExprKind::MethodCall(call) = &rhs.kind else {
+        return IndexExpr::Unsupported;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return IndexExpr::Unsupported;
+    }
+    let receiver = unwrap_pointer_producing_expr(&call.receiver);
+    let Some(receiver_hir_id) = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) else {
+        return IndexExpr::Unsupported;
+    };
+    if !rewrite.group_member_hir_ids.contains(&receiver_hir_id)
+        || !introduced_hir_ids.contains(&receiver_hir_id)
+    {
+        return IndexExpr::Unsupported;
+    }
+    let Some(receiver_rewrite) = planned_rewrites.get(&receiver_hir_id) else {
+        return IndexExpr::Unsupported;
+    };
+    if receiver_rewrite.base_hir_id != rewrite.base_hir_id
+        || receiver_rewrite.base_name != rewrite.base_name
+    {
+        return IndexExpr::Unsupported;
+    }
+    IndexExpr::Plain(relative_index_expr(
+        &idx_read_expr(receiver_rewrite),
+        name,
+        &call.args[0],
+    ))
+}
+
+fn assignment_index_expr(
+    rhs: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+    introduced_hir_ids: Option<&FxHashSet<HirId>>,
+    rewrite: &BindingRewrite,
+) -> IndexExpr {
+    match offset_from_base_expr(rhs, ast_to_hir, tcx, rewrite) {
+        IndexExpr::Unsupported => {}
+        index => return index,
+    }
+
+    let rhs = unwrap_pointer_producing_expr(rhs);
+    let ExprKind::MethodCall(call) = &rhs.kind else {
+        return IndexExpr::Unsupported;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return IndexExpr::Unsupported;
+    }
+    let receiver = unwrap_pointer_producing_expr(&call.receiver);
+    let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
+    if receiver_hir_id != Some(rewrite.source_hir_id) {
+        if receiver_hir_id.is_some_and(|hir_id| {
+            planned_rewrites.contains_key(&hir_id)
+                && introduced_hir_ids.is_some_and(|introduced| introduced.contains(&hir_id))
+        }) {
+            return IndexExpr::Unsupported;
+        }
+        return group_member_pointer_assignment_index_expr(rhs, ast_to_hir, tcx, rewrite);
     }
     IndexExpr::Plain(relative_index_expr(
         &idx_read_expr(rewrite),
@@ -1040,12 +1485,17 @@ fn base_assignment_index_expr(
         return IndexExpr::Null;
     }
     let rhs = unwrap_cast_and_paren(rhs);
-    if hir_id_of_ast_expr(ast_to_hir, tcx, rhs.id) == Some(base_rewrite.base_hir_id) {
+    if !base_rewrite.field_base
+        && hir_id_of_ast_expr(ast_to_hir, tcx, rhs.id) == Some(base_rewrite.base_hir_id)
+    {
+        return IndexExpr::Plain(utils::expr!("{}", base_rewrite.index_name));
+    }
+    if base_rewrite.field_base && expr_matches_base_name(rhs, &base_rewrite.base_name) {
         return IndexExpr::Plain(utils::expr!("{}", base_rewrite.index_name));
     }
     if let Some(rewrite) = direct_planned_local_hir_id(ast_to_hir, tcx, planned_rewrites, rhs)
         .and_then(|hir_id| planned_rewrites.get(&hir_id))
-        && rewrite.base_hir_id == base_rewrite.base_hir_id
+        && same_rewrite_base(rewrite, base_rewrite)
     {
         return IndexExpr::Plain(utils::expr!("{}", idx_read_expr(rewrite)));
     }
@@ -1059,14 +1509,23 @@ fn base_assignment_index_expr(
     }
     let receiver = unwrap_cast_and_paren(&call.receiver);
     let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
-    if receiver_hir_id == Some(base_rewrite.base_hir_id)
-        || receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, base_rewrite.base_hir_id)
-    {
+    let receiver_is_base = (!base_rewrite.field_base
+        && receiver_hir_id == Some(base_rewrite.base_hir_id))
+        || receiver_is_base_as_ptr_for_context(
+            receiver,
+            ast_to_hir,
+            tcx,
+            base_rewrite.base_hir_id,
+            &base_rewrite.base_name,
+            base_rewrite.field_base,
+        )
+        || (base_rewrite.field_base && expr_matches_base_name(receiver, &base_rewrite.base_name));
+    if receiver_is_base {
         let offset = offset_index_arg_expr(name, &call.args[0]);
         return IndexExpr::Plain(add_index_expr(&base_rewrite.index_name, &offset));
     }
     if let Some(rewrite) = receiver_hir_id.and_then(|hir_id| planned_rewrites.get(&hir_id))
-        && rewrite.base_hir_id == base_rewrite.base_hir_id
+        && same_rewrite_base(rewrite, base_rewrite)
     {
         return IndexExpr::Plain(relative_index_expr(
             &idx_read_expr(rewrite),
@@ -1171,7 +1630,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
         {
             let mut cursors = self
                 .plan
-                .base_by_hir_id
+                .base_by_key
                 .values()
                 .filter(|rewrite| rewrite.fn_def_id == def_id)
                 .cloned()
@@ -1200,7 +1659,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             mut_visit::walk_local(self, local);
             return;
         };
-        let Some(rewrite) = self.plan.by_hir_id.get(&hir_id).cloned() else {
+        let Some(mut rewrite) = self.plan.by_hir_id.get(&hir_id).cloned() else {
             mut_visit::walk_local(self, local);
             return;
         };
@@ -1208,7 +1667,24 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             mut_visit::walk_local(self, local);
             return;
         };
-        let index = offset_from_base_expr(init, self.ast_to_hir, self.tcx, &rewrite);
+        if let Some(base_name) =
+            projected_as_ptr_receiver_base_name(init, self.ast_to_hir, self.tcx, &rewrite)
+        {
+            rewrite.base_name = base_name;
+            rewrite.base_is_raw_ptr = false;
+            self.plan.by_hir_id.insert(hir_id, rewrite.clone());
+        }
+        let mut index = offset_from_base_expr(init, self.ast_to_hir, self.tcx, &rewrite);
+        if let IndexExpr::Unsupported = index {
+            index = introduced_group_member_assignment_index_expr(
+                init,
+                self.ast_to_hir,
+                self.tcx,
+                &self.plan.by_hir_id,
+                &self.introduced_hir_ids,
+                &rewrite,
+            );
+        }
         let Some(new_init) = index_init_expr(index, rewrite.nullable) else {
             mut_visit::walk_local(self, local);
             return;
@@ -1226,12 +1702,9 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
     fn visit_expr(&mut self, expr: &mut Expr) {
         match &mut expr.kind {
             ExprKind::Assign(lhs, rhs, _) => {
-                if let Some(hir_id) = direct_base_cursor_hir_id(
-                    self.ast_to_hir,
-                    self.tcx,
-                    &self.plan.base_by_hir_id,
-                    lhs,
-                ) && let Some(rewrite) = self.plan.base_by_hir_id.get(&hir_id)
+                if let Some(base_key) =
+                    direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, lhs)
+                    && let Some(rewrite) = self.plan.base_by_key.get(&base_key)
                 {
                     let index = base_assignment_index_expr(
                         rhs,
@@ -1256,7 +1729,24 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                     lhs,
                 ) && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
                 {
-                    let index = assignment_index_expr(rhs, self.ast_to_hir, self.tcx, rewrite);
+                    let mut index = introduced_group_member_assignment_index_expr(
+                        rhs,
+                        self.ast_to_hir,
+                        self.tcx,
+                        &self.plan.by_hir_id,
+                        &self.introduced_hir_ids,
+                        rewrite,
+                    );
+                    if let IndexExpr::Unsupported = index {
+                        index = assignment_index_expr(
+                            rhs,
+                            self.ast_to_hir,
+                            self.tcx,
+                            &self.plan.by_hir_id,
+                            Some(&self.introduced_hir_ids),
+                            rewrite,
+                        );
+                    }
                     if let Some(new_rhs) = index_assignment_rhs_expr(index, rewrite.nullable) {
                         *lhs = P(utils::expr!("{}", rewrite.index_name));
                         *rhs = P(new_rhs);
@@ -1271,13 +1761,8 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                 return;
             }
             ExprKind::AssignOp(_, lhs, rhs) => {
-                if direct_base_cursor_hir_id(
-                    self.ast_to_hir,
-                    self.tcx,
-                    &self.plan.base_by_hir_id,
-                    lhs,
-                )
-                .is_none()
+                if direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, lhs)
+                    .is_none()
                     && introduced_planned_local_hir_id(
                         self.ast_to_hir,
                         self.tcx,
@@ -1292,13 +1777,8 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                 return;
             }
             ExprKind::AddrOf(_, _, inner) => {
-                if direct_base_cursor_hir_id(
-                    self.ast_to_hir,
-                    self.tcx,
-                    &self.plan.base_by_hir_id,
-                    inner,
-                )
-                .is_none()
+                if direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, inner)
+                    .is_none()
                     && introduced_planned_local_hir_id(
                         self.ast_to_hir,
                         self.tcx,
@@ -1332,9 +1812,56 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             }
         }
 
+        if let ExprKind::Binary(op, lhs, rhs) = &expr.kind
+            && matches!(
+                op.node,
+                BinOpKind::Eq
+                    | BinOpKind::Ne
+                    | BinOpKind::Lt
+                    | BinOpKind::Le
+                    | BinOpKind::Gt
+                    | BinOpKind::Ge
+            )
+        {
+            let lhs_hir =
+                hir_id_of_ast_expr(self.ast_to_hir, self.tcx, unwrap_cast_and_paren(lhs).id);
+            let rhs_hir =
+                hir_id_of_ast_expr(self.ast_to_hir, self.tcx, unwrap_cast_and_paren(rhs).id);
+            let lhs_rewrite = lhs_hir.and_then(|hir_id| self.plan.by_hir_id.get(&hir_id));
+            let rhs_rewrite = rhs_hir.and_then(|hir_id| self.plan.by_hir_id.get(&hir_id));
+            let lhs_introduced =
+                lhs_hir.is_some_and(|hir_id| self.introduced_hir_ids.contains(&hir_id));
+            let rhs_introduced =
+                rhs_hir.is_some_and(|hir_id| self.introduced_hir_ids.contains(&hir_id));
+            if let (Some(lhs_rewrite), Some(rhs_rewrite)) = (lhs_rewrite, rhs_rewrite)
+                && lhs_introduced
+                && rhs_introduced
+                && !lhs_rewrite.nullable
+                && !rhs_rewrite.nullable
+                && lhs_rewrite.base_hir_id == rhs_rewrite.base_hir_id
+                && lhs_rewrite.base_name == rhs_rewrite.base_name
+                && lhs_rewrite.ptr_ty == rhs_rewrite.ptr_ty
+            {
+                let lhs_idx = idx_read_expr(lhs_rewrite);
+                let rhs_idx = idx_read_expr(rhs_rewrite);
+                *expr = match op.node {
+                    BinOpKind::Eq => utils::expr!("{lhs_idx} == {rhs_idx}"),
+                    BinOpKind::Ne => utils::expr!("{lhs_idx} != {rhs_idx}"),
+                    BinOpKind::Lt => utils::expr!("{lhs_idx} < {rhs_idx}"),
+                    BinOpKind::Le => utils::expr!("{lhs_idx} <= {rhs_idx}"),
+                    BinOpKind::Gt => utils::expr!("{lhs_idx} > {rhs_idx}"),
+                    BinOpKind::Ge => utils::expr!("{lhs_idx} >= {rhs_idx}"),
+                    _ => unreachable!(),
+                };
+                self.changed = true;
+                return;
+            }
+        }
+
         if let ExprKind::Unary(UnOp::Deref, inner) = &mut expr.kind
-            && let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, inner.id)
-            && let Some(rewrite) = self.plan.base_by_hir_id.get(&hir_id)
+            && let Some(base_key) =
+                direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, inner)
+            && let Some(rewrite) = self.plan.base_by_key.get(&base_key)
         {
             let ptr = base_cursor_pointer_expr(rewrite);
             *expr = utils::expr!("*({})", pprust::expr_to_string(&ptr));
@@ -1353,10 +1880,55 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             return;
         }
 
+        if let ExprKind::MethodCall(call) = &expr.kind
+            && call.seg.ident.name.as_str() == "offset_from"
+            && call.args.len() == 1
+        {
+            let receiver = unwrap_cast_and_paren(&call.receiver);
+            let arg = unwrap_cast_and_paren(&call.args[0]);
+            let receiver_hir = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, receiver.id);
+            let arg_hir = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, arg.id);
+            let receiver_rewrite = receiver_hir.and_then(|hir_id| self.plan.by_hir_id.get(&hir_id));
+            let arg_rewrite = arg_hir.and_then(|hir_id| self.plan.by_hir_id.get(&hir_id));
+            let receiver_introduced =
+                receiver_hir.is_some_and(|hir_id| self.introduced_hir_ids.contains(&hir_id));
+            let arg_introduced =
+                arg_hir.is_some_and(|hir_id| self.introduced_hir_ids.contains(&hir_id));
+            let replacement = if let (Some(lhs), Some(rhs)) = (receiver_rewrite, arg_rewrite)
+                && lhs.base_hir_id == rhs.base_hir_id
+                && lhs.base_name == rhs.base_name
+            {
+                if receiver_introduced && arg_introduced {
+                    Some(utils::expr!(
+                        "({}) - ({})",
+                        idx_read_expr(lhs),
+                        idx_read_expr(rhs)
+                    ))
+                } else if arg_introduced {
+                    let base_ptr = base_offset_expr_for_index(rhs, &idx_read_expr(rhs));
+                    Some(utils::expr!(
+                        "({}).offset_from({})",
+                        pprust::expr_to_string(receiver),
+                        base_ptr
+                    ))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            if let Some(replacement) = replacement {
+                *expr = replacement;
+                self.changed = true;
+                return;
+            }
+        }
+
         mut_visit::walk_expr(self, expr);
 
-        if let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, expr.id)
-            && let Some(rewrite) = self.plan.base_by_hir_id.get(&hir_id)
+        if let Some(base_key) =
+            direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, expr)
+            && let Some(rewrite) = self.plan.base_by_key.get(&base_key)
         {
             *expr = base_cursor_pointer_expr(rewrite);
             self.changed = true;

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -35,10 +35,25 @@ use crate::{
     utils::rustc::RustProgram,
 };
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum BindingRepresentation {
+    IndexOnly,
+    Materialized(MaterializationKind),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum MaterializationKind {
+    SharedRef,
+    RawPtr,
+}
+
 #[derive(Clone, Debug)]
 struct BindingRewrite {
     source_hir_id: HirId,
     index_name: String,
+    representation: BindingRepresentation,
+    source_name: String,
+    has_index_benefit: bool,
     base_hir_id: HirId,
     base_name: String,
     base_index_name: Option<String>,
@@ -71,6 +86,303 @@ struct RewritePlan {
     index_names_by_fn: FxHashMap<LocalDefId, FxHashSet<String>>,
 }
 
+#[derive(Default, Clone, Debug)]
+struct BindingUseSummary {
+    deref_count: usize,
+    field_or_index_count: usize,
+    pointer_value_count: usize,
+    movement_count: usize,
+    comparison_count: usize,
+    offset_from_count: usize,
+    call_arg_count: usize,
+    address_taken_count: usize,
+    unsupported_escape: bool,
+    writes_through_pointer: bool,
+}
+
+impl BindingUseSummary {
+    fn value_use_count(&self) -> usize {
+        self.deref_count + self.field_or_index_count + self.pointer_value_count
+    }
+
+    fn has_index_benefit(&self) -> bool {
+        self.movement_count + self.comparison_count + self.offset_from_count > 0
+    }
+
+    fn materialization_kind(&self, ptr_mut: bool) -> Option<MaterializationKind> {
+        if self.unsupported_escape || self.address_taken_count > 0 {
+            return None;
+        }
+        if self.call_arg_count > 0 {
+            return Some(MaterializationKind::RawPtr);
+        }
+        if self.pointer_value_count > 0 {
+            return Some(MaterializationKind::RawPtr);
+        }
+        if self.writes_through_pointer {
+            return ptr_mut.then_some(MaterializationKind::RawPtr);
+        }
+        if self.value_use_count() > 0 {
+            return Some(MaterializationKind::SharedRef);
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod binding_use_summary_tests {
+    use rustc_hash::FxHashMap;
+
+    use super::{
+        BindingUseSummary, MaterializationKind, collect_binding_use_summaries_for_names_for_test,
+    };
+
+    fn classifier_summaries(
+        code: &str,
+        planned_names: &[&str],
+    ) -> FxHashMap<String, BindingUseSummary> {
+        ::utils::compilation::run_compiler_on_str(code, |tcx| {
+            collect_binding_use_summaries_for_names_for_test(tcx, planned_names)
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn direct_pointer_value_use_materializes_as_raw_pointer() {
+        let summary = BindingUseSummary {
+            pointer_value_count: 1,
+            ..BindingUseSummary::default()
+        };
+
+        assert_eq!(
+            summary.materialization_kind(false),
+            Some(MaterializationKind::RawPtr)
+        );
+    }
+
+    #[test]
+    fn call_argument_use_materializes_as_raw_pointer() {
+        let summary = BindingUseSummary {
+            call_arg_count: 1,
+            ..BindingUseSummary::default()
+        };
+
+        assert_eq!(
+            summary.materialization_kind(false),
+            Some(MaterializationKind::RawPtr)
+        );
+    }
+
+    #[test]
+    fn unsupported_escape_prevents_materialization() {
+        let summary = BindingUseSummary {
+            pointer_value_count: 1,
+            unsupported_escape: true,
+            ..BindingUseSummary::default()
+        };
+
+        assert_eq!(summary.materialization_kind(false), None);
+    }
+
+    #[test]
+    fn movement_and_comparison_operands_are_not_pointer_value_uses() {
+        let summaries = classifier_summaries(
+            r#"
+pub unsafe fn foo(mut p: *mut i32) -> bool {
+    let mut q: *mut i32 = p.offset(1);
+    let moved: *mut i32 = q.offset(2);
+    q == moved
+}
+"#,
+            &["q"],
+        );
+        let q = summaries.get("q").expect("expected q summary");
+
+        assert_eq!(q.movement_count, 1);
+        assert_eq!(q.comparison_count, 1);
+        assert_eq!(q.pointer_value_count, 0);
+    }
+
+    #[test]
+    fn offset_from_records_receiver_and_direct_pointer_argument() {
+        let summaries = classifier_summaries(
+            r#"
+pub unsafe fn foo(mut p: *mut i32) -> isize {
+    let mut q: *mut i32 = p.offset(1);
+    let mut r: *mut i32 = p.offset(3);
+    q.offset_from(r)
+}
+"#,
+            &["q", "r"],
+        );
+        let q = summaries.get("q").expect("expected q summary");
+        let r = summaries.get("r").expect("expected r summary");
+
+        assert_eq!(q.offset_from_count, 1);
+        assert_eq!(r.offset_from_count, 1);
+        assert_eq!(q.pointer_value_count, 0);
+        assert_eq!(r.pointer_value_count, 0);
+    }
+
+    #[test]
+    fn field_and_index_through_pointer_deref_are_field_or_index_uses() {
+        let field_summaries = classifier_summaries(
+            r#"
+#[repr(C)]
+pub struct Item {
+    pub value: i32,
+}
+
+pub unsafe fn foo(mut p: *mut Item) -> i32 {
+    let mut q: *mut Item = p.offset(1);
+    (*q).value
+}
+"#,
+            &["q"],
+        );
+        let q = field_summaries.get("q").expect("expected field q summary");
+
+        assert_eq!(q.field_or_index_count, 1);
+        assert_eq!(q.deref_count, 1);
+        assert_eq!(q.pointer_value_count, 0);
+
+        let indexed_field_summaries = classifier_summaries(
+            r#"
+#[repr(C)]
+pub struct Item {
+    pub values: [i32; 4],
+}
+
+pub unsafe fn foo(mut p: *mut Item, i: usize) -> i32 {
+    let mut q: *mut Item = p.offset(1);
+    (*q).values[i]
+}
+"#,
+            &["q"],
+        );
+        let q = indexed_field_summaries
+            .get("q")
+            .expect("expected indexed field q summary");
+
+        assert_eq!(q.field_or_index_count, 2);
+        assert_eq!(q.deref_count, 1);
+        assert_eq!(q.pointer_value_count, 0);
+    }
+
+    #[test]
+    fn escape_like_aggregate_and_return_uses_are_unsupported_escapes() {
+        let aggregate_summaries = classifier_summaries(
+            r#"
+pub unsafe fn aggregate(mut p: *mut i32) -> (*mut i32, [*mut i32; 1]) {
+    let mut q: *mut i32 = p.offset(1);
+    (q, [q])
+}
+"#,
+            &["q"],
+        );
+        let q = aggregate_summaries
+            .get("q")
+            .expect("expected aggregate q summary");
+
+        assert!(q.unsupported_escape);
+
+        let return_summaries = classifier_summaries(
+            r#"
+pub unsafe fn ret(mut p: *mut i32) -> *mut i32 {
+    let mut q: *mut i32 = p.offset(1);
+    return q;
+}
+"#,
+            &["q"],
+        );
+        let q = return_summaries
+            .get("q")
+            .expect("expected return q summary");
+
+        assert!(q.unsupported_escape);
+    }
+
+    #[test]
+    fn implicit_return_tail_use_is_an_unsupported_escape() {
+        let summaries = classifier_summaries(
+            r#"
+pub unsafe fn ret(mut p: *mut i32) -> *mut i32 {
+    let mut q: *mut i32 = p.offset(1);
+    q
+}
+"#,
+            &["q"],
+        );
+        let q = summaries.get("q").expect("expected q summary");
+
+        assert!(q.unsupported_escape);
+        assert_eq!(q.pointer_value_count, 0);
+    }
+
+    #[test]
+    fn projected_assignment_sets_write_through_pointer() {
+        let summaries = classifier_summaries(
+            r#"
+#[repr(C)]
+pub struct Item {
+    pub value: i32,
+}
+
+pub unsafe fn foo(mut p: *mut Item) {
+    let mut q: *mut Item = p.offset(1);
+    (*q).value = 1;
+}
+"#,
+            &["q"],
+        );
+        let q = summaries.get("q").expect("expected q summary");
+
+        assert!(q.writes_through_pointer);
+    }
+
+    #[test]
+    fn compound_assignment_sets_write_through_pointer() {
+        let summaries = classifier_summaries(
+            r#"
+#[repr(C)]
+pub struct Item {
+    pub value: i32,
+}
+
+pub unsafe fn foo(mut p: *mut Item) {
+    let mut q: *mut Item = p.offset(1);
+    (*q).value += 2;
+}
+"#,
+            &["q"],
+        );
+        let q = summaries.get("q").expect("expected q summary");
+
+        assert!(q.writes_through_pointer);
+    }
+
+    #[test]
+    fn mutable_reborrow_sets_write_through_pointer() {
+        let summaries = classifier_summaries(
+            r#"
+#[repr(C)]
+pub struct Item {
+    pub value: i32,
+}
+
+pub unsafe fn foo(mut p: *mut Item) {
+    let mut q: *mut Item = p.offset(1);
+    let _borrow: &mut Item = &mut *q;
+}
+"#,
+            &["q"],
+        );
+        let q = summaries.get("q").expect("expected q summary");
+
+        assert!(q.writes_through_pointer);
+    }
+}
+
 pub(crate) fn apply_array_local_index_rewrite<'tcx>(
     krate: &mut Crate,
     input: &RustProgram<'tcx>,
@@ -89,6 +401,7 @@ pub(crate) fn apply_array_local_index_rewrite<'tcx>(
     );
     refine_base_pointer_kinds_from_ast(krate, ast_to_hir, input.tcx, &mut plan);
     prune_unsupported_direct_place_uses(krate, ast_to_hir, input.tcx, &mut plan);
+    choose_binding_representations(krate, ast_to_hir, input.tcx, &mut plan);
     if plan.by_hir_id.is_empty() {
         return false;
     }
@@ -556,6 +869,9 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
             BindingRewrite {
                 source_hir_id,
                 index_name,
+                representation: BindingRepresentation::IndexOnly,
+                source_name: source_name.clone(),
+                has_index_benefit: false,
                 base_hir_id,
                 base_name: base_name.clone(),
                 base_index_name: base_index_name.clone(),
@@ -676,13 +992,14 @@ fn local_is_pure_field_base_proxy(body: &rustc_middle::mir::Body<'_>, local: Loc
                 block,
                 statement_index,
             };
-            if let StatementKind::Assign(box (lhs, rvalue)) = &statement.kind {
-                if lhs.local == local && lhs.projection.is_empty() {
-                    if rvalue_mentions_local(rvalue, local, location) {
-                        has_non_assignment_use = true;
-                    }
-                    continue;
+            if let StatementKind::Assign(box (lhs, rvalue)) = &statement.kind
+                && lhs.local == local
+                && lhs.projection.is_empty()
+            {
+                if rvalue_mentions_local(rvalue, local, location) {
+                    has_non_assignment_use = true;
                 }
+                continue;
             }
             if statement_mentions_local(statement, local, location) {
                 has_non_assignment_use = true;
@@ -690,10 +1007,9 @@ fn local_is_pure_field_base_proxy(body: &rustc_middle::mir::Body<'_>, local: Loc
         }
         if let Some(terminator) = &block_data.terminator
             && let TerminatorKind::Call { destination, .. } = &terminator.kind
+            && destination.local == local
         {
-            if destination.local == local {
-                has_call_destination = true;
-            }
+            has_call_destination = true;
         }
         if let Some(terminator) = &block_data.terminator {
             let location = Location {
@@ -787,6 +1103,454 @@ fn prune_orphan_base_cursors(plan: &mut RewritePlan) {
         .collect::<FxHashSet<_>>();
     plan.base_by_key
         .retain(|base_key, _| live_base_keys.contains(base_key));
+}
+
+fn choose_binding_representations(
+    krate: &Crate,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    plan: &mut RewritePlan,
+) {
+    if plan.by_hir_id.is_empty() {
+        return;
+    }
+    let mut visitor = BindingUseClassifier {
+        ast_to_hir,
+        tcx,
+        planned_rewrites: &plan.by_hir_id,
+        summaries: FxHashMap::default(),
+    };
+    visitor.visit_crate(krate);
+    let mut summaries = std::mem::take(&mut visitor.summaries);
+    drop(visitor);
+    for (hir_id, rewrite) in &mut plan.by_hir_id {
+        let summary = summaries.remove(hir_id).unwrap_or_default();
+        rewrite.has_index_benefit = summary.has_index_benefit();
+        if let Some(kind) = summary.materialization_kind(rewrite.ptr_mut) {
+            if matches!(kind, MaterializationKind::RawPtr)
+                && summary.writes_through_pointer
+                && summary.call_arg_count == 0
+                && summary.pointer_value_count == 0
+                && !rewrite.field_base
+            {
+                rewrite.representation = BindingRepresentation::IndexOnly;
+                continue;
+            }
+            if rewrite.nullable && !matches!(kind, MaterializationKind::RawPtr) {
+                rewrite.representation = BindingRepresentation::IndexOnly;
+                continue;
+            }
+            rewrite.representation = BindingRepresentation::Materialized(kind);
+        } else if !summary.has_index_benefit() {
+            rewrite.representation = BindingRepresentation::IndexOnly;
+        }
+    }
+}
+
+#[cfg(test)]
+fn collect_binding_use_summaries_for_names_for_test(
+    tcx: TyCtxt<'_>,
+    planned_names: &[&str],
+) -> FxHashMap<String, BindingUseSummary> {
+    let mut krate = utils::ast::expanded_ast(tcx);
+    let ast_to_hir = utils::ast::make_ast_to_hir(&mut krate, tcx);
+    utils::ast::remove_unnecessary_items_from_ast(&mut krate);
+
+    let mut binding_visitor = TestBindingHirIdVisitor {
+        ast_to_hir: &ast_to_hir,
+        tcx,
+        planned_names: planned_names.iter().copied().collect(),
+        hir_ids_by_name: FxHashMap::default(),
+    };
+    binding_visitor.visit_crate(&krate);
+    let planned_rewrites = binding_visitor
+        .hir_ids_by_name
+        .iter()
+        .map(|(name, &hir_id)| {
+            (
+                hir_id,
+                BindingRewrite {
+                    source_hir_id: hir_id,
+                    index_name: format!("{name}_idx"),
+                    representation: BindingRepresentation::IndexOnly,
+                    source_name: name.clone(),
+                    has_index_benefit: false,
+                    base_hir_id: hir_id,
+                    base_name: "base".to_string(),
+                    base_index_name: None,
+                    base_is_raw_ptr: true,
+                    nullable: false,
+                    ptr_ty: "*mut i32".to_string(),
+                    ptr_mut: true,
+                    field_base: false,
+                    base_proxy_hir_ids: FxHashSet::default(),
+                    group_member_hir_ids: FxHashSet::default(),
+                },
+            )
+        })
+        .collect::<FxHashMap<_, _>>();
+
+    let mut visitor = BindingUseClassifier {
+        ast_to_hir: &ast_to_hir,
+        tcx,
+        planned_rewrites: &planned_rewrites,
+        summaries: FxHashMap::default(),
+    };
+    visitor.visit_crate(&krate);
+    let mut summaries = std::mem::take(&mut visitor.summaries);
+    drop(visitor);
+
+    planned_rewrites
+        .iter()
+        .map(|(hir_id, rewrite)| {
+            (
+                rewrite.source_name.clone(),
+                summaries.remove(hir_id).unwrap_or_default(),
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+struct TestBindingHirIdVisitor<'a, 'tcx> {
+    ast_to_hir: &'a AstToHir,
+    tcx: TyCtxt<'tcx>,
+    planned_names: FxHashSet<&'a str>,
+    hir_ids_by_name: FxHashMap<String, HirId>,
+}
+
+#[cfg(test)]
+impl AstVisitor<'_> for TestBindingHirIdVisitor<'_, '_> {
+    fn visit_param(&mut self, param: &Param) {
+        self.record_param(param);
+        visit::walk_param(self, param);
+    }
+
+    fn visit_local(&mut self, local: &rustc_ast::Local) {
+        self.record_local(local);
+        visit::walk_local(self, local);
+    }
+}
+
+#[cfg(test)]
+impl TestBindingHirIdVisitor<'_, '_> {
+    fn record_param(&mut self, param: &Param) {
+        let PatKind::Ident(_, ident, _) = &param.pat.kind else {
+            return;
+        };
+        let name = ident.name.to_string();
+        if !self.planned_names.contains(name.as_str()) {
+            return;
+        }
+        let Some(hir_param) = self.ast_to_hir.get_param(param.id, self.tcx) else {
+            return;
+        };
+        let hir::PatKind::Binding(_, hir_id, _, _) = hir_param.pat.kind else {
+            return;
+        };
+        self.hir_ids_by_name.insert(name, hir_id);
+    }
+
+    fn record_local(&mut self, local: &rustc_ast::Local) {
+        let PatKind::Ident(_, ident, _) = &local.pat.kind else {
+            return;
+        };
+        let name = ident.name.to_string();
+        if !self.planned_names.contains(name.as_str()) {
+            return;
+        }
+        let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx) else {
+            return;
+        };
+        let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind else {
+            return;
+        };
+        self.hir_ids_by_name.insert(name, hir_id);
+    }
+}
+
+struct BindingUseClassifier<'a, 'tcx> {
+    ast_to_hir: &'a AstToHir,
+    tcx: TyCtxt<'tcx>,
+    planned_rewrites: &'a FxHashMap<HirId, BindingRewrite>,
+    summaries: FxHashMap<HirId, BindingUseSummary>,
+}
+
+impl AstVisitor<'_> for BindingUseClassifier<'_, '_> {
+    fn visit_block(&mut self, block: &Block) {
+        let Some((tail, stmts)) = block.stmts.split_last() else {
+            visit::walk_block(self, block);
+            return;
+        };
+        let StmtKind::Expr(tail_expr) = &tail.kind else {
+            visit::walk_block(self, block);
+            return;
+        };
+        if self.record_unsupported_escape_if_direct(tail_expr) {
+            for stmt in stmts {
+                self.visit_stmt(stmt);
+            }
+        } else {
+            visit::walk_block(self, block);
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        if let Some(hir_id) = direct_planned_local_hir_id(
+            self.ast_to_hir,
+            self.tcx,
+            self.planned_rewrites,
+            unwrap_cast_and_paren(expr),
+        ) {
+            self.summaries
+                .entry(hir_id)
+                .or_default()
+                .pointer_value_count += 1;
+        }
+
+        match &expr.kind {
+            ExprKind::Array(exprs) | ExprKind::Tup(exprs) => {
+                if self.visit_escape_like_exprs(exprs.iter().map(|expr| &**expr)) {
+                    return;
+                }
+            }
+            ExprKind::Repeat(elem, _) => {
+                if self.record_unsupported_escape_if_direct(elem) {
+                    return;
+                }
+            }
+            ExprKind::Unary(UnOp::Deref, inner) => {
+                if let Some(hir_id) = self.direct_planned_local_hir_id(inner) {
+                    let summary = self.summaries.entry(hir_id).or_default();
+                    summary.deref_count += 1;
+                    summary.pointer_value_count = summary.pointer_value_count.saturating_sub(1);
+                    return;
+                }
+            }
+            ExprKind::Field(inner, _) | ExprKind::Index(inner, _, _) => {
+                if let Some(hir_id) = self.direct_planned_local_hir_id(inner) {
+                    let summary = self.summaries.entry(hir_id).or_default();
+                    summary.field_or_index_count += 1;
+                    summary.pointer_value_count = summary.pointer_value_count.saturating_sub(1);
+                    if let ExprKind::Index(_, index, _) = &expr.kind {
+                        self.visit_expr(index);
+                    }
+                    return;
+                } else {
+                    for hir_id in self.direct_pointer_deref_hir_ids(inner) {
+                        self.summaries
+                            .entry(hir_id)
+                            .or_default()
+                            .field_or_index_count += 1;
+                    }
+                }
+            }
+            ExprKind::MethodCall(call) => {
+                let name = call.seg.ident.name.as_str();
+                let mut handled_receiver = false;
+                if let Some(hir_id) = self.direct_planned_local_hir_id(&call.receiver) {
+                    let summary = self.summaries.entry(hir_id).or_default();
+                    match name {
+                        "offset" | "add" => {
+                            summary.movement_count += 1;
+                            handled_receiver = true;
+                        }
+                        "offset_from" => {
+                            summary.offset_from_count += 1;
+                            handled_receiver = true;
+                        }
+                        "as_ptr" | "as_mut_ptr" => {
+                            summary.pointer_value_count += 1;
+                            handled_receiver = true;
+                        }
+                        _ => {}
+                    }
+                }
+                let mut handled_arg = vec![false; call.args.len()];
+                if name == "offset_from" {
+                    for (index, arg) in call.args.iter().enumerate() {
+                        if let Some(hir_id) = self.direct_planned_local_hir_id(arg) {
+                            self.summaries.entry(hir_id).or_default().offset_from_count += 1;
+                            handled_arg[index] = true;
+                        }
+                    }
+                }
+                if handled_receiver || handled_arg.iter().any(|handled| *handled) {
+                    if !handled_receiver {
+                        self.visit_expr(&call.receiver);
+                    }
+                    for (arg, handled) in call.args.iter().zip(handled_arg) {
+                        if !handled {
+                            self.visit_expr(arg);
+                        }
+                    }
+                    return;
+                }
+            }
+            ExprKind::Binary(op, lhs, rhs)
+                if matches!(
+                    op.node,
+                    BinOpKind::Eq
+                        | BinOpKind::Ne
+                        | BinOpKind::Lt
+                        | BinOpKind::Le
+                        | BinOpKind::Gt
+                        | BinOpKind::Ge
+                ) =>
+            {
+                for side in [lhs, rhs] {
+                    if let Some(hir_id) = self.direct_planned_local_hir_id(side) {
+                        self.summaries.entry(hir_id).or_default().comparison_count += 1;
+                    } else {
+                        self.visit_expr(side);
+                    }
+                }
+                return;
+            }
+            ExprKind::Assign(lhs, rhs, _) => {
+                if let Some(hir_id) = self.direct_planned_local_hir_id(lhs) {
+                    self.summaries.entry(hir_id).or_default().movement_count += 1;
+                }
+                self.record_write_through_pointer(lhs);
+                self.visit_expr(rhs);
+                return;
+            }
+            ExprKind::AssignOp(_, lhs, rhs) => {
+                self.record_write_through_pointer(lhs);
+                self.visit_expr(rhs);
+                return;
+            }
+            ExprKind::AddrOf(_, mutability, inner) => {
+                if mutability.is_mut() {
+                    self.record_write_through_pointer(inner);
+                }
+                if let Some(hir_id) = self.direct_planned_local_hir_id(inner) {
+                    self.summaries
+                        .entry(hir_id)
+                        .or_default()
+                        .address_taken_count += 1;
+                    return;
+                }
+            }
+            ExprKind::Call(_, args) => {
+                let mut handled_arg = false;
+                for arg in args {
+                    if let Some(hir_id) = self.direct_planned_local_hir_id(arg) {
+                        self.summaries.entry(hir_id).or_default().call_arg_count += 1;
+                        handled_arg = true;
+                    }
+                }
+                if handled_arg {
+                    if let ExprKind::Call(callee, args) = &expr.kind {
+                        self.visit_expr(callee);
+                        for arg in args {
+                            if self.direct_planned_local_hir_id(arg).is_none() {
+                                self.visit_expr(arg);
+                            }
+                        }
+                    }
+                    return;
+                }
+            }
+            ExprKind::Ret(Some(value))
+            | ExprKind::Break(_, Some(value))
+            | ExprKind::Become(value)
+            | ExprKind::Yeet(Some(value)) => {
+                if self.record_unsupported_escape_if_direct(value) {
+                    return;
+                }
+            }
+            ExprKind::Yield(kind) => {
+                if let Some(value) = kind.expr()
+                    && self.record_unsupported_escape_if_direct(value)
+                {
+                    return;
+                }
+            }
+            ExprKind::Struct(struct_expr) => {
+                let mut handled = false;
+                for field in &struct_expr.fields {
+                    if self.record_unsupported_escape_if_direct(&field.expr) {
+                        handled = true;
+                    } else {
+                        self.visit_expr(&field.expr);
+                    }
+                }
+                if handled {
+                    visit::walk_path(self, &struct_expr.path);
+                    return;
+                }
+            }
+            _ => {}
+        }
+        visit::walk_expr(self, expr);
+    }
+}
+
+impl BindingUseClassifier<'_, '_> {
+    fn direct_planned_local_hir_id(&self, expr: &Expr) -> Option<HirId> {
+        direct_planned_local_hir_id(
+            self.ast_to_hir,
+            self.tcx,
+            self.planned_rewrites,
+            unwrap_cast_and_paren(expr),
+        )
+    }
+
+    fn record_write_through_pointer(&mut self, expr: &Expr) {
+        for hir_id in self.direct_pointer_deref_hir_ids(expr) {
+            self.summaries
+                .entry(hir_id)
+                .or_default()
+                .writes_through_pointer = true;
+        }
+    }
+
+    fn direct_pointer_deref_hir_ids(&self, expr: &Expr) -> FxHashSet<HirId> {
+        let mut hir_ids = FxHashSet::default();
+        self.collect_direct_pointer_deref_hir_ids(expr, &mut hir_ids);
+        hir_ids
+    }
+
+    fn collect_direct_pointer_deref_hir_ids(&self, expr: &Expr, hir_ids: &mut FxHashSet<HirId>) {
+        let expr = unwrap_cast_and_paren(expr);
+        match &expr.kind {
+            ExprKind::Unary(UnOp::Deref, inner) => {
+                if let Some(hir_id) = self.direct_planned_local_hir_id(inner) {
+                    hir_ids.insert(hir_id);
+                } else {
+                    self.collect_direct_pointer_deref_hir_ids(inner, hir_ids);
+                }
+            }
+            ExprKind::Field(inner, _) => {
+                self.collect_direct_pointer_deref_hir_ids(inner, hir_ids);
+            }
+            ExprKind::Index(inner, _, _) => {
+                self.collect_direct_pointer_deref_hir_ids(inner, hir_ids);
+            }
+            _ => {}
+        }
+    }
+
+    fn record_unsupported_escape_if_direct(&mut self, expr: &Expr) -> bool {
+        let Some(hir_id) = self.direct_planned_local_hir_id(expr) else {
+            return false;
+        };
+        self.summaries.entry(hir_id).or_default().unsupported_escape = true;
+        true
+    }
+
+    fn visit_escape_like_exprs<'a>(&mut self, exprs: impl Iterator<Item = &'a Expr>) -> bool {
+        let mut handled = false;
+        for expr in exprs {
+            if self.record_unsupported_escape_if_direct(expr) {
+                handled = true;
+            } else {
+                self.visit_expr(expr);
+            }
+        }
+        handled
+    }
 }
 
 struct UnsupportedDirectPlaceUseVisitor<'a, 'tcx> {
@@ -1295,28 +2059,21 @@ fn offset_from_base_expr(
     tcx: TyCtxt<'_>,
     rewrite: &BindingRewrite,
 ) -> IndexExpr {
-    pointer_index_from_base_expr(
-        expr,
-        ast_to_hir,
-        tcx,
-        rewrite.base_hir_id,
-        &rewrite.base_name,
-        rewrite.field_base,
-        &rewrite.base_proxy_hir_ids,
-        base_current_index_expr(rewrite),
-    )
+    pointer_index_from_base_expr(expr, ast_to_hir, tcx, rewrite)
 }
 
 fn pointer_index_from_base_expr(
     expr: &Expr,
     ast_to_hir: &AstToHir,
     tcx: TyCtxt<'_>,
-    base_hir_id: HirId,
-    base_name: &str,
-    field_base: bool,
-    base_proxy_hir_ids: &FxHashSet<HirId>,
-    base_index_name: Option<&str>,
+    rewrite: &BindingRewrite,
 ) -> IndexExpr {
+    let base_hir_id = rewrite.base_hir_id;
+    let base_name = rewrite.base_name.as_str();
+    let field_base = rewrite.field_base;
+    let base_proxy_hir_ids = &rewrite.base_proxy_hir_ids;
+    let base_index_name = base_current_index_expr(rewrite);
+
     if is_null_expr(expr) {
         return IndexExpr::Null;
     }
@@ -1326,6 +2083,14 @@ fn pointer_index_from_base_expr(
     if (!field_base && expr_hir_id == Some(base_hir_id))
         || expr_hir_id.is_some_and(|id| base_proxy_hir_ids.contains(&id))
         || (field_base && expr_matches_base_name(expr, base_name))
+        || receiver_is_base_as_ptr_for_context(
+            expr,
+            ast_to_hir,
+            tcx,
+            base_hir_id,
+            base_name,
+            field_base,
+        )
     {
         return IndexExpr::Plain(match base_index_name {
             Some(index_name) => utils::expr!("{}", index_name),
@@ -1576,6 +2341,15 @@ fn pointer_expr_for_index(rewrite: &BindingRewrite) -> Expr {
     utils::expr!("{} as {}", base_offset, rewrite.ptr_ty)
 }
 
+fn materialized_init_expr(rewrite: &BindingRewrite, index_expr: &str) -> Expr {
+    let ptr = base_offset_expr_for_index(rewrite, index_expr);
+    utils::expr!("{} as {}", ptr, rewrite.ptr_ty)
+}
+
+fn materialized_ty(rewrite: &BindingRewrite) -> P<Ty> {
+    P(utils::ty!("{}", rewrite.ptr_ty))
+}
+
 fn pointer_value_expr(rewrite: &BindingRewrite) -> Expr {
     if rewrite.nullable {
         let null_fn = if rewrite.ptr_mut {
@@ -1615,12 +2389,145 @@ fn introduced_planned_local_hir_id(
     introduced_hir_ids.contains(&hir_id).then_some(hir_id)
 }
 
+fn planned_materialized_local_hir_id(
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+    expr: &Expr,
+) -> Option<HirId> {
+    let hir_id = direct_planned_local_hir_id(ast_to_hir, tcx, planned_rewrites, expr)?;
+    planned_rewrites
+        .get(&hir_id)
+        .is_some_and(rewrite_uses_materialized_binding)
+        .then_some(hir_id)
+}
+
+fn introduced_materialized_local_hir_id(
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+    introduced_hir_ids: &FxHashSet<HirId>,
+    expr: &Expr,
+) -> Option<HirId> {
+    let hir_id = planned_materialized_local_hir_id(ast_to_hir, tcx, planned_rewrites, expr)?;
+    introduced_hir_ids.contains(&hir_id).then_some(hir_id)
+}
+
+fn representation_uses_index_rewrite(representation: &BindingRepresentation) -> bool {
+    matches!(representation, BindingRepresentation::IndexOnly)
+}
+
+fn rewrite_uses_index_rewrite(rewrite: &BindingRewrite) -> bool {
+    representation_uses_index_rewrite(&rewrite.representation)
+        || (matches!(
+            rewrite.representation,
+            BindingRepresentation::Materialized(_)
+        ) && rewrite.nullable)
+}
+
+fn rewrite_uses_materialized_binding(rewrite: &BindingRewrite) -> bool {
+    matches!(
+        rewrite.representation,
+        BindingRepresentation::Materialized(_)
+    ) && !rewrite.nullable
+}
+
+fn introduced_index_rewritten_local_hir_id(
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
+    introduced_hir_ids: &FxHashSet<HirId>,
+    expr: &Expr,
+) -> Option<HirId> {
+    let hir_id = introduced_planned_local_hir_id(ast_to_hir, tcx, introduced_hir_ids, expr)?;
+    planned_rewrites
+        .get(&hir_id)
+        .is_some_and(rewrite_uses_index_rewrite)
+        .then_some(hir_id)
+}
+
 struct ArrayLocalIndexRewriteVisitor<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     ast_to_hir: &'a AstToHir,
     plan: RewritePlan,
     introduced_hir_ids: FxHashSet<HirId>,
     changed: bool,
+}
+
+impl ArrayLocalIndexRewriteVisitor<'_, '_> {
+    fn introduced_index_backed_rewrite(&self, hir_id: HirId) -> Option<&BindingRewrite> {
+        if !self.introduced_hir_ids.contains(&hir_id) {
+            return None;
+        }
+        let rewrite = self.plan.by_hir_id.get(&hir_id)?;
+        (rewrite_uses_index_rewrite(rewrite) || rewrite_uses_materialized_binding(rewrite))
+            .then_some(rewrite)
+    }
+
+    fn index_expr_for_operand(&self, expr: &Expr, anchor: &BindingRewrite) -> Option<String> {
+        if let Some(hir_id) =
+            hir_id_of_ast_expr(self.ast_to_hir, self.tcx, unwrap_cast_and_paren(expr).id)
+            && let Some(rewrite) = self.introduced_index_backed_rewrite(hir_id)
+            && !rewrite.nullable
+            && rewrite.base_hir_id == anchor.base_hir_id
+            && rewrite.base_name == anchor.base_name
+        {
+            return Some(idx_read_expr(rewrite));
+        }
+        match offset_from_base_expr(expr, self.ast_to_hir, self.tcx, anchor) {
+            IndexExpr::Plain(index) => Some(pprust::expr_to_string(&index)),
+            IndexExpr::Null | IndexExpr::Unsupported => None,
+        }
+    }
+
+    fn rewrite_materialized_local_stmt(&mut self, local: &mut rustc_ast::Local) -> Option<Stmt> {
+        let let_stmt = self.ast_to_hir.get_let_stmt(local.id, self.tcx)?;
+        let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind else {
+            return None;
+        };
+        let mut rewrite = self.plan.by_hir_id.get(&hir_id)?.clone();
+        if !rewrite_uses_materialized_binding(&rewrite) {
+            return None;
+        }
+
+        let init = local.kind.init_mut()?;
+        if let Some(base_name) =
+            projected_as_ptr_receiver_base_name(init, self.ast_to_hir, self.tcx, &rewrite)
+        {
+            rewrite.base_name = base_name;
+            rewrite.base_is_raw_ptr = false;
+            self.plan.by_hir_id.insert(hir_id, rewrite.clone());
+        }
+
+        let mut index = offset_from_base_expr(init, self.ast_to_hir, self.tcx, &rewrite);
+        if let IndexExpr::Unsupported = index {
+            index = introduced_group_member_assignment_index_expr(
+                init,
+                self.ast_to_hir,
+                self.tcx,
+                &self.plan.by_hir_id,
+                &self.introduced_hir_ids,
+                &rewrite,
+            );
+        }
+        let new_index_init = index_init_expr(index, rewrite.nullable)?;
+        let index_name = rewrite.index_name.clone();
+        let index_stmt = utils::stmt!(
+            "let mut {}: isize = {};",
+            index_name,
+            pprust::expr_to_string(&new_index_init)
+        );
+        let materialized_init = materialized_init_expr(&rewrite, &idx_read_expr(&rewrite));
+
+        if !rewrite_binding_pat(&mut local.pat, &rewrite.source_name) {
+            return None;
+        }
+        local.ty = Some(materialized_ty(&rewrite));
+        *init = P(materialized_init);
+        self.introduced_hir_ids.insert(hir_id);
+        self.changed = true;
+        Some(index_stmt)
+    }
 }
 
 impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
@@ -1650,6 +2557,69 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
         mut_visit::walk_item(self, item);
     }
 
+    fn visit_block(&mut self, block: &mut Block) {
+        let mut new_stmts = Vec::with_capacity(block.stmts.len());
+        for mut stmt in std::mem::take(&mut block.stmts) {
+            if let StmtKind::Let(local) = &mut stmt.kind
+                && let Some(index_stmt) = self.rewrite_materialized_local_stmt(local)
+            {
+                new_stmts.push(index_stmt);
+                new_stmts.push(stmt);
+                continue;
+            }
+            if let StmtKind::Expr(expr) | StmtKind::Semi(expr) = &mut stmt.kind
+                && let ExprKind::Assign(lhs, rhs, _) = &mut expr.kind
+                && let Some(hir_id) = introduced_materialized_local_hir_id(
+                    self.ast_to_hir,
+                    self.tcx,
+                    &self.plan.by_hir_id,
+                    &self.introduced_hir_ids,
+                    lhs,
+                )
+                && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id).cloned()
+            {
+                let mut index = introduced_group_member_assignment_index_expr(
+                    rhs,
+                    self.ast_to_hir,
+                    self.tcx,
+                    &self.plan.by_hir_id,
+                    &self.introduced_hir_ids,
+                    &rewrite,
+                );
+                if let IndexExpr::Unsupported = index {
+                    index = assignment_index_expr(
+                        rhs,
+                        self.ast_to_hir,
+                        self.tcx,
+                        &self.plan.by_hir_id,
+                        Some(&self.introduced_hir_ids),
+                        &rewrite,
+                    );
+                }
+                if let Some(new_rhs) = index_assignment_rhs_expr(index, rewrite.nullable) {
+                    let idx_stmt = utils::stmt!(
+                        "{} = {};",
+                        rewrite.index_name,
+                        pprust::expr_to_string(&new_rhs)
+                    );
+                    let materialized_rhs =
+                        materialized_init_expr(&rewrite, &idx_read_expr(&rewrite));
+                    let value_stmt = utils::stmt!(
+                        "{} = {};",
+                        rewrite.source_name,
+                        pprust::expr_to_string(&materialized_rhs)
+                    );
+                    new_stmts.push(idx_stmt);
+                    new_stmts.push(value_stmt);
+                    self.changed = true;
+                    continue;
+                }
+            }
+            new_stmts.extend(self.flat_map_stmt(stmt));
+        }
+        block.stmts = new_stmts.into();
+    }
+
     fn visit_local(&mut self, local: &mut rustc_ast::Local) {
         let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx) else {
             mut_visit::walk_local(self, local);
@@ -1663,6 +2633,10 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             mut_visit::walk_local(self, local);
             return;
         };
+        if rewrite_uses_materialized_binding(&rewrite) {
+            mut_visit::walk_local(self, local);
+            return;
+        }
         let Some(init) = local.kind.init_mut() else {
             mut_visit::walk_local(self, local);
             return;
@@ -1728,6 +2702,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                     &self.introduced_hir_ids,
                     lhs,
                 ) && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
+                    && rewrite_uses_index_rewrite(rewrite)
                 {
                     let mut index = introduced_group_member_assignment_index_expr(
                         rhs,
@@ -1763,9 +2738,10 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             ExprKind::AssignOp(_, lhs, rhs) => {
                 if direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, lhs)
                     .is_none()
-                    && introduced_planned_local_hir_id(
+                    && introduced_index_rewritten_local_hir_id(
                         self.ast_to_hir,
                         self.tcx,
+                        &self.plan.by_hir_id,
                         &self.introduced_hir_ids,
                         lhs,
                     )
@@ -1779,9 +2755,10 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             ExprKind::AddrOf(_, _, inner) => {
                 if direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, inner)
                     .is_none()
-                    && introduced_planned_local_hir_id(
+                    && introduced_index_rewritten_local_hir_id(
                         self.ast_to_hir,
                         self.tcx,
+                        &self.plan.by_hir_id,
                         &self.introduced_hir_ids,
                         inner,
                     )
@@ -1801,6 +2778,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                 && let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, receiver.id)
                 && self.introduced_hir_ids.contains(&hir_id)
                 && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
+                && rewrite_uses_index_rewrite(rewrite)
             {
                 *expr = if rewrite.nullable {
                     utils::expr!("{}.is_none()", rewrite.index_name)
@@ -1827,23 +2805,16 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                 hir_id_of_ast_expr(self.ast_to_hir, self.tcx, unwrap_cast_and_paren(lhs).id);
             let rhs_hir =
                 hir_id_of_ast_expr(self.ast_to_hir, self.tcx, unwrap_cast_and_paren(rhs).id);
-            let lhs_rewrite = lhs_hir.and_then(|hir_id| self.plan.by_hir_id.get(&hir_id));
-            let rhs_rewrite = rhs_hir.and_then(|hir_id| self.plan.by_hir_id.get(&hir_id));
-            let lhs_introduced =
-                lhs_hir.is_some_and(|hir_id| self.introduced_hir_ids.contains(&hir_id));
-            let rhs_introduced =
-                rhs_hir.is_some_and(|hir_id| self.introduced_hir_ids.contains(&hir_id));
-            if let (Some(lhs_rewrite), Some(rhs_rewrite)) = (lhs_rewrite, rhs_rewrite)
-                && lhs_introduced
-                && rhs_introduced
-                && !lhs_rewrite.nullable
-                && !rhs_rewrite.nullable
-                && lhs_rewrite.base_hir_id == rhs_rewrite.base_hir_id
-                && lhs_rewrite.base_name == rhs_rewrite.base_name
-                && lhs_rewrite.ptr_ty == rhs_rewrite.ptr_ty
+            let lhs_rewrite =
+                lhs_hir.and_then(|hir_id| self.introduced_index_backed_rewrite(hir_id));
+            let rhs_rewrite =
+                rhs_hir.and_then(|hir_id| self.introduced_index_backed_rewrite(hir_id));
+            let anchor = lhs_rewrite.or(rhs_rewrite);
+            if let Some(anchor) = anchor
+                && !anchor.nullable
+                && let Some(lhs_idx) = self.index_expr_for_operand(lhs, anchor)
+                && let Some(rhs_idx) = self.index_expr_for_operand(rhs, anchor)
             {
-                let lhs_idx = idx_read_expr(lhs_rewrite);
-                let rhs_idx = idx_read_expr(rhs_rewrite);
                 *expr = match op.node {
                     BinOpKind::Eq => utils::expr!("{lhs_idx} == {rhs_idx}"),
                     BinOpKind::Ne => utils::expr!("{lhs_idx} != {rhs_idx}"),
@@ -1873,6 +2844,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             && let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, inner.id)
             && self.introduced_hir_ids.contains(&hir_id)
             && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
+            && rewrite_uses_index_rewrite(rewrite)
         {
             let ptr = pointer_expr_for_index(rewrite);
             *expr = utils::expr!("*({})", pprust::expr_to_string(&ptr));
@@ -1888,35 +2860,19 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             let arg = unwrap_cast_and_paren(&call.args[0]);
             let receiver_hir = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, receiver.id);
             let arg_hir = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, arg.id);
-            let receiver_rewrite = receiver_hir.and_then(|hir_id| self.plan.by_hir_id.get(&hir_id));
-            let arg_rewrite = arg_hir.and_then(|hir_id| self.plan.by_hir_id.get(&hir_id));
-            let receiver_introduced =
-                receiver_hir.is_some_and(|hir_id| self.introduced_hir_ids.contains(&hir_id));
-            let arg_introduced =
-                arg_hir.is_some_and(|hir_id| self.introduced_hir_ids.contains(&hir_id));
-            let replacement = if let (Some(lhs), Some(rhs)) = (receiver_rewrite, arg_rewrite)
-                && lhs.base_hir_id == rhs.base_hir_id
-                && lhs.base_name == rhs.base_name
-            {
-                if receiver_introduced && arg_introduced {
-                    Some(utils::expr!(
-                        "({}) - ({})",
-                        idx_read_expr(lhs),
-                        idx_read_expr(rhs)
-                    ))
-                } else if arg_introduced {
-                    let base_ptr = base_offset_expr_for_index(rhs, &idx_read_expr(rhs));
-                    Some(utils::expr!(
-                        "({}).offset_from({})",
-                        pprust::expr_to_string(receiver),
-                        base_ptr
-                    ))
-                } else {
-                    None
+            let receiver_rewrite =
+                receiver_hir.and_then(|hir_id| self.introduced_index_backed_rewrite(hir_id));
+            let arg_rewrite =
+                arg_hir.and_then(|hir_id| self.introduced_index_backed_rewrite(hir_id));
+            let anchor = receiver_rewrite.or(arg_rewrite);
+            let replacement = anchor.and_then(|anchor| {
+                if anchor.nullable {
+                    return None;
                 }
-            } else {
-                None
-            };
+                let receiver_idx = self.index_expr_for_operand(receiver, anchor)?;
+                let arg_idx = self.index_expr_for_operand(arg, anchor)?;
+                Some(utils::expr!("({}) - ({})", receiver_idx, arg_idx))
+            });
             if let Some(replacement) = replacement {
                 *expr = replacement;
                 self.changed = true;
@@ -1938,6 +2894,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
         if let Some(hir_id) = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, expr.id)
             && self.introduced_hir_ids.contains(&hir_id)
             && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
+            && rewrite_uses_index_rewrite(rewrite)
         {
             *expr = pointer_value_expr(rewrite);
             self.changed = true;

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     utils::rustc::RustProgram,
 };
 
-mod array_local_index_rewriter;
+pub(crate) mod array_local_index_rewriter;
 pub(crate) mod collector;
 pub(crate) mod decision;
 pub(crate) mod diagnostics;

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9071,3 +9071,49 @@ pub unsafe fn make_holder() -> Holder {
         );
     }
 }
+
+#[test]
+fn test_array_local_rewriter_field_base_group_rewrites_loop_pointers() {
+    let code = r#"
+#[repr(C)]
+pub struct Image {
+    pub pix: *mut u8,
+    pub w: i32,
+    pub h: i32,
+}
+pub unsafe fn flip(mut img: *mut Image) {
+    let mut pix: *mut u8 = (*img).pix;
+    let mut w: i32 = (*img).w;
+    let mut h: i32 = (*img).h;
+    let mut flips: i32 = h / 2;
+    let mut i: i32 = 0;
+    while i < flips {
+        let mut a: *mut u8 = pix.offset((w * i) as isize);
+        let mut b: *mut u8 = pix.offset((w * (h - i - 1)) as isize);
+        let mut j: i32 = 0;
+        while j < w {
+            let t: u8 = *a;
+            *a = *b;
+            *b = t;
+            a = a.offset(1);
+            b = b.offset(1);
+            j += 1;
+        }
+        i += 1;
+    }
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    eprintln!("changed={changed}\n{s}");
+    assert!(changed, "expected rewrite to change the code:\n{s}");
+    assert!(s.contains("a_idx"), "expected a_idx in:\n{s}");
+    assert!(s.contains("b_idx"), "expected b_idx in:\n{s}");
+    assert!(
+        !s.contains("let mut a: *mut u8"),
+        "expected a to be rewritten in:\n{s}"
+    );
+    assert!(
+        !s.contains("let mut b: *mut u8"),
+        "expected b to be rewritten in:\n{s}"
+    );
+}

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -8164,6 +8164,44 @@ pub unsafe fn foo(p: &[i32], n: isize) -> i32 {
 }
 
 #[test]
+fn test_array_local_rewriter_rewrites_wrapped_array_field_pointer_initializers() {
+    let code = r#"
+#[repr(C)]
+pub struct Item {
+    pub value: i32,
+}
+
+#[repr(C)]
+pub struct ResultArray {
+    pub data: [Item; 8],
+    pub count: i32,
+}
+
+pub unsafe fn weighted(mut arr: *mut ResultArray, mut i: isize) -> i32 {
+    let mut current: *mut Item =
+        &mut *((*arr).data).as_mut_ptr().offset(i) as *mut Item;
+    let mut base: *mut Item =
+        &mut *((*arr).data).as_mut_ptr().offset(0) as *mut Item;
+    let cmp: i32 = if current > base { 1 } else { 0 };
+    let weight: isize = current.offset_from(base);
+    (*current).value + weight as i32 + cmp
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(
+        changed,
+        "expected wrapped pointer initializers to be rewritten:\n{s}"
+    );
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut current_idx: isize = i"), "{s}");
+    assert!(s.contains("let mut base_idx: isize = (0) as isize"), "{s}");
+    assert!(s.contains("if current_idx > base_idx"), "{s}");
+    assert!(s.contains(".data).as_ptr().offset(current_idx)"), "{s}");
+    assert!(!s.contains("let mut current: *mut Item"), "{s}");
+    assert!(!s.contains("let mut base: *mut Item"), "{s}");
+}
+
+#[test]
 fn test_struct_array_field_run_from_field_rooted_offset() {
     let code = r#"
 #[repr(C)]
@@ -9116,4 +9154,108 @@ pub unsafe fn flip(mut img: *mut Image) {
         !s.contains("let mut b: *mut u8"),
         "expected b to be rewritten in:\n{s}"
     );
+}
+
+#[test]
+fn test_array_local_rewriter_tracks_index_for_reassigned_field_base() {
+    let code = r#"
+#[repr(C)]
+pub struct State {
+    pub out: *mut i8,
+    pub out_end: *mut i8,
+}
+
+pub unsafe fn copy_from_back(mut s: *mut State, mut length: isize, mut distance: isize) -> i32 {
+    let mut src: *mut i8 = (*s).out.offset(-distance);
+    let mut dst: *mut i8 = (*s).out;
+    (*s).out = (*s).out.offset(length);
+    *dst = *src;
+    dst = dst.offset(1);
+    src = src.offset(1);
+    *dst as i32 + *src as i32
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(
+        changed,
+        "expected field-base index tracking to rewrite:\n{s}"
+    );
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("out_idx") || s.contains("s_out_idx"), "{s}");
+    assert!(s.contains("src_idx"), "{s}");
+    assert!(s.contains("dst_idx"), "{s}");
+    assert!(!s.contains("let mut src: *mut i8"), "{s}");
+    assert!(!s.contains("let mut dst: *mut i8"), "{s}");
+    assert!(!s.contains("(*s).out = (*s).out.offset(length)"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_keeps_distinct_indexes_for_two_reassigned_field_bases() {
+    let code = r#"
+#[repr(C)]
+pub struct Pair {
+    pub a: *mut i8,
+    pub b: *mut i16,
+}
+
+pub unsafe fn dual(mut p: *mut Pair, mut da: isize, mut db: isize) -> i32 {
+    let mut ax: *mut i8 = (*p).a.offset(1);
+    let mut bx: *mut i16 = (*p).b.offset(1);
+    (*p).a = (*p).a.offset(da);
+    (*p).b = (*p).b.offset(db);
+    ax = ax.offset(1);
+    bx = bx.offset(1);
+    *ax as i32 + *bx as i32
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(
+        changed,
+        "expected both reassigned field bases to be rewritten:\n{s}"
+    );
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut a_idx: isize"), "{s}");
+    assert!(s.contains("let mut b_idx: isize"), "{s}");
+    assert!(s.contains("ax_idx"), "{s}");
+    assert!(s.contains("bx_idx"), "{s}");
+    assert!(!s.contains("let mut ax: *mut i8"), "{s}");
+    assert!(!s.contains("let mut bx: *mut i16"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_rewrites_field_base_cursor_local_used_in_offset_from() {
+    let code = r#"
+#[repr(C)]
+pub struct ProcessState {
+    pub buffer: *mut i8,
+}
+
+unsafe extern "C" {
+    fn memchr(ptr: *const core::ffi::c_void, ch: i32, n: usize) -> *mut core::ffi::c_void;
+}
+
+pub unsafe fn process_buffer(mut state: *mut ProcessState, mut target: i8, mut remaining: usize) -> i32 {
+    let mut count: i32 = 0;
+    let mut ptr: *mut i8 = (*state).buffer;
+    while remaining > 0 {
+        let mut found: *mut i8 = memchr(ptr as *const core::ffi::c_void, target as i32, remaining) as *mut i8;
+        if found.is_null() {
+            break;
+        }
+        count += 1;
+        remaining = remaining.wrapping_sub((found.offset_from(ptr) + 1) as usize);
+        ptr = found.offset(1);
+    }
+    count
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(
+        changed,
+        "expected field-base cursor local to be rewritten:\n{s}"
+    );
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("ptr_idx"), "{s}");
+    assert!(!s.contains("let mut ptr: *mut i8"), "{s}");
+    assert!(!s.contains("ptr = found.offset(1)"), "{s}");
 }

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -7847,13 +7847,9 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
     assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
     assert!(s.contains("let mut q_idx: isize = (3) as isize"), "{s}");
-    assert!(s.contains("*((p).offset(q_idx) as *mut i32) = 3"), "{s}");
-    assert!(
-        s.matches("*((p).offset(q_idx) as *mut i32)").count() >= 2,
-        "{s}"
-    );
     assert!(!s.contains("let mut q: *mut i32"), "{s}");
-    assert!(!s.contains("*q"), "{s}");
+    assert!(s.contains("*((p).offset(q_idx) as *mut i32) = 3"), "{s}");
+    assert!(s.contains("*((p).offset(q_idx) as *mut i32)"), "{s}");
 }
 
 #[test]
@@ -7904,6 +7900,74 @@ pub unsafe fn foo(mut p: *mut i32, mut take: bool) -> *mut i32 {
     );
     assert!(s.contains("|idx| ((p).offset(idx)) as *mut i32"), "{s}");
     assert!(!s.contains("let mut q: *mut i32"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_keeps_direct_base_write_cursor_index_only() {
+    let code = r#"
+pub unsafe fn wcscat_like(mut dst: *mut i32, mut num_elem: usize, mut src: *const i32) -> i32 {
+    let mut ptr: *mut i32 = dst.offset(0);
+    if dst.is_null() || num_elem == 0 {
+        return 22;
+    }
+    while ptr < dst.offset(num_elem as isize) && *ptr != 0 {
+        ptr = ptr.offset(1);
+    }
+    while ptr < dst.offset(num_elem as isize) {
+        let fresh = *src;
+        src = src.offset(1);
+        *ptr = fresh;
+        let seen = *ptr;
+        ptr = ptr.offset(1);
+        if seen == 0 {
+            return 0;
+        }
+    }
+    *dst = 0;
+    34
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut ptr_idx: isize"), "{s}");
+    assert!(!s.contains("let mut ptr: *mut i32"), "{s}");
+    assert!(!s.contains("*ptr"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_keeps_cast_cursor_index_only() {
+    let code = r#"
+fn parse_bool(c: i8) -> bool {
+    c == 89 || c == 121
+}
+
+pub unsafe fn validate_sequence(mut sequence: *mut i8, mut len: usize) -> i32 {
+    if len == 0 {
+        return 0;
+    }
+    let mut bools: *mut bool = sequence as *mut bool;
+    let mut i: usize = 0;
+    while i < len {
+        let val: bool = parse_bool(*sequence.offset(i as isize));
+        *bools.offset(i as isize) = val;
+        i = i.wrapping_add(1);
+    }
+    if !*bools.offset(0) {
+        return -10;
+    }
+    if len > 1 && (*bools.offset(len.wrapping_sub(1) as isize)) as i32 != 0 {
+        return -11;
+    }
+    0
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut bools_idx: isize"), "{s}");
+    assert!(!s.contains("let mut bools: *mut bool"), "{s}");
+    assert!(!s.contains("*bools.offset"), "{s}");
 }
 
 #[test]
@@ -8025,6 +8089,7 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
     assert!(s.contains("let mut q_idx: isize = (1) as isize"), "{s}");
     assert!(s.contains("q_idx ="), "{s}");
     assert!(s.contains("(q_idx) + ((2) as isize)"), "{s}");
+    assert!(!s.contains("let mut q: *mut i32"), "{s}");
     assert!(s.contains("*((p).offset(q_idx) as *mut i32) = 9"), "{s}");
     assert!(!s.contains("q = q.offset"), "{s}");
 }
@@ -8094,12 +8159,8 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
     assert!(s.contains("let mut q_idx: isize"), "{s}");
     assert!(s.contains("(p_idx) + ((1) as isize)"), "{s}");
     assert!(s.contains("p_idx = (p_idx) + ((1) as isize)"), "{s}");
-    assert!(
-        s.contains("*((p).offset(q_idx) as *mut i32)")
-            && s.contains("*((p).offset(p_idx) as *mut i32)"),
-        "{s}"
-    );
-    assert!(!s.contains("let mut q: *mut i32"), "{s}");
+    assert!(s.contains("let mut q: *mut i32"), "{s}");
+    assert!(s.contains("*q + *((p).offset(p_idx) as *mut i32)"), "{s}");
     assert!(!s.contains("p = p.offset(1)"), "{s}");
 }
 
@@ -8118,12 +8179,11 @@ pub unsafe fn foo(mut p: *mut i32, n: isize) -> i32 {
     assert!(s.contains("let mut p_idx: isize = 0isize"), "{s}");
     assert!(s.contains("let mut prev_idx: isize = p_idx"), "{s}");
     assert!(s.contains("p_idx = (p_idx) + (n)"), "{s}");
+    assert!(s.contains("let mut prev: *mut i32"), "{s}");
     assert!(
-        s.contains("*((p).offset(prev_idx) as *mut i32)")
-            && s.contains("*((p).offset(p_idx) as *mut i32)"),
+        s.contains("*prev + *((p).offset(p_idx) as *mut i32)"),
         "{s}"
     );
-    assert!(!s.contains("let mut prev: *mut i32"), "{s}");
     assert!(!s.contains("p = p.offset(n)"), "{s}");
 }
 
@@ -8141,6 +8201,7 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
     assert!(s.contains("q_idx"), "{s}");
     assert!(!s.contains("let mut q: *mut i32"), "{s}");
+    assert!(s.contains("(&mut ((p)[(q_idx) as usize..]))[0] = 3"), "{s}");
 }
 
 #[test]
@@ -8199,6 +8260,64 @@ pub unsafe fn weighted(mut arr: *mut ResultArray, mut i: isize) -> i32 {
     assert!(s.contains(".data).as_ptr().offset(current_idx)"), "{s}");
     assert!(!s.contains("let mut current: *mut Item"), "{s}");
     assert!(!s.contains("let mut base: *mut Item"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_materializes_read_only_field_base_local() {
+    let code = r#"
+#[repr(C)]
+pub struct Bucket {
+    pub hash: [usize; 8],
+    pub index: [isize; 8],
+}
+
+#[repr(C)]
+pub struct Table {
+    pub storage: *mut Bucket,
+    pub len: usize,
+}
+
+pub unsafe fn sum_hashes(mut table: *mut Table) -> usize {
+    let mut total: usize = 0;
+    let mut i: usize = 0;
+    while i < (*table).len {
+        let mut ob: *mut Bucket = (*table).storage.offset(i as isize);
+        let mut j: usize = 0;
+        while j < 8 {
+            if (*ob).index[j] >= 0 {
+                total = total.wrapping_add((*ob).hash[j]);
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+    total
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "expected materialized read-only rewrite:\n{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("ob_idx"), "{s}");
+    assert!(
+        s.contains("let ob: *mut Bucket")
+            || s.contains("let mut ob: *mut Bucket")
+            || s.contains("let ob: *mut crate::Bucket")
+            || s.contains("let mut ob: *mut crate::Bucket"),
+        "expected ob to stay materialized as a raw pointer before pointer rewriting:\n{s}"
+    );
+    assert!(
+        s.contains("(*ob).index[j as usize]") || s.contains("(*ob).index[j]"),
+        "{s}"
+    );
+    assert!(
+        s.contains("(*ob).hash[j as usize]") || s.contains("(*ob).hash[j]"),
+        "{s}"
+    );
+    let storage_offset_uses = s.matches("storage).offset(ob_idx)").count();
+    assert!(
+        storage_offset_uses <= 1,
+        "expected at most one storage offset to materialize ob, got {storage_offset_uses}:\n{s}"
+    );
 }
 
 #[test]
@@ -9147,13 +9266,115 @@ pub unsafe fn flip(mut img: *mut Image) {
     assert!(s.contains("a_idx"), "expected a_idx in:\n{s}");
     assert!(s.contains("b_idx"), "expected b_idx in:\n{s}");
     assert!(
-        !s.contains("let mut a: *mut u8"),
-        "expected a to be rewritten in:\n{s}"
+        s.contains("let mut a: *mut u8") || s.contains("let a: *mut u8"),
+        "expected a to stay materialized in:\n{s}"
     );
     assert!(
-        !s.contains("let mut b: *mut u8"),
-        "expected b to be rewritten in:\n{s}"
+        s.contains("let mut b: *mut u8") || s.contains("let b: *mut u8"),
+        "expected b to stay materialized in:\n{s}"
     );
+}
+
+#[test]
+fn test_array_local_rewriter_materializes_mutable_moving_cursors() {
+    let code = r#"
+#[repr(C)]
+pub struct Image {
+    pub pix: *mut u8,
+    pub w: i32,
+    pub h: i32,
+}
+
+pub unsafe fn flip(mut img: *mut Image) {
+    let mut pix: *mut u8 = (*img).pix;
+    let mut w: i32 = (*img).w;
+    let mut h: i32 = (*img).h;
+    let mut flips: i32 = h / 2;
+    let mut i: i32 = 0;
+    while i < flips {
+        let mut a: *mut u8 = pix.offset((w * i) as isize);
+        let mut b: *mut u8 = pix.offset((w * (h - i - 1)) as isize);
+        let mut j: i32 = 0;
+        while j < w {
+            let t: u8 = *a;
+            *a = *b;
+            *b = t;
+            a = a.offset(1);
+            b = b.offset(1);
+            j += 1;
+        }
+        i += 1;
+    }
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(
+        changed,
+        "expected materialized mutable cursor rewrite:\n{s}"
+    );
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("a_idx"), "{s}");
+    assert!(s.contains("b_idx"), "{s}");
+    assert!(
+        s.contains("let mut a: *mut u8") || s.contains("let a: *mut u8"),
+        "expected materialized pointer local a to remain:\n{s}"
+    );
+    assert!(
+        s.contains("let mut b: *mut u8") || s.contains("let b: *mut u8"),
+        "expected materialized pointer local b to remain:\n{s}"
+    );
+    assert!(
+        s.contains("let t: u8 = *a") || s.contains("let mut t: u8 = *a"),
+        "expected read to use materialized a rather than rematerialized base offset:\n{s}"
+    );
+    assert!(s.contains("*a = *b"), "{s}");
+    assert!(s.contains("*b = t"), "{s}");
+    let a_offset_uses = s.matches("pix).offset(a_idx)").count();
+    let b_offset_uses = s.matches("pix).offset(b_idx)").count();
+    assert!(
+        a_offset_uses <= 2,
+        "expected a_idx offsets only for materializing/refreshing a, got {a_offset_uses}:\n{s}"
+    );
+    assert!(
+        b_offset_uses <= 2,
+        "expected b_idx offsets only for materializing/refreshing b, got {b_offset_uses}:\n{s}"
+    );
+    assert!(
+        s.contains("a_idx = (a_idx) +") || s.contains("a_idx = a_idx +") || s.contains("a_idx +="),
+        "expected a_idx to be advanced relative to itself:\n{s}"
+    );
+    assert!(
+        s.contains("b_idx = (b_idx) +") || s.contains("b_idx = b_idx +") || s.contains("b_idx +="),
+        "expected b_idx to be advanced relative to itself:\n{s}"
+    );
+}
+
+#[test]
+fn test_array_local_rewriter_skips_materialization_when_pointer_escapes() {
+    let code = r#"
+#[repr(C)]
+pub struct Holder {
+    pub data: *mut i32,
+}
+
+unsafe extern "C" {
+    fn store_pointer(p: *mut i32);
+}
+
+pub unsafe fn expose(mut h: *mut Holder, mut i: isize) {
+    let mut p: *mut i32 = (*h).data.offset(i);
+    store_pointer(p);
+    *p = 3;
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    if changed {
+        assert!(
+            !s.contains("let p: &") && !s.contains("let mut p: &mut"),
+            "escaping pointer must not be materialized as a reference:\n{s}"
+        );
+    }
 }
 
 #[test]
@@ -9184,8 +9405,8 @@ pub unsafe fn copy_from_back(mut s: *mut State, mut length: isize, mut distance:
     assert!(s.contains("out_idx") || s.contains("s_out_idx"), "{s}");
     assert!(s.contains("src_idx"), "{s}");
     assert!(s.contains("dst_idx"), "{s}");
-    assert!(!s.contains("let mut src: *mut i8"), "{s}");
-    assert!(!s.contains("let mut dst: *mut i8"), "{s}");
+    assert!(s.contains("let mut src: *mut i8"), "{s}");
+    assert!(s.contains("let mut dst: *mut i8"), "{s}");
     assert!(!s.contains("(*s).out = (*s).out.offset(length)"), "{s}");
 }
 
@@ -9218,8 +9439,8 @@ pub unsafe fn dual(mut p: *mut Pair, mut da: isize, mut db: isize) -> i32 {
     assert!(s.contains("let mut b_idx: isize"), "{s}");
     assert!(s.contains("ax_idx"), "{s}");
     assert!(s.contains("bx_idx"), "{s}");
-    assert!(!s.contains("let mut ax: *mut i8"), "{s}");
-    assert!(!s.contains("let mut bx: *mut i16"), "{s}");
+    assert!(s.contains("let mut ax: *mut i8"), "{s}");
+    assert!(s.contains("let mut bx: *mut i16"), "{s}");
 }
 
 #[test]
@@ -9256,6 +9477,14 @@ pub unsafe fn process_buffer(mut state: *mut ProcessState, mut target: i8, mut r
     );
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
     assert!(s.contains("ptr_idx"), "{s}");
-    assert!(!s.contains("let mut ptr: *mut i8"), "{s}");
+    assert!(
+        s.contains("let mut ptr: *mut i8") || s.contains("let ptr: *mut i8"),
+        "expected call argument cursor to stay materialized as a raw pointer:\n{s}"
+    );
     assert!(!s.contains("ptr = found.offset(1)"), "{s}");
+    assert!(
+        s.contains("ptr = ((*state).buffer).offset(ptr_idx) as *mut i8")
+            || s.contains("ptr = ((*state).buffer).offset(ptr_idx);"),
+        "expected ptr to refresh from ptr_idx after movement:\n{s}"
+    );
 }

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9411,6 +9411,60 @@ pub unsafe fn copy_from_back(mut s: *mut State, mut length: isize, mut distance:
 }
 
 #[test]
+fn test_array_local_rewriter_keeps_field_base_memory_copy_cursors_index_only() {
+    let code = r#"
+#[repr(C)]
+pub struct State {
+    pub out: *mut i8,
+}
+
+unsafe extern "C" {
+    fn memset(ptr: *mut core::ffi::c_void, value: i32, n: usize) -> *mut core::ffi::c_void;
+}
+
+pub unsafe fn copy_from_back(mut s: *mut State, mut length: i32, mut distance: i32) {
+    let mut src: *mut i8 = (*s).out.offset(-(distance as isize));
+    let mut dst: *mut i8 = (*s).out;
+    (*s).out = (*s).out.offset(length as isize);
+    if distance == 1 {
+        memset(dst as *mut core::ffi::c_void, (*src) as i32, length as usize);
+    } else {
+        while length != 0 {
+            length -= 1;
+            let fresh = *src;
+            src = src.offset(1);
+            *dst = fresh;
+            dst = dst.offset(1);
+        }
+    }
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(
+        changed,
+        "expected field-base memory copy cursors to be rewritten:\n{s}"
+    );
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("src_idx"), "{s}");
+    assert!(s.contains("dst_idx"), "{s}");
+    assert!(!s.contains("let mut src: *mut i8"), "{s}");
+    assert!(!s.contains("let mut dst: *mut i8"), "{s}");
+    assert!(
+        s.contains("memset(((*s).out).offset(dst_idx)")
+            || s.contains("memset((*s).out.offset(dst_idx)"),
+        "expected memset destination to inline dst_idx from the field base:\n{s}"
+    );
+    assert!(
+        s.contains("*(((*s).out).offset(src_idx)") || s.contains("*((*s).out.offset(src_idx)"),
+        "expected src deref to inline src_idx from the field base:\n{s}"
+    );
+    assert!(
+        s.contains("*(((*s).out).offset(dst_idx)") || s.contains("*((*s).out.offset(dst_idx)"),
+        "expected dst deref to inline dst_idx from the field base:\n{s}"
+    );
+}
+
+#[test]
 fn test_array_local_rewriter_keeps_distinct_indexes_for_two_reassigned_field_bases() {
     let code = r#"
 #[repr(C)]
@@ -9477,14 +9531,17 @@ pub unsafe fn process_buffer(mut state: *mut ProcessState, mut target: i8, mut r
     );
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
     assert!(s.contains("ptr_idx"), "{s}");
+    assert!(!s.contains("let mut ptr: *mut i8"), "{s}");
+    assert!(!s.contains("let ptr: *mut i8"), "{s}");
     assert!(
-        s.contains("let mut ptr: *mut i8") || s.contains("let ptr: *mut i8"),
-        "expected call argument cursor to stay materialized as a raw pointer:\n{s}"
+        s.contains("memchr(((*state).buffer).offset(ptr_idx)")
+            || s.contains("memchr((*state).buffer.offset(ptr_idx)"),
+        "expected memchr to inline ptr_idx from the field base:\n{s}"
     );
+    assert!(!s.contains("memchr(ptr as *const core::ffi::c_void"), "{s}");
     assert!(!s.contains("ptr = found.offset(1)"), "{s}");
     assert!(
-        s.contains("ptr = ((*state).buffer).offset(ptr_idx) as *mut i8")
-            || s.contains("ptr = ((*state).buffer).offset(ptr_idx);"),
-        "expected ptr to refresh from ptr_idx after movement:\n{s}"
+        !s.contains("ptr = ((*state).buffer).offset(ptr_idx)"),
+        "{s}"
     );
 }

--- a/src/bin/crat.rs
+++ b/src/bin/crat.rs
@@ -119,7 +119,6 @@ struct Args {
         help = "Enable verbose ownership solver output for the pointer pass"
     )]
     pointer_verbose: bool,
-
     #[arg(short, long, help = "Enable verbose output")]
     verbose: bool,
     #[arg(long, value_delimiter = ',', help = "Transformation passes to run")]


### PR DESCRIPTION
Related #112 

# Summary

Handles two limitations of above:
- Currently rewrites only if there is a source variable for the base pointer. To rewrite a broader range of pointers, selection criteria should be improved.
- Currently rewriter only rewrites if base pointer offset is not zero, so some target groups are selected but not rewritten yet.

Changes
- Extend index rewriting to struct field base pointers. (e.g. (*param).field)
- To restrict rewrites which may increase unsafe feature counts, add gates to filter rewrite selections.

# Test

Regression test compared to master

feature | master | array-local-rewrite | delta
-- | -- | -- | --
from_ptr | 57 | 58 | +1
from_raw_parts_mut | 7530 | 7528 | -2
offset | 2698 | 2695 | -3

test case | differences with delta
-- | --
Public-Tests/B01_organic/flip_horizontal_lib | from_raw_parts_mut: 1 -> 0 (-1), offset: 2 -> 4 (+2)
Public-Tests/B02_organic/cJSON_lib | from_ptr: 2 -> 3 (+1), from_raw_parts: 50 -> 49 (-1)
Public-Tests/B02_organic/hm_geti_lib | offset: 174 -> 167 (-7)
Public-Tests/B02_organic/load_png_mem_lib | offset: 60 -> 63 (+3)
Public-Tests/B02_organic/pinflate_lib | offset: 13 -> 16 (+3)
Public-Tests/B02_organic/sh_geti_lib | offset: 147 -> 140 (-7)
Public-Tests/B02_synthetic/arrayfunc_lib | offset_from: 1 -> 0 (-1)
Public-Tests/B02_synthetic/confusion_lib | from_raw_parts: 0 -> 1 (+1), from_raw_parts_mut: 1 -> 0 (-1), offset: 0 -> 3 (+3), offset_from: 1 -> 2 (+1)

Rewritten test cases (including base pointers stored in fields)
```
Public-Tests/B01_organic/flip_horizontal_lib
Public-Tests/B01_organic/wcscat_lib
Public-Tests/B02_organic/cJSON_lib
Public-Tests/B02_organic/helxo_lib
Public-Tests/B02_organic/hm_geti_lib
Public-Tests/B02_organic/intput_lib
Public-Tests/B02_organic/load_png_mem_lib
Public-Tests/B02_organic/pinflate_lib
Public-Tests/B02_organic/sh_geti_lib
Public-Tests/B02_organic/sh_puts_lib
Public-Tests/B02_organic/str_dups_lib
Public-Tests/B02_organic/str_put_lib
Public-Tests/B02_synthetic/arrayfunc_lib
Public-Tests/B02_synthetic/confusion_lib
Public-Tests/B02_synthetic/dataentry_lib
Public-Tests/B02_synthetic/memchra2_lib
Public-Tests/P01_sphincs_plus/005_* through Public-Tests/P01_sphincs_plus/132_*
```

Example transformation
```Rust
// pinflate_lib
// Before
                let mut src: *const i8 =
                    __crat_borrowed_s.out.offset(-(backwards_distance as
                                    isize));
                let mut dst: *mut i8 = __crat_borrowed_s.out;
                __crat_borrowed_s.out =
                    __crat_borrowed_s.out.offset(length as isize);
                   ...
                    _ => {
                        loop {
                            let fresh0 = length;
                            length = length - 1;
                            if !(fresh0 != 0) { break; }
                            let fresh1 = *src;
                            src = src.offset(1);
                            *dst = fresh1;
                            dst = dst.offset(1);

// After
                let mut src_idx: isize =
                    out_idx + (-(backwards_distance as isize));
                let mut dst_idx: isize = out_idx;
                out_idx = out_idx + (length as isize);
                ...
                    _ => {
                     loop {
                            let fresh0 = length;
                            length = length - 1;
                            if !(fresh0 != 0) { break; }
                            let fresh1 =
                                *(__crat_borrowed_s.out.offset(src_idx) as *mut i8);
                            src_idx = src_idx + 1;
                            *(__crat_borrowed_s.out.offset(dst_idx) as *mut i8) =
                                fresh1;
                            dst_idx = dst_idx + 1;
                        }
```