### PR TITLE
Support owned outparam to cursor rewriting

### DIFF
--- a/crates/pointer_replacer/src/rewriter/decision.rs
+++ b/crates/pointer_replacer/src/rewriter/decision.rs
@@ -235,10 +235,17 @@ impl<'tcx> DecisionMaker<'tcx> {
                 )
             } else if self._owning_pointers[local] && self.array_pointers[local] {
                 if self._output_params.contains(local) {
-                    (
-                        Some(PtrKind::Slice(true)),
-                        DecisionReason::OwningArrayOutputParam,
-                    )
+                    if self.needs_cursor.contains(local) {
+                        (
+                            Some(PtrKind::SliceCursor(true)),
+                            DecisionReason::OwningArrayOutputParam,
+                        )
+                    } else {
+                        (
+                            Some(PtrKind::Slice(true)),
+                            DecisionReason::OwningArrayOutputParam,
+                        )
+                    }
                 } else if is_local_struct {
                     (
                         Some(PtrKind::Raw(self.mutable_pointers[local])),
@@ -1241,10 +1248,10 @@ pub unsafe fn foo(p: {pointer_ty}) {{
     }
 
     #[test]
-    fn owning_array_output_with_cursor_need_stays_mut_slice() {
+    fn owning_array_output_with_cursor_need_becomes_mut_cursor() {
         assert_eq!(
             decide_for_param(true, true, true, true, false, false, true),
-            PtrKind::Slice(true)
+            PtrKind::SliceCursor(true)
         );
     }
 

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -121,6 +121,9 @@ impl LocalRawParamSummary {
 impl MutVisitor for TransformVisitor<'_, '_> {
     fn visit_crate(&mut self, krate: &mut Crate) {
         mut_visit::walk_crate(self, krate);
+        if self.slice_cursor.get() {
+            CursorProjectionSimplifier.visit_crate(krate);
+        }
 
         if self.bytemuck_derives.borrow().is_empty() {
             return;
@@ -1164,15 +1167,14 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                             self.effective_ptr_kind(hir_id),
                             Some(PtrKind::SliceCursor(_))
                         )
-                        && pe.projs.len() == 1
-                        && let PtrExprProj::Offset(offset) = &pe.projs[0]
+                        && let Some(offset) = combined_cursor_offset(&pe.projs)
                         && !pe.addr_of
                         && !pe.as_ptr
                         && !pe.cast_int
                     {
                         let base_str = pprust::expr_to_string(pe.base);
-                        let offset_str = pprust::expr_to_string(offset);
-                        *expr = utils::expr!("({})[({}) as isize]", base_str, offset_str)
+                        let offset_str = pprust::expr_to_string(&offset);
+                        *expr = utils::expr!("({})[{}]", base_str, offset_str)
                     } else {
                         match self.transform_ptr(e, hir_e, PtrCtx::Deref(m)) {
                             PtrKind::Raw(_) => {}
@@ -7429,6 +7431,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
             );
         let is_mut_cursor_base =
             matches!(self.ptr_source_kind(pe), Some(PtrKind::SliceCursor(true)));
+        let mut owns_cursor = false;
         let mut e = pe.base.clone();
         if pe.projs.is_empty() {
             return e;
@@ -7466,11 +7469,20 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                         }
                     } else if is_mut_cursor_base {
                         if m {
-                            e = utils::expr!(
-                                "({}).as_deref_mut().offset_by(({}) as isize)",
-                                pprust::expr_to_string(&e),
-                                pprust::expr_to_string(offset),
-                            );
+                            if owns_cursor {
+                                e = utils::expr!(
+                                    "({}).offset_by(({}) as isize)",
+                                    pprust::expr_to_string(&e),
+                                    pprust::expr_to_string(offset),
+                                );
+                            } else {
+                                e = utils::expr!(
+                                    "({}).as_deref_mut().offset_by(({}) as isize)",
+                                    pprust::expr_to_string(&e),
+                                    pprust::expr_to_string(offset),
+                                );
+                                owns_cursor = true;
+                            }
                         } else if is_slice_cursor_mut_constructor_call(&e) {
                             e = utils::expr!(
                                 "({}).as_deref().offset_by(({}) as isize)",
@@ -7493,6 +7505,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     }
                 }
                 PtrExprProj::Cast(ty) if ty.is_usize() => {
+                    owns_cursor = false;
                     if is_raw {
                         e = utils::expr!("({}) as usize", pprust::expr_to_string(&e),);
                     } else {
@@ -7505,6 +7518,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     is_raw = true;
                 }
                 PtrExprProj::Cast(ty) => {
+                    owns_cursor = false;
                     let (to_ty, _) = unwrap_ptr_from_mir_ty(*ty).unwrap();
                     if is_raw {
                         e = utils::expr!(
@@ -7535,6 +7549,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     }
                 }
                 PtrExprProj::IntegerOp(expr, op) => {
+                    owns_cursor = false;
                     let method = match op {
                         OpKind::WrappingAdd => "wrapping_add",
                         OpKind::WrappingSub => "wrapping_sub",
@@ -7547,6 +7562,7 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     );
                 }
                 PtrExprProj::IntegerBinOp(expr, op) => {
+                    owns_cursor = false;
                     let op_str = match op {
                         BinOpKind::BitAnd => "&",
                         BinOpKind::BitOr => "|",
@@ -7819,6 +7835,130 @@ impl<'a, 'tcx> PtrExpr<'a, 'tcx> {
             && !self.addr_of
             && !self.as_ptr
     }
+}
+
+fn combined_offsets(offsets: &[&Expr], cast_to_isize: bool) -> Option<Expr> {
+    let (first, rest) = offsets.split_first()?;
+    let format_offset = |offset: &Expr| {
+        let offset = if cast_to_isize {
+            offset
+        } else {
+            remove_redundant_isize_casts(offset)
+        };
+        let offset = pprust::expr_to_string(offset);
+        if cast_to_isize {
+            format!("({offset}) as isize")
+        } else {
+            format!("({offset})")
+        }
+    };
+    let mut combined = format_offset(first);
+    for offset in rest {
+        combined = format!("({combined}).wrapping_add({})", format_offset(offset));
+    }
+    Some(utils::expr!("{combined}"))
+}
+
+fn remove_redundant_isize_casts(mut expr: &Expr) -> &Expr {
+    loop {
+        let ExprKind::Cast(inner, ty) = &unwrap_paren(expr).kind else {
+            return expr;
+        };
+        let ExprKind::Cast(_, inner_ty) = &unwrap_paren(inner).kind else {
+            return expr;
+        };
+        if !is_isize_ty(ty) || !is_isize_ty(inner_ty) {
+            return expr;
+        }
+        expr = inner;
+    }
+}
+
+fn is_isize_ty(ty: &Ty) -> bool {
+    let TyKind::Path(None, path) = &ty.kind else {
+        return false;
+    };
+    path.segments.len() == 1 && path.segments[0].ident.name.as_str() == "isize"
+}
+
+fn combined_cursor_offset(projs: &[PtrExprProj<'_, '_>]) -> Option<Expr> {
+    let offsets = projs
+        .iter()
+        .map(|proj| match proj {
+            PtrExprProj::Offset(offset) => Some(*offset),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+    combined_offsets(&offsets, true)
+}
+
+struct CursorProjectionSimplifier;
+
+impl MutVisitor for CursorProjectionSimplifier {
+    fn visit_expr(&mut self, expr: &mut Expr) {
+        mut_visit::walk_expr(self, expr);
+
+        if let ExprKind::MethodCall(call) = &mut unwrap_paren_mut(expr).kind
+            && call.seg.ident.name.as_str() == "offset_by"
+            && let Some(receiver) = cursor_offset_without_reborrow(&call.receiver)
+        {
+            call.receiver = receiver;
+        }
+
+        let replacement = if let ExprKind::Index(base, index, _) = &unwrap_paren(expr).kind
+            && is_zero_integer_expr(index)
+        {
+            let mut offsets = Vec::new();
+            cursor_offset_chain(base, &mut offsets).and_then(|base| {
+                let base = pprust::expr_to_string(base);
+                let offset = combined_offsets(&offsets, false)?;
+                Some(utils::expr!(
+                    "({base})[{}]",
+                    pprust::expr_to_string(&offset),
+                ))
+            })
+        } else {
+            None
+        };
+        if let Some(replacement) = replacement {
+            *expr = replacement;
+        }
+    }
+}
+
+fn cursor_offset_without_reborrow(expr: &Expr) -> Option<P<Expr>> {
+    let ExprKind::MethodCall(reborrow) = &unwrap_paren(expr).kind else {
+        return None;
+    };
+    if reborrow.seg.ident.name.as_str() != "as_deref_mut" || !reborrow.args.is_empty() {
+        return None;
+    }
+    let ExprKind::MethodCall(offset) = &unwrap_paren(&reborrow.receiver).kind else {
+        return None;
+    };
+    (offset.seg.ident.name.as_str() == "offset_by").then(|| reborrow.receiver.clone())
+}
+
+fn cursor_offset_chain<'a>(expr: &'a Expr, offsets: &mut Vec<&'a Expr>) -> Option<&'a Expr> {
+    let ExprKind::MethodCall(call) = &unwrap_paren(expr).kind else {
+        return None;
+    };
+    match call.seg.ident.name.as_str() {
+        "offset_by" if call.args.len() == 1 => {
+            let base = cursor_offset_chain(&call.receiver, offsets)?;
+            offsets.push(&call.args[0]);
+            Some(base)
+        }
+        "as_deref_mut" if call.args.is_empty() => Some(&call.receiver),
+        _ => None,
+    }
+}
+
+fn is_zero_integer_expr(expr: &Expr) -> bool {
+    let ExprKind::Lit(lit) = &unwrap_cast_and_paren(expr).kind else {
+        return false;
+    };
+    lit.kind == token::LitKind::Integer && lit.symbol.as_str() == "0"
 }
 
 fn unwrap_addr_of_deref(expr: &Expr) -> &Expr {
@@ -16037,6 +16177,34 @@ mod tests {
         rewriter::{Config, replace_local_borrows},
         utils::rustc::RustProgram,
     };
+
+    #[test]
+    fn cursor_projection_simplifier_combines_offset_index() {
+        utils::compilation::run_compiler_on_str("fn f() {}", |_| {
+            let mut expr = utils::expr!(
+                "p.as_deref_mut().offset_by(a).as_deref_mut().offset_by(b)[0 as usize]"
+            );
+            CursorProjectionSimplifier.visit_expr(&mut expr);
+            let expr = pprust::expr_to_string(&expr);
+            assert!(expr.contains("wrapping_add"), "{expr}");
+            assert!(!expr.contains("as_deref_mut"), "{expr}");
+            assert!(!expr.contains("offset_by"), "{expr}");
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_reborrows_once() {
+        utils::compilation::run_compiler_on_str("fn f() {}", |_| {
+            let mut expr =
+                utils::expr!("p.as_deref_mut().offset_by(a).as_deref_mut().offset_by(b)");
+            CursorProjectionSimplifier.visit_expr(&mut expr);
+            let expr = pprust::expr_to_string(&expr);
+            assert_eq!(expr.matches("as_deref_mut").count(), 1, "{expr}");
+            assert_eq!(expr.matches("offset_by").count(), 2, "{expr}");
+        })
+        .unwrap();
+    }
 
     fn collect_program(tcx: TyCtxt<'_>) -> RustProgram<'_> {
         let mut functions = Vec::new();

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -3,7 +3,7 @@ use std::cell::{Cell, RefCell};
 use etrace::some_or;
 use rustc_abi::FieldIdx;
 use rustc_ast::{
-    mut_visit::{self, MutVisitor},
+    mut_visit::{self, FnKind, MutVisitor},
     ptr::P,
     *,
 };
@@ -122,7 +122,7 @@ impl MutVisitor for TransformVisitor<'_, '_> {
     fn visit_crate(&mut self, krate: &mut Crate) {
         mut_visit::walk_crate(self, krate);
         if self.slice_cursor.get() {
-            CursorProjectionSimplifier.visit_crate(krate);
+            CursorProjectionSimplifier::default().visit_crate(krate);
         }
 
         if self.bytemuck_derives.borrow().is_empty() {
@@ -1162,11 +1162,7 @@ impl MutVisitor for TransformVisitor<'_, '_> {
                     let hir_inner = hir_unwrap_addr_of_deref(hir_unwrap_cast(hir_e));
                     let pe = self.ptr_expr(inner, hir_inner);
                     if let Some(pe) = pe
-                        && let PtrExprBaseKind::Path(Res::Local(hir_id)) = pe.base_kind
-                        && matches!(
-                            self.effective_ptr_kind(hir_id),
-                            Some(PtrKind::SliceCursor(_))
-                        )
+                        && self.ptr_expr_base_is_cursor(&pe)
                         && let Some(offset) = combined_cursor_offset(&pe.projs)
                         && !pe.addr_of
                         && !pe.as_ptr
@@ -5227,6 +5223,19 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
         None
     }
 
+    fn ptr_expr_base_is_cursor(&self, pe: &PtrExpr<'_, 'tcx>) -> bool {
+        match pe.base_kind {
+            PtrExprBaseKind::Path(Res::Local(hir_id)) => matches!(
+                self.effective_ptr_kind(hir_id),
+                Some(PtrKind::SliceCursor(_))
+            ),
+            _ => self
+                .promoted_field_slot_for_hir_field(pe.hir_base)
+                .and_then(|field| self.field_ptr_kind(field))
+                .is_some_and(|kind| matches!(kind, PtrKind::SliceCursor(_))),
+        }
+    }
+
     fn allocator_root<'a>(&self, expr: &'a Expr) -> Option<AllocatorRoot<'a>> {
         let ExprKind::Call(callee, args) = &unwrap_cast_and_paren(expr).kind else {
             return None;
@@ -7892,9 +7901,80 @@ fn combined_cursor_offset(projs: &[PtrExprProj<'_, '_>]) -> Option<Expr> {
     combined_offsets(&offsets, true)
 }
 
-struct CursorProjectionSimplifier;
+#[derive(Default)]
+struct CursorProjectionSimplifier {
+    binding_scopes: Vec<FxHashMap<Symbol, bool>>,
+    binding_counts: FxHashMap<Symbol, usize>,
+}
 
 impl MutVisitor for CursorProjectionSimplifier {
+    fn visit_item(&mut self, item: &mut Item) {
+        let outer_scopes = std::mem::take(&mut self.binding_scopes);
+        let outer_counts = std::mem::take(&mut self.binding_counts);
+        mut_visit::walk_item(self, item);
+        self.binding_scopes = outer_scopes;
+        self.binding_counts = outer_counts;
+    }
+
+    fn visit_fn(&mut self, fn_kind: FnKind<'_>, _span: rustc_span::Span, _id: NodeId) {
+        match fn_kind {
+            FnKind::Fn(context, visibility, function) => {
+                let outer_scopes = std::mem::take(&mut self.binding_scopes);
+                let outer_counts = std::mem::take(&mut self.binding_counts);
+
+                let mut counter = BindingCounter::default();
+                for param in &mut function.sig.decl.inputs {
+                    counter.visit_pat(&mut param.pat);
+                }
+                if let Some(body) = &mut function.body {
+                    counter.visit_block(body);
+                }
+                self.binding_counts = counter.counts;
+
+                let mut param_scope = FxHashMap::default();
+                for param in &function.sig.decl.inputs {
+                    if let Some(name) = simple_binding_name(&param.pat) {
+                        param_scope.insert(name, is_cursor_ty(&param.ty));
+                    }
+                }
+                self.binding_scopes.push(param_scope);
+                mut_visit::walk_fn(self, FnKind::Fn(context, visibility, function));
+
+                self.binding_scopes = outer_scopes;
+                self.binding_counts = outer_counts;
+            }
+            FnKind::Closure(binder, coroutine_kind, decl, body) => {
+                let mut param_scope = FxHashMap::default();
+                for param in &decl.inputs {
+                    if let Some(name) = simple_binding_name(&param.pat) {
+                        param_scope.insert(name, is_cursor_ty(&param.ty));
+                    }
+                }
+                self.binding_scopes.push(param_scope);
+                mut_visit::walk_fn(self, FnKind::Closure(binder, coroutine_kind, decl, body));
+                self.binding_scopes.pop();
+            }
+        }
+    }
+
+    fn visit_block(&mut self, block: &mut Block) {
+        self.binding_scopes.push(FxHashMap::default());
+        mut_visit::walk_block(self, block);
+        self.binding_scopes.pop();
+    }
+
+    fn visit_local(&mut self, local: &mut Local) {
+        let binding = simple_binding_name(&local.pat)
+            .map(|name| (name, local.ty.as_deref().is_some_and(is_cursor_ty)));
+        mut_visit::walk_local(self, local);
+        if let Some((name, is_cursor)) = binding {
+            self.binding_scopes
+                .last_mut()
+                .expect("local outside a lexical scope")
+                .insert(name, is_cursor);
+        }
+    }
+
     fn visit_expr(&mut self, expr: &mut Expr) {
         mut_visit::walk_expr(self, expr);
 
@@ -7909,20 +7989,118 @@ impl MutVisitor for CursorProjectionSimplifier {
             && is_zero_integer_expr(index)
         {
             let mut offsets = Vec::new();
-            cursor_offset_chain(base, &mut offsets).and_then(|base| {
-                let base = pprust::expr_to_string(base);
-                let offset = combined_offsets(&offsets, false)?;
-                Some(utils::expr!(
-                    "({base})[{}]",
-                    pprust::expr_to_string(&offset),
-                ))
-            })
+            self.cursor_offset_chain(base, &mut offsets)
+                .and_then(|base| {
+                    let offset = combined_offsets(&offsets, false)?;
+                    let offset = pprust::expr_to_string(&offset);
+                    Some(match base {
+                        CursorIndexBase::Cursor(base) => {
+                            let base = pprust::expr_to_string(base);
+                            utils::expr!("({base})[{offset}]")
+                        }
+                        CursorIndexBase::Slice(slice) => {
+                            let slice = pprust::expr_to_string(slice);
+                            utils::expr!("({slice})[({offset}) as usize]")
+                        }
+                    })
+                })
         } else {
             None
         };
         if let Some(replacement) = replacement {
             *expr = replacement;
         }
+    }
+}
+
+impl CursorProjectionSimplifier {
+    fn cursor_offset_chain<'a>(
+        &self,
+        expr: &'a Expr,
+        offsets: &mut Vec<&'a Expr>,
+    ) -> Option<CursorIndexBase<'a>> {
+        match &unwrap_paren(expr).kind {
+            ExprKind::MethodCall(call) => match call.seg.ident.name.as_str() {
+                "offset_by" if call.args.len() == 1 => {
+                    let base = self.cursor_offset_chain(&call.receiver, offsets)?;
+                    offsets.push(&call.args[0]);
+                    Some(base)
+                }
+                "as_deref_mut" if call.args.is_empty() => {
+                    Some(CursorIndexBase::Cursor(&call.receiver))
+                }
+                _ => None,
+            },
+            ExprKind::Call(callee, args) if args.len() == 1 && is_slice_cursor_new(callee) => {
+                let ExprKind::MethodCall(as_slice) = &unwrap_paren(&args[0]).kind else {
+                    return None;
+                };
+                if as_slice.seg.ident.name.as_str() != "as_slice" || !as_slice.args.is_empty() {
+                    return None;
+                }
+                self.cursor_offset_chain(&as_slice.receiver, offsets)
+                    .or_else(|| {
+                        self.is_cursor_binding(&as_slice.receiver)
+                            .then_some(CursorIndexBase::Cursor(&as_slice.receiver))
+                    })
+                    .or(Some(CursorIndexBase::Slice(&args[0])))
+            }
+            _ => None,
+        }
+    }
+
+    fn is_cursor_binding(&self, expr: &Expr) -> bool {
+        let ExprKind::Path(None, path) = &unwrap_paren(expr).kind else {
+            return false;
+        };
+        let [segment] = path.segments.as_slice() else {
+            return false;
+        };
+        self.binding_scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.get(&segment.ident.name).copied())
+            .unwrap_or(false)
+            && self.binding_counts.get(&segment.ident.name) == Some(&1)
+    }
+}
+
+#[derive(Default)]
+struct BindingCounter {
+    counts: FxHashMap<Symbol, usize>,
+}
+
+impl MutVisitor for BindingCounter {
+    fn visit_pat(&mut self, pat: &mut Pat) {
+        if let PatKind::Ident(_, ident, _) = &pat.kind {
+            *self.counts.entry(ident.name).or_default() += 1;
+        }
+        mut_visit::walk_pat(self, pat);
+    }
+}
+
+fn simple_binding_name(pat: &Pat) -> Option<Symbol> {
+    let PatKind::Ident(_, ident, None) = &pat.kind else {
+        return None;
+    };
+    Some(ident.name)
+}
+
+fn is_cursor_ty(ty: &Ty) -> bool {
+    match &ty.kind {
+        TyKind::Paren(ty) => is_cursor_ty(ty),
+        TyKind::Path(None, path) => {
+            let [crate_segment, module_segment, ty_segment] = path.segments.as_slice() else {
+                return false;
+            };
+            crate_segment.ident.name.as_str() == "crate"
+                && module_segment.ident.name.as_str() == "slice_cursor"
+                && matches!(
+                    ty_segment.ident.name.as_str(),
+                    "SliceCursor" | "SliceCursorMut"
+                )
+        }
+        _ => false,
     }
 }
 
@@ -7939,28 +8117,9 @@ fn cursor_offset_without_reborrow(expr: &Expr) -> Option<P<Expr>> {
     (offset.seg.ident.name.as_str() == "offset_by").then(|| reborrow.receiver.clone())
 }
 
-fn cursor_offset_chain<'a>(expr: &'a Expr, offsets: &mut Vec<&'a Expr>) -> Option<&'a Expr> {
-    match &unwrap_paren(expr).kind {
-        ExprKind::MethodCall(call) => match call.seg.ident.name.as_str() {
-            "offset_by" if call.args.len() == 1 => {
-                let base = cursor_offset_chain(&call.receiver, offsets)?;
-                offsets.push(&call.args[0]);
-                Some(base)
-            }
-            "as_deref_mut" if call.args.is_empty() => Some(&call.receiver),
-            _ => None,
-        },
-        ExprKind::Call(callee, args) if args.len() == 1 && is_slice_cursor_new(callee) => {
-            let ExprKind::MethodCall(as_slice) = &unwrap_paren(&args[0]).kind else {
-                return None;
-            };
-            if as_slice.seg.ident.name.as_str() != "as_slice" || !as_slice.args.is_empty() {
-                return None;
-            }
-            cursor_offset_chain(&as_slice.receiver, offsets).or(Some(&as_slice.receiver))
-        }
-        _ => None,
-    }
+enum CursorIndexBase<'a> {
+    Cursor(&'a Expr),
+    Slice(&'a Expr),
 }
 
 fn is_slice_cursor_new(expr: &Expr) -> bool {
@@ -16197,13 +16356,434 @@ mod tests {
         utils::rustc::RustProgram,
     };
 
+    fn with_simplified_cursor_projection(source: &str, check: impl FnOnce(&Expr) + Send) {
+        utils::compilation::run_compiler_on_str("fn f() {}", move |_| {
+            let mut krate = utils::ast::parse_crate(source.to_string());
+            CursorProjectionSimplifier::default().visit_crate(&mut krate);
+
+            #[derive(Default)]
+            struct WildInitializer(Option<P<Expr>>);
+
+            impl MutVisitor for WildInitializer {
+                fn visit_local(&mut self, local: &mut Local) {
+                    if matches!(local.pat.kind, PatKind::Wild)
+                        && let Some(init) = local.kind.init()
+                    {
+                        assert!(self.0.is_none(), "multiple wildcard initializers");
+                        self.0 = Some(Box::new(init.clone()));
+                    }
+                    mut_visit::walk_local(self, local);
+                }
+            }
+
+            let mut initializer = WildInitializer::default();
+            initializer.visit_crate(&mut krate);
+            check(&initializer.0.expect("missing wildcard initializer"));
+        })
+        .unwrap();
+    }
+
+    fn assert_path(expr: &Expr, expected: &str) {
+        let ExprKind::Path(None, path) = &unwrap_paren(expr).kind else {
+            panic!(
+                "expected path {expected}, got {}",
+                pprust::expr_to_string(expr)
+            );
+        };
+        assert_eq!(path.segments.len(), 1, "{}", pprust::expr_to_string(expr));
+        assert_eq!(path.segments[0].ident.name.as_str(), expected);
+    }
+
+    fn assert_simple_ty(ty: &Ty, expected: &str) {
+        let TyKind::Path(None, path) = &ty.kind else {
+            panic!("expected type {expected}, got {}", pprust::ty_to_string(ty));
+        };
+        assert_eq!(path.segments.len(), 1, "{}", pprust::ty_to_string(ty));
+        assert_eq!(path.segments[0].ident.name.as_str(), expected);
+    }
+
+    fn assert_combined_cursor_index(index: &Expr) {
+        let ExprKind::MethodCall(call) = &unwrap_paren(index).kind else {
+            panic!(
+                "expected wrapping_add, got {}",
+                pprust::expr_to_string(index)
+            );
+        };
+        assert_eq!(call.seg.ident.name.as_str(), "wrapping_add");
+        assert_path(&call.receiver, "raw_idx");
+        let [offset] = call.args.as_slice() else {
+            panic!("expected one wrapping_add argument");
+        };
+        let ExprKind::Cast(offset, ty) = &unwrap_paren(offset).kind else {
+            panic!(
+                "expected x as isize, got {}",
+                pprust::expr_to_string(offset)
+            );
+        };
+        assert_path(offset, "x");
+        assert_simple_ty(ty, "isize");
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_indexes_proven_cursor_parameter() {
+        with_simplified_cursor_projection(
+            r#"
+            fn f(
+                raw: crate::slice_cursor::SliceCursorMut<'_, u8>,
+                raw_idx: isize,
+                x: i32,
+            ) {
+                let _ = crate::slice_cursor::SliceCursor::new(
+                    crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                        .offset_by(raw_idx)
+                        .as_slice(),
+                )
+                .offset_by(x as isize)[0usize];
+            }
+            "#,
+            |initializer| {
+                let ExprKind::Index(base, index, _) = &unwrap_paren(initializer).kind else {
+                    panic!(
+                        "expected index, got {}",
+                        pprust::expr_to_string(initializer)
+                    );
+                };
+                assert_path(base, "raw");
+                assert_combined_cursor_index(index);
+            },
+        );
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_indexes_proven_cursor_local() {
+        with_simplified_cursor_projection(
+            r#"
+            fn f(
+                cursor: crate::slice_cursor::SliceCursorMut<'_, u8>,
+                raw_idx: isize,
+                x: i32,
+            ) {
+                let raw: crate::slice_cursor::SliceCursorMut<'_, u8> = cursor;
+                let _ = crate::slice_cursor::SliceCursor::new(
+                    crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                        .offset_by(raw_idx)
+                        .as_slice(),
+                )
+                .offset_by(x as isize)[0usize];
+            }
+            "#,
+            |initializer| {
+                let ExprKind::Index(base, index, _) = &unwrap_paren(initializer).kind else {
+                    panic!(
+                        "expected index, got {}",
+                        pprust::expr_to_string(initializer)
+                    );
+                };
+                assert_path(base, "raw");
+                assert_combined_cursor_index(index);
+            },
+        );
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_respects_non_cursor_shadowing() {
+        with_simplified_cursor_projection(
+            r#"
+            fn f(
+                raw: crate::slice_cursor::SliceCursorMut<'_, u8>,
+                values: &[u8],
+                raw_idx: isize,
+                x: i32,
+            ) {
+                {
+                    let raw: &[u8] = values;
+                    let _ = crate::slice_cursor::SliceCursor::new(
+                        crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                            .offset_by(raw_idx)
+                            .as_slice(),
+                    )
+                    .offset_by(x as isize)[0usize];
+                }
+            }
+            "#,
+            |initializer| {
+                let ExprKind::Index(base, index, _) = &unwrap_paren(initializer).kind else {
+                    panic!(
+                        "expected index, got {}",
+                        pprust::expr_to_string(initializer)
+                    );
+                };
+                let ExprKind::MethodCall(call) = &unwrap_paren(base).kind else {
+                    panic!(
+                        "expected raw.as_slice(), got {}",
+                        pprust::expr_to_string(base)
+                    );
+                };
+                assert_eq!(call.seg.ident.name.as_str(), "as_slice");
+                assert!(call.args.is_empty());
+                assert_path(&call.receiver, "raw");
+
+                let ExprKind::Cast(index, ty) = &unwrap_paren(index).kind else {
+                    panic!("expected usize cast, got {}", pprust::expr_to_string(index));
+                };
+                assert_simple_ty(ty, "usize");
+                assert_combined_cursor_index(index);
+            },
+        );
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_respects_closure_parameter_shadowing() {
+        with_simplified_cursor_projection(
+            r#"
+            fn f(
+                raw: crate::slice_cursor::SliceCursorMut<'_, u8>,
+                raw_idx: isize,
+                x: i32,
+            ) {
+                let _closure = |raw: &[u8]| {
+                    let _ = crate::slice_cursor::SliceCursor::new(
+                        crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                            .offset_by(raw_idx)
+                            .as_slice(),
+                    )
+                    .offset_by(x as isize)[0usize];
+                };
+            }
+            "#,
+            |initializer| {
+                let ExprKind::Index(base, index, _) = &unwrap_paren(initializer).kind else {
+                    panic!(
+                        "expected index, got {}",
+                        pprust::expr_to_string(initializer)
+                    );
+                };
+                let ExprKind::MethodCall(call) = &unwrap_paren(base).kind else {
+                    panic!(
+                        "expected raw.as_slice(), got {}",
+                        pprust::expr_to_string(base)
+                    );
+                };
+                assert_eq!(call.seg.ident.name.as_str(), "as_slice");
+                assert!(call.args.is_empty());
+                assert_path(&call.receiver, "raw");
+
+                let ExprKind::Cast(index, ty) = &unwrap_paren(index).kind else {
+                    panic!("expected usize cast, got {}", pprust::expr_to_string(index));
+                };
+                assert_simple_ty(ty, "usize");
+                assert_combined_cursor_index(index);
+            },
+        );
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_simplifies_unshadowed_closure_capture() {
+        with_simplified_cursor_projection(
+            r#"
+            fn f(
+                raw: crate::slice_cursor::SliceCursorMut<'_, u8>,
+                raw_idx: isize,
+                x: i32,
+            ) {
+                let _closure = || {
+                    let _ = crate::slice_cursor::SliceCursor::new(
+                        crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                            .offset_by(raw_idx)
+                            .as_slice(),
+                    )
+                    .offset_by(x as isize)[0usize];
+                };
+            }
+            "#,
+            |initializer| {
+                let ExprKind::Index(base, index, _) = &unwrap_paren(initializer).kind else {
+                    panic!(
+                        "expected index, got {}",
+                        pprust::expr_to_string(initializer)
+                    );
+                };
+                assert_path(base, "raw");
+                assert_combined_cursor_index(index);
+            },
+        );
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_isolates_nested_items() {
+        with_simplified_cursor_projection(
+            r#"
+            fn f(
+                raw: crate::slice_cursor::SliceCursorMut<'_, u8>,
+                raw_idx: isize,
+                x: i32,
+            ) {
+                static raw: &[u8] = &[];
+                const VALUE: () = {
+                    let _ = crate::slice_cursor::SliceCursor::new(
+                        crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                            .offset_by(raw_idx)
+                            .as_slice(),
+                    )
+                    .offset_by(x as isize)[0usize];
+                };
+            }
+            "#,
+            |initializer| {
+                let ExprKind::Index(base, index, _) = &unwrap_paren(initializer).kind else {
+                    panic!(
+                        "expected index, got {}",
+                        pprust::expr_to_string(initializer)
+                    );
+                };
+                let ExprKind::MethodCall(call) = &unwrap_paren(base).kind else {
+                    panic!(
+                        "expected raw.as_slice(), got {}",
+                        pprust::expr_to_string(base)
+                    );
+                };
+                assert_eq!(call.seg.ident.name.as_str(), "as_slice");
+                assert!(call.args.is_empty());
+                assert_path(&call.receiver, "raw");
+
+                let ExprKind::Cast(index, ty) = &unwrap_paren(index).kind else {
+                    panic!("expected usize cast, got {}", pprust::expr_to_string(index));
+                };
+                assert_simple_ty(ty, "usize");
+                assert_combined_cursor_index(index);
+            },
+        );
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_respects_destructuring_shadowing() {
+        with_simplified_cursor_projection(
+            r#"
+            fn f(
+                raw: crate::slice_cursor::SliceCursorMut<'_, u8>,
+                values: (&[u8],),
+                raw_idx: isize,
+                x: i32,
+            ) {
+                let (raw,) = values;
+                let _ = crate::slice_cursor::SliceCursor::new(
+                    crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                        .offset_by(raw_idx)
+                        .as_slice(),
+                )
+                .offset_by(x as isize)[0usize];
+            }
+            "#,
+            |initializer| {
+                let ExprKind::Index(base, index, _) = &unwrap_paren(initializer).kind else {
+                    panic!(
+                        "expected index, got {}",
+                        pprust::expr_to_string(initializer)
+                    );
+                };
+                let ExprKind::MethodCall(call) = &unwrap_paren(base).kind else {
+                    panic!(
+                        "expected raw.as_slice(), got {}",
+                        pprust::expr_to_string(base)
+                    );
+                };
+                assert_eq!(call.seg.ident.name.as_str(), "as_slice");
+                assert!(call.args.is_empty());
+                assert_path(&call.receiver, "raw");
+
+                let ExprKind::Cast(index, ty) = &unwrap_paren(index).kind else {
+                    panic!("expected usize cast, got {}", pprust::expr_to_string(index));
+                };
+                assert_simple_ty(ty, "usize");
+                assert_combined_cursor_index(index);
+            },
+        );
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_indexes_proven_associated_function_parameter() {
+        with_simplified_cursor_projection(
+            r#"
+            struct S;
+
+            impl S {
+                fn f(
+                    raw: crate::slice_cursor::SliceCursorMut<'_, u8>,
+                    raw_idx: isize,
+                    x: i32,
+                ) {
+                    let _ = crate::slice_cursor::SliceCursor::new(
+                        crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                            .offset_by(raw_idx)
+                            .as_slice(),
+                    )
+                    .offset_by(x as isize)[0usize];
+                }
+            }
+            "#,
+            |initializer| {
+                let ExprKind::Index(base, index, _) = &unwrap_paren(initializer).kind else {
+                    panic!(
+                        "expected index, got {}",
+                        pprust::expr_to_string(initializer)
+                    );
+                };
+                assert_path(base, "raw");
+                assert_combined_cursor_index(index);
+            },
+        );
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_rejects_noncanonical_cursor_type() {
+        with_simplified_cursor_projection(
+            r#"
+            fn f(
+                raw: other::SliceCursor<'_, u8>,
+                raw_idx: isize,
+                x: i32,
+            ) {
+                let _ = crate::slice_cursor::SliceCursor::new(
+                    crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                        .offset_by(raw_idx)
+                        .as_slice(),
+                )
+                .offset_by(x as isize)[0usize];
+            }
+            "#,
+            |initializer| {
+                let ExprKind::Index(base, index, _) = &unwrap_paren(initializer).kind else {
+                    panic!(
+                        "expected index, got {}",
+                        pprust::expr_to_string(initializer)
+                    );
+                };
+                let ExprKind::MethodCall(call) = &unwrap_paren(base).kind else {
+                    panic!(
+                        "expected raw.as_slice(), got {}",
+                        pprust::expr_to_string(base)
+                    );
+                };
+                assert_eq!(call.seg.ident.name.as_str(), "as_slice");
+                assert!(call.args.is_empty());
+                assert_path(&call.receiver, "raw");
+
+                let ExprKind::Cast(index, ty) = &unwrap_paren(index).kind else {
+                    panic!("expected usize cast, got {}", pprust::expr_to_string(index));
+                };
+                assert_simple_ty(ty, "usize");
+                assert_combined_cursor_index(index);
+            },
+        );
+    }
+
     #[test]
     fn cursor_projection_simplifier_combines_offset_index() {
         utils::compilation::run_compiler_on_str("fn f() {}", |_| {
             let mut expr = utils::expr!(
                 "p.as_deref_mut().offset_by(a).as_deref_mut().offset_by(b)[0 as usize]"
             );
-            CursorProjectionSimplifier.visit_expr(&mut expr);
+            CursorProjectionSimplifier::default().visit_expr(&mut expr);
             let expr = pprust::expr_to_string(&expr);
             assert!(expr.contains("wrapping_add"), "{expr}");
             assert!(!expr.contains("as_deref_mut"), "{expr}");
@@ -16217,7 +16797,7 @@ mod tests {
         utils::compilation::run_compiler_on_str("fn f() {}", |_| {
             let mut expr =
                 utils::expr!("p.as_deref_mut().offset_by(a).as_deref_mut().offset_by(b)");
-            CursorProjectionSimplifier.visit_expr(&mut expr);
+            CursorProjectionSimplifier::default().visit_expr(&mut expr);
             let expr = pprust::expr_to_string(&expr);
             assert_eq!(expr.matches("as_deref_mut").count(), 1, "{expr}");
             assert_eq!(expr.matches("offset_by").count(), 2, "{expr}");
@@ -16236,12 +16816,30 @@ mod tests {
                 )
                 .offset_by(b)[0usize]"
             );
-            CursorProjectionSimplifier.visit_expr(&mut expr);
+            CursorProjectionSimplifier::default().visit_expr(&mut expr);
             let expr = pprust::expr_to_string(&expr);
-            assert!(expr.contains("(raw)["), "{expr}");
             assert!(expr.contains("wrapping_add"), "{expr}");
+            assert!(expr.contains("raw.as_slice"), "{expr}");
+            assert!(expr.contains("as usize"), "{expr}");
             assert!(!expr.contains("SliceCursor::new"), "{expr}");
             assert!(!expr.contains("offset_by"), "{expr}");
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_indexes_unproven_as_slice_receiver() {
+        utils::compilation::run_compiler_on_str("fn f() {}", |_| {
+            let mut expr = utils::expr!(
+                "crate::slice_cursor::SliceCursor::new(values.as_slice()).offset_by(a)[0usize]"
+            );
+            CursorProjectionSimplifier::default().visit_expr(&mut expr);
+            let expr = pprust::expr_to_string(&expr);
+            assert!(expr.contains("values.as_slice"), "{expr}");
+            assert!(expr.contains("as usize"), "{expr}");
+            assert!(!expr.contains("SliceCursor::new"), "{expr}");
+            assert!(!expr.contains("offset_by"), "{expr}");
+            assert!(!expr.starts_with("(values)["), "{expr}");
         })
         .unwrap();
     }

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -7940,18 +7940,37 @@ fn cursor_offset_without_reborrow(expr: &Expr) -> Option<P<Expr>> {
 }
 
 fn cursor_offset_chain<'a>(expr: &'a Expr, offsets: &mut Vec<&'a Expr>) -> Option<&'a Expr> {
-    let ExprKind::MethodCall(call) = &unwrap_paren(expr).kind else {
-        return None;
-    };
-    match call.seg.ident.name.as_str() {
-        "offset_by" if call.args.len() == 1 => {
-            let base = cursor_offset_chain(&call.receiver, offsets)?;
-            offsets.push(&call.args[0]);
-            Some(base)
+    match &unwrap_paren(expr).kind {
+        ExprKind::MethodCall(call) => match call.seg.ident.name.as_str() {
+            "offset_by" if call.args.len() == 1 => {
+                let base = cursor_offset_chain(&call.receiver, offsets)?;
+                offsets.push(&call.args[0]);
+                Some(base)
+            }
+            "as_deref_mut" if call.args.is_empty() => Some(&call.receiver),
+            _ => None,
+        },
+        ExprKind::Call(callee, args) if args.len() == 1 && is_slice_cursor_new(callee) => {
+            let ExprKind::MethodCall(as_slice) = &unwrap_paren(&args[0]).kind else {
+                return None;
+            };
+            if as_slice.seg.ident.name.as_str() != "as_slice" || !as_slice.args.is_empty() {
+                return None;
+            }
+            cursor_offset_chain(&as_slice.receiver, offsets).or(Some(&as_slice.receiver))
         }
-        "as_deref_mut" if call.args.is_empty() => Some(&call.receiver),
         _ => None,
     }
+}
+
+fn is_slice_cursor_new(expr: &Expr) -> bool {
+    let ExprKind::Path(_, path) = &unwrap_paren(expr).kind else {
+        return false;
+    };
+    let segments = &path.segments;
+    segments.len() >= 2
+        && segments[segments.len() - 2].ident.name.as_str() == "SliceCursor"
+        && segments[segments.len() - 1].ident.name.as_str() == "new"
 }
 
 fn is_zero_integer_expr(expr: &Expr) -> bool {
@@ -16202,6 +16221,27 @@ mod tests {
             let expr = pprust::expr_to_string(&expr);
             assert_eq!(expr.matches("as_deref_mut").count(), 1, "{expr}");
             assert_eq!(expr.matches("offset_by").count(), 2, "{expr}");
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn cursor_projection_simplifier_removes_shared_cursor_constructors() {
+        utils::compilation::run_compiler_on_str("fn f() {}", |_| {
+            let mut expr = utils::expr!(
+                "crate::slice_cursor::SliceCursor::new(
+                    crate::slice_cursor::SliceCursor::new(raw.as_slice())
+                        .offset_by(a)
+                        .as_slice()
+                )
+                .offset_by(b)[0usize]"
+            );
+            CursorProjectionSimplifier.visit_expr(&mut expr);
+            let expr = pprust::expr_to_string(&expr);
+            assert!(expr.contains("(raw)["), "{expr}");
+            assert!(expr.contains("wrapping_add"), "{expr}");
+            assert!(!expr.contains("SliceCursor::new"), "{expr}");
+            assert!(!expr.contains("offset_by"), "{expr}");
         })
         .unwrap();
     }

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -7630,6 +7630,36 @@ pub unsafe fn drive() -> u8 {
 }
 
 #[test]
+fn test_mut_cursor_multi_offset_deref_uses_combined_index() {
+    run_test(
+        r#"
+pub unsafe fn write_offset(p: *mut i32, a: isize, b: isize) {
+    *p.offset(a).offset(b) = 1;
+}
+"#,
+        &["(p)[((a) as isize).wrapping_add((b) as isize)] = 1"],
+        &["(p).as_deref_mut().offset_by"],
+    );
+}
+
+#[test]
+fn test_mut_cursor_multi_offset_call_reborrows_once() {
+    run_test(
+        r#"
+pub unsafe fn recurse(items: *mut i32, a: isize, b: isize) {
+    if b == 0 {
+        return;
+    }
+    recurse(items.offset(a).offset(b), a, b - 1);
+    *items = b as i32;
+}
+"#,
+        &["as_deref_mut", ")).offset_by((b) as isize)"],
+        &["as_deref_mut().offset_by((b) as isize)"],
+    );
+}
+
+#[test]
 fn test_opt_boxed_slice_offset_cursor_uses_slice_view_base() {
     run_test(
         r#"

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -1892,10 +1892,13 @@ pub unsafe fn load_word(s: *const State) -> u32 {
 "#,
         &[
             "pub words: crate::slice_cursor::SliceCursorMut<'a, u32>",
-            ".as_slice()",
-            ".offset_by((s.word_index",
+            "(s.words))[((s.word_index as isize))]",
         ],
-        &["let mut _c = ((*s).words);", "*(*s).words.offset"],
+        &[
+            "SliceCursor::new((s.words).as_slice())",
+            "let mut _c = ((*s).words);",
+            "*(*s).words.offset",
+        ],
     );
 }
 
@@ -7266,7 +7269,7 @@ pub unsafe extern "C" fn foo() {
 }
 
 #[test]
-fn test_param_byte_cast_offset_rewrites_to_slice_bytemuck() {
+fn test_param_byte_cast_offset_rewrites_to_slice_cursor() {
     run_test(
         r#"
 #[repr(C)]
@@ -7284,20 +7287,21 @@ pub unsafe extern "C" fn caller(info: *mut Info, offset: i32, value: u32) {
 }
 "#,
         &[
-            "pub unsafe extern \"C\" fn set_type(mut addr: &mut [u32]",
-            "bytemuck::cast_slice_mut::<_,",
-            "u8>(&mut (addr))",
-            "set_type((leaf_addr).as_slice_mut(), offset, value);",
+            "crate::slice_cursor::SliceCursorMut<'_, u32>",
+            "SliceCursorMut::from_raw_parts_mut((addr).as_ptr()",
+            "as *mut u8, 1_000_000",
+            "set_type((leaf_addr).as_deref_mut(), offset, value);",
         ],
         &[
             "pub unsafe extern \"C\" fn set_type(mut addr: *mut u32",
             "*(addr as *mut u8).offset",
+            "bytemuck::cast_slice_mut",
         ],
     );
 }
 
 #[test]
-fn test_raw_local_noop_cast_call_does_not_demote_slice_callee() {
+fn test_raw_local_noop_cast_call_does_not_demote_cursor_callee() {
     run_test(
         r#"
 #[repr(C)]
@@ -7321,14 +7325,16 @@ pub unsafe extern "C" fn caller(v_info: *mut core::ffi::c_void, offset: i32, val
 }
 "#,
         &[
-            "pub unsafe extern \"C\" fn set_type(mut addr: &mut [u32]",
-            "bytemuck::cast_slice_mut::<_,",
-            "u8>(&mut (addr))",
+            "crate::slice_cursor::SliceCursorMut<'_, u32>",
+            "SliceCursorMut::from_raw_parts_mut((addr).as_ptr()",
+            "as *mut u8, 1_000_000",
             "set_type(if (leaf_addr).is_null()",
+            "SliceCursorMut::from_raw_parts_mut((leaf_addr),",
         ],
         &[
             "pub unsafe extern \"C\" fn set_type(mut addr: *mut u32",
             "*(addr as *mut u8).offset",
+            "bytemuck::cast_slice_mut",
         ],
     );
 }

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -1870,9 +1870,15 @@ pub unsafe fn touch(buf: [i32; 4]) -> i32 {
         &[
             "pub p: crate::slice_cursor::SliceCursor<'a, i32>",
             "crate::slice_cursor::SliceCursor::",
+            "(h.p)[",
+            "-1",
+        ],
+        &[
+            "pub p: Option<&'a i32>",
+            "pub p: *const i32",
+            "*h.p.offset",
             ".offset_by((-1) as isize)",
         ],
-        &["pub p: Option<&'a i32>", "pub p: *const i32", "*h.p.offset"],
     );
 }
 
@@ -1892,10 +1898,12 @@ pub unsafe fn load_word(s: *const State) -> u32 {
 "#,
         &[
             "pub words: crate::slice_cursor::SliceCursorMut<'a, u32>",
-            "(s.words))[((s.word_index as isize))]",
+            "(s.words)[",
+            "s.word_index",
         ],
         &[
             "SliceCursor::new((s.words).as_slice())",
+            "(s.words).as_slice()",
             "let mut _c = ((*s).words);",
             "*(*s).words.offset",
         ],
@@ -1919,9 +1927,14 @@ pub unsafe fn load_word(s: *const State) -> u32 {
         &[
             "pub struct State<'a>",
             "pub words: crate::slice_cursor::SliceCursor<'a, u32>",
+            "(s.words)[",
+            "s.word_index",
+        ],
+        &[
+            "pub words: Option<&'a u32>",
+            "*(*s).words.offset",
             ".offset_by((s.word_index",
         ],
-        &["pub words: Option<&'a u32>", "*(*s).words.offset"],
     );
 }
 


### PR DESCRIPTION
## Summary

Previously, parameters that were decided to be both owned and output param were converted into slices. 
This has been updated to check needs_cursor and convert them into cursors instead if a negative index access is present.

Plus, implemented additional cleanups for cursor offset operations.
- Removed duplicated as_mut_ptr and offset calls on cursor. For instance:
```Rust 
      // Before
      buf.as_deref_mut()
          .offset_by(a)
          .as_deref_mut()
          .offset_by(b)
      
      // Improved
      buf.as_deref_mut()
          .offset_by(a)
          .offset_by(b)
```
  
- Removed offset and constructor calls if we read the first element right after the construction 
```Rust 
  // Before
  SliceCursor::new(raw.as_slice()).offset_by(a)[0]
  // After
  raw[a]
```

## Test
regression compared to master

Output changed:
```
Hidden-Tests/B01_organic/convex_clip_lib
Hidden-Tests/B01_organic/png_qsort_lib
Public-Tests/B01_organic/dequantize_granule_lib
Public-Tests/B01_organic/gaussian_kernel_lib
Public-Tests/B01_organic/merge_sort_lib
Public-Tests/B01_organic/synth_pair_lib
Public-Tests/B02_organic/convert_pix_lib
Public-Tests/B02_organic/load_png_mem_lib
Public-Tests/B02_organic/pinflate_lib
Public-Tests/B02_organic/underhanded_c_nuke_lib
Public-Tests/B02_organic/unfilter_lib
Public-Tests/B02_synthetic/dataentry_lib
Public-Tests/B02_synthetic/memmove
Public-Tests/B02_synthetic/mutable_duplication_dag
```

Unsafe feature changes:
22,873 -> 22,881
- memcpy: +2
- memmove: +6
These arise from slice to cursor changes in merge_sort_lib, underhanded_c_nuke_lib, and memmove.

Code examples:
```Rust
// B02_organic/unfilter_lib
// Before
fn unfilter_internal(mut w: i32, mut h: i32, mut bpp: i32,
    mut raw: &mut [u8]) -> i32 {
    let mut raw_idx: isize = 0isize;
    let mut len: i32 = w * bpp;
...
                    (&mut (&mut raw[raw_idx as usize..])[x as usize..])[0] =
                        ((&(&mut raw[raw_idx as usize..])[x as usize..])[0] as i32 +
                                    (&(&mut raw[raw_idx as usize..])[(x - bpp) as usize..])[0]
                                        as i32) as u8;
                    x += 1;
                }
            }
...

}

// After
fn unfilter_internal(mut w: i32, mut h: i32, mut bpp: i32,
    mut raw: crate::slice_cursor::SliceCursorMut<'_, u8>) -> i32 {
    let mut raw_idx: isize = 0isize;
    let mut len: i32 = w * bpp;
...
                    raw[raw_idx.wrapping_add((x as isize))] =
                        (raw[raw_idx.wrapping_add((x as isize))] as i32 +
                                    raw[raw_idx.wrapping_add(((x - bpp) as isize))] as i32) as
                            u8;
                    x += 1;
                }
            }            
            
```

