### PR TITLE
Improve array local provenance analysis (inter-proc, field bases, traces)

### DIFF
--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -885,16 +885,36 @@ fn member_pointer_elements_match_base_element<'tcx>(
                     return local_origin_uses_pointer_arithmetic(body, tcx, info.root);
                 }
                 local_origin_uses_pointer_arithmetic(body, tcx, info.root)
-                    || local_origin_uses_pointer_cast(body, tcx, info.root)
+                    || element_tys_same_size_align(body, tcx, base_element_ty, member_element_ty)
             })
     })
+}
+
+/// true when two element types have the same size, so an index counted in one
+/// unit advances the same number of bytes in the other; alignment is also
+/// required to match as extra conservatism for the rare same-size/different-align
+/// case. both must be sized with a computable layout; otherwise returns false
+/// (fail closed).
+fn element_tys_same_size_align<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    base_element_ty: Ty<'tcx>,
+    member_element_ty: Ty<'tcx>,
+) -> bool {
+    let typing_env = ty::TypingEnv::post_analysis(tcx, body.source.def_id());
+    let (Ok(base_layout), Ok(member_layout)) = (
+        tcx.layout_of(typing_env.as_query_input(base_element_ty)),
+        tcx.layout_of(typing_env.as_query_input(member_element_ty)),
+    ) else {
+        return false;
+    };
+    base_layout.size == member_layout.size && base_layout.align.abi == member_layout.align.abi
 }
 
 #[derive(Clone, Copy)]
 struct PointerOrigin {
     source: Local,
     uses_pointer_arithmetic: bool,
-    uses_pointer_cast: bool,
 }
 
 fn local_origin_uses_pointer_arithmetic<'tcx>(
@@ -923,32 +943,6 @@ fn local_origin_uses_pointer_arithmetic_inner(
     })
 }
 
-fn local_origin_uses_pointer_cast<'tcx>(
-    body: &Body<'tcx>,
-    tcx: TyCtxt<'tcx>,
-    local: Local,
-) -> bool {
-    let origins = pointer_origin_map(body, tcx);
-    let mut visited = FxHashSet::default();
-    local_origin_uses_pointer_cast_inner(local, &origins, &mut visited)
-}
-
-fn local_origin_uses_pointer_cast_inner(
-    local: Local,
-    origins: &FxHashMap<Local, Vec<PointerOrigin>>,
-    visited: &mut FxHashSet<Local>,
-) -> bool {
-    if !visited.insert(local) {
-        return false;
-    }
-    origins.get(&local).is_some_and(|edges| {
-        edges.iter().any(|edge| {
-            edge.uses_pointer_cast
-                || local_origin_uses_pointer_cast_inner(edge.source, origins, visited)
-        })
-    })
-}
-
 fn pointer_origin_map<'tcx>(
     body: &Body<'tcx>,
     tcx: TyCtxt<'tcx>,
@@ -964,19 +958,17 @@ fn pointer_origin_map<'tcx>(
                 Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) => Some(PointerOrigin {
                     source: place.local,
                     uses_pointer_arithmetic: false,
-                    uses_pointer_cast: false,
                 }),
                 Rvalue::Use(Operand::Copy(place) | Operand::Move(place))
                 | Rvalue::CopyForDeref(place) => Some(PointerOrigin {
                     source: place.local,
                     uses_pointer_arithmetic: false,
-                    uses_pointer_cast: false,
                 }),
+                // casts still create a source edge so arithmetic is found through a cast chain
                 Rvalue::Cast(_, Operand::Copy(place) | Operand::Move(place), _) => {
                     Some(PointerOrigin {
                         source: place.local,
                         uses_pointer_arithmetic: false,
-                        uses_pointer_cast: true,
                     })
                 }
                 _ => None,
@@ -1009,7 +1001,6 @@ fn pointer_origin_map<'tcx>(
             origins.entry(dst).or_default().push(PointerOrigin {
                 source: place.local,
                 uses_pointer_arithmetic: is_pointer_arithmetic(tcx, def_id, &name),
-                uses_pointer_cast: false,
             });
         }
     }

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -24,6 +24,7 @@ use rustc_span::{def_id::DefId, source_map::Spanned};
 use crate::{
     analyses::{
         liveness::MaybeLiveLocals,
+        mir::CallGraphPostOrder,
         mir_variable_grouping::SourceVarGroups,
         type_qualifier::foster::mutability::{Mutability as PtrMut, MutabilityResult},
     },
@@ -81,7 +82,7 @@ pub enum BaseId {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum UnknownReason {
     NullLike,
     ConstantPointer,
@@ -115,6 +116,44 @@ pub struct PointerFlowGraph {
 #[derive(Clone, Debug, Default)]
 pub struct ProvenanceResult {
     pub reachable_bases: FxHashMap<PfgNode, FxHashSet<BaseId>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct FunctionSummary {
+    return_flows: Vec<SummaryFlow>,
+    arg_write_flows: Vec<ArgWriteFlow>,
+    unknown_return_slots: Vec<Vec<SlotPathElem>>,
+    unknown_arg_writes: Vec<ArgWriteTarget>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct SummaryFlow {
+    dst_return_path: Vec<SlotPathElem>,
+    src: SummarySource,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct ArgWriteFlow {
+    dst_arg_index: usize,
+    dst_path: Vec<SlotPathElem>,
+    src: SummarySource,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct ArgWriteTarget {
+    arg_index: usize,
+    path: Vec<SlotPathElem>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum SummarySource {
+    ParamSlot {
+        arg_index: usize,
+        path: Vec<SlotPathElem>,
+    },
+    Unknown(UnknownReason),
+    OpaqueReturn,
+    HeapAlloc,
 }
 
 #[derive(Clone, Debug)]
@@ -166,7 +205,7 @@ pub enum QualifierKey {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SlotPathElem {
     Pointee,
     Field(FieldIdx),
@@ -235,6 +274,26 @@ impl ProvenanceResult {
         });
         let unique = iter.next()?.clone();
         iter.next().is_none().then_some(unique)
+    }
+}
+
+impl FunctionSummary {
+    fn is_empty(&self) -> bool {
+        self.return_flows.is_empty()
+            && self.arg_write_flows.is_empty()
+            && self.unknown_return_slots.is_empty()
+            && self.unknown_arg_writes.is_empty()
+    }
+
+    fn normalize(&mut self) {
+        self.return_flows.sort();
+        self.return_flows.dedup();
+        self.arg_write_flows.sort();
+        self.arg_write_flows.dedup();
+        self.unknown_return_slots.sort();
+        self.unknown_return_slots.dedup();
+        self.unknown_arg_writes.sort();
+        self.unknown_arg_writes.dedup();
     }
 }
 
@@ -312,24 +371,91 @@ pub fn array_local_provenance_analysis(
     input: &RustProgram<'_>,
     alloc_fns: &FxHashSet<LocalDefId>,
 ) -> FxHashMap<LocalDefId, ArrayLocalProvenance> {
-    input
-        .functions
-        .iter()
-        .map(|&def_id| {
-            let body = input
-                .tcx
-                .mir_drops_elaborated_and_const_checked(def_id)
-                .borrow();
-            (def_id, analyze_body(input.tcx, def_id, &body, alloc_fns))
-        })
-        .collect()
+    let call_graph = CallGraphPostOrder::new(input);
+    let function_set: FxHashSet<LocalDefId> = input.functions.iter().copied().collect();
+    let mut summaries: FxHashMap<LocalDefId, FunctionSummary> = FxHashMap::default();
+    let mut results: FxHashMap<LocalDefId, ArrayLocalProvenance> = FxHashMap::default();
+
+    for scc in call_graph.sccs() {
+        let local_scc: Vec<LocalDefId> = scc
+            .iter()
+            .filter_map(|def_id| def_id.as_local())
+            .filter(|def_id| function_set.contains(def_id))
+            .collect();
+        if local_scc.is_empty() {
+            continue;
+        }
+
+        for &def_id in &local_scc {
+            summaries.entry(def_id).or_default();
+        }
+
+        let mut stabilized = false;
+        for _ in 0..32 {
+            let mut changed = false;
+            for &def_id in &local_scc {
+                let body = input
+                    .tcx
+                    .mir_drops_elaborated_and_const_checked(def_id)
+                    .borrow();
+                let result = analyze_body_with_summaries(
+                    input.tcx,
+                    def_id,
+                    &body,
+                    alloc_fns,
+                    Some(&summaries),
+                );
+                let mut summary = build_function_summary(input.tcx, def_id, &body, &result);
+                summary.normalize();
+                changed |= summaries.get(&def_id) != Some(&summary);
+                summaries.insert(def_id, summary);
+                results.insert(def_id, result);
+            }
+            if !changed {
+                stabilized = true;
+                break;
+            }
+        }
+
+        if !stabilized {
+            for &def_id in &local_scc {
+                summaries.remove(&def_id);
+            }
+            for &def_id in &local_scc {
+                let body = input
+                    .tcx
+                    .mir_drops_elaborated_and_const_checked(def_id)
+                    .borrow();
+                let result = analyze_body_with_summaries(
+                    input.tcx,
+                    def_id,
+                    &body,
+                    alloc_fns,
+                    Some(&summaries),
+                );
+                results.insert(def_id, result);
+            }
+        }
+    }
+
+    results
 }
 
 pub fn analyze_body<'tcx>(
     tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+    body: &Body<'tcx>,
+    alloc_fns: &FxHashSet<LocalDefId>,
+) -> ArrayLocalProvenance {
+    analyze_body_with_summaries(tcx, def_id, body, alloc_fns, None)
+}
+
+fn analyze_body_with_summaries<'tcx>(
+    tcx: TyCtxt<'tcx>,
     _def_id: LocalDefId,
     body: &Body<'tcx>,
     alloc_fns: &FxHashSet<LocalDefId>,
+    callee_summaries: Option<&FxHashMap<LocalDefId, FunctionSummary>>,
 ) -> ArrayLocalProvenance {
     let slot_table = SlotTable::new(body, tcx);
     let rhs_map = build_rhs_map(body, tcx);
@@ -337,6 +463,7 @@ pub fn analyze_body<'tcx>(
         tcx,
         body,
         alloc_fns,
+        callee_summaries,
         slot_table: &slot_table,
         graph: PointerFlowGraph::default(),
         rhs_map,
@@ -1261,18 +1388,7 @@ fn location_writes_through_dependent_member<'tcx>(
 }
 
 fn slot_path_from_place<'tcx>(place: Place<'tcx>) -> Option<Vec<SlotPathElem>> {
-    place
-        .projection
-        .iter()
-        .map(|elem| match elem {
-            ProjectionElem::Deref => Some(SlotPathElem::Pointee),
-            ProjectionElem::Field(field, _) => Some(SlotPathElem::Field(field)),
-            ProjectionElem::Index(_)
-            | ProjectionElem::ConstantIndex { .. }
-            | ProjectionElem::Subslice { .. } => Some(SlotPathElem::Element),
-            _ => None,
-        })
-        .collect()
+    slot_path_from_projection(place.projection.as_ref())
 }
 
 fn loc_range_overlaps_base_locs(
@@ -1737,6 +1853,7 @@ struct Collector<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     body: &'a Body<'tcx>,
     alloc_fns: &'a FxHashSet<LocalDefId>,
+    callee_summaries: Option<&'a FxHashMap<LocalDefId, FunctionSummary>>,
     slot_table: &'a SlotTable,
     graph: PointerFlowGraph,
     rhs_map: FxHashMap<Local, Vec<AssignRhs<'tcx>>>,
@@ -1883,6 +2000,149 @@ impl<'tcx> Collector<'_, 'tcx> {
         }
     }
 
+    fn instantiate_summary_source_node(
+        &self,
+        source: &SummarySource,
+        args: &[Spanned<Operand<'tcx>>],
+        location: Location,
+    ) -> Option<PfgNode> {
+        match source {
+            SummarySource::ParamSlot { arg_index, path } => {
+                let arg = args.get(*arg_index)?;
+                let place = operand_place(&arg.node)?;
+                self.place_path_node(place, path)
+            }
+            SummarySource::Unknown(reason) => {
+                let base = BaseId::Unknown {
+                    location,
+                    reason: reason.clone(),
+                };
+                Some(PfgNode::Base(base))
+            }
+            SummarySource::OpaqueReturn => Some(PfgNode::Base(BaseId::OpaqueReturn { location })),
+            SummarySource::HeapAlloc => Some(PfgNode::Base(BaseId::HeapAlloc { location })),
+        }
+    }
+
+    fn place_path_node(&self, place: Place<'tcx>, path: &[SlotPathElem]) -> Option<PfgNode> {
+        let slots = self.slot_table.place_slots(place, self.body, self.tcx)?;
+        for slot in slots {
+            let info = self.slot_table.slot_infos.get(slot)?;
+            if info.path.ends_with(path) {
+                return Some(PfgNode::Slot(slot));
+            }
+        }
+        None
+    }
+
+    fn argument_path_node(
+        &self,
+        args: &[Spanned<Operand<'tcx>>],
+        arg_index: usize,
+        path: &[SlotPathElem],
+    ) -> Option<PfgNode> {
+        let arg = args.get(arg_index)?;
+        let place = operand_place(&arg.node)?;
+        self.place_path_node(place, path)
+    }
+
+    fn destination_path_node(
+        &self,
+        destination: Place<'tcx>,
+        path: &[SlotPathElem],
+    ) -> Option<PfgNode> {
+        self.place_path_node(destination, path)
+    }
+
+    fn should_skip_unknown_memory_load_on_node(&self, dst: &PfgNode) -> bool {
+        matches!(dst, PfgNode::Slot(slot) if self.direct_param_slots.contains(slot))
+    }
+
+    fn collect_summary_call(
+        &mut self,
+        callee: LocalDefId,
+        args: &[Spanned<Operand<'tcx>>],
+        destination: Place<'tcx>,
+        location: Location,
+    ) -> bool {
+        let Some(summary) = self
+            .callee_summaries
+            .and_then(|summaries| summaries.get(&callee))
+            .cloned()
+        else {
+            return false;
+        };
+        if summary.is_empty() {
+            return false;
+        }
+
+        let mut return_edges = Vec::new();
+        let mut arg_write_edges = Vec::new();
+        let mut unknown_returns = Vec::new();
+        let mut unknown_arg_writes = Vec::new();
+
+        for flow in &summary.return_flows {
+            let Some(src) = self.instantiate_summary_source_node(&flow.src, args, location) else {
+                return false;
+            };
+            let Some(dst) = self.destination_path_node(destination, &flow.dst_return_path) else {
+                return false;
+            };
+            return_edges.push((src, dst));
+        }
+
+        for flow in &summary.arg_write_flows {
+            let Some(src) = self.instantiate_summary_source_node(&flow.src, args, location) else {
+                return false;
+            };
+            let Some(dst) = self.argument_path_node(args, flow.dst_arg_index, &flow.dst_path)
+            else {
+                return false;
+            };
+            arg_write_edges.push((src, dst));
+        }
+
+        for path in &summary.unknown_return_slots {
+            let Some(dst) = self.destination_path_node(destination, path) else {
+                return false;
+            };
+            unknown_returns.push(dst);
+        }
+
+        for target in &summary.unknown_arg_writes {
+            let Some(dst) = self.argument_path_node(args, target.arg_index, &target.path) else {
+                return false;
+            };
+            unknown_arg_writes.push(dst);
+        }
+
+        for (src, dst) in return_edges.into_iter().chain(arg_write_edges) {
+            if let PfgNode::Base(base) = &src {
+                self.graph.add_base(base.clone());
+            }
+            self.graph.add_edge(src, dst);
+        }
+
+        for dst in unknown_returns {
+            self.graph.add_base_edge(BaseId::OpaqueReturn { location }, dst);
+        }
+
+        for dst in unknown_arg_writes {
+            if self.should_skip_unknown_memory_load_on_node(&dst) {
+                continue;
+            }
+            self.graph.add_base_edge(
+                BaseId::Unknown {
+                    location,
+                    reason: UnknownReason::UnsupportedMemoryLoad,
+                },
+                dst,
+            );
+        }
+
+        true
+    }
+
     fn collect_terminator(&mut self, block: BasicBlock, location: Location) {
         let terminator = self.body.basic_blocks[block].terminator();
         let TerminatorKind::Call {
@@ -1896,6 +2156,13 @@ impl<'tcx> Collector<'_, 'tcx> {
         };
 
         let call = call_name(self.tcx, func);
+
+        if let Some((def_id, _name)) = call.as_ref()
+            && let Some(local_def_id) = def_id.as_local()
+            && self.collect_summary_call(local_def_id, args, *destination, location)
+        {
+            return;
+        }
 
         if !call
             .as_ref()
@@ -2198,7 +2465,7 @@ impl<'tcx> Collector<'_, 'tcx> {
             if self.slot_table.slot_infos[slot].depth == 0 {
                 continue;
             }
-            if self.direct_param_slots.contains(&slot) {
+            if self.should_skip_unknown_memory_load_on_node(&PfgNode::Slot(slot)) {
                 continue;
             }
             self.graph.add_base_edge(
@@ -2822,6 +3089,334 @@ fn solve_reachable_bases(graph: &PointerFlowGraph) -> ProvenanceResult {
     }
 
     ProvenanceResult { reachable_bases }
+}
+
+fn summary_source_for_base(base: &BaseId, result: &ArrayLocalProvenance) -> SummarySource {
+    match base {
+        BaseId::Param { local, slot } => {
+            let arg_index = param_index_for_local(*local).unwrap_or(0);
+            let path = result
+                .slot_table
+                .slot_infos
+                .get(*slot)
+                .map(|info| info.path.clone())
+                .unwrap_or_default();
+            SummarySource::ParamSlot { arg_index, path }
+        }
+        BaseId::HeapAlloc { .. } => SummarySource::HeapAlloc,
+        BaseId::OpaqueReturn { .. } => SummarySource::OpaqueReturn,
+        BaseId::Unknown { reason, .. } => SummarySource::Unknown(reason.clone()),
+        BaseId::IntToPtr { .. } => SummarySource::Unknown(UnknownReason::ConstantPointer),
+        BaseId::LocalArray { .. } | BaseId::LocalScalar { .. } | BaseId::RawBorrow { .. } => {
+            SummarySource::Unknown(UnknownReason::UnsupportedMemoryLoad)
+        }
+    }
+}
+
+fn param_index_for_local(local: Local) -> Option<usize> {
+    let index = local.index();
+    (index > 0).then_some(index - 1)
+}
+
+fn slot_path_from_projection<V, T>(
+    projection: &[ProjectionElem<V, T>],
+) -> Option<Vec<SlotPathElem>> {
+    projection
+        .iter()
+        .map(|elem| match elem {
+            ProjectionElem::Deref => Some(SlotPathElem::Pointee),
+            ProjectionElem::Field(field, _) => Some(SlotPathElem::Field(*field)),
+            ProjectionElem::Index(_)
+            | ProjectionElem::ConstantIndex { .. }
+            | ProjectionElem::Subslice { .. } => Some(SlotPathElem::Element),
+            _ => None,
+        })
+        .collect()
+}
+
+fn is_self_arg_target_base(
+    base: &BaseId,
+    target: &ArgWriteTarget,
+    result: &ArrayLocalProvenance,
+) -> bool {
+    matches!(
+        base,
+        BaseId::Param {
+            local,
+            slot,
+        } if param_index_for_local(*local) == Some(target.arg_index)
+            && result
+                .slot_table
+                .slot_infos
+                .get(*slot)
+                .is_some_and(|info| info.path == target.path)
+    )
+}
+
+fn return_slot_paths<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    result: &ArrayLocalProvenance,
+) -> Vec<(SlotIdx, Vec<SlotPathElem>)> {
+    result
+        .slot_table
+        .place_slots(Place::return_place(), body, tcx)
+        .map(|slots| {
+            slots
+                .filter_map(|slot| {
+                    result
+                        .slot_table
+                        .slot_infos
+                        .get(slot)
+                        .map(|info| (slot, info.path.clone()))
+                })
+                .collect()
+    })
+    .unwrap_or_default()
+}
+
+fn boundary_arg_write_targets_for_place<'tcx>(
+    place: Place<'tcx>,
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    result: &ArrayLocalProvenance,
+) -> Vec<(ArgWriteTarget, SlotIdx)> {
+    let Some(deref_index) = place
+        .projection
+        .iter()
+        .position(|elem| matches!(elem, ProjectionElem::Deref))
+    else {
+        return vec![];
+    };
+
+    let prefix_projection = &place.projection[..deref_index];
+    if slot_path_from_projection(prefix_projection).is_none() {
+        return vec![];
+    }
+
+    let prefix_place = Place::from(place.local).project_deeper(prefix_projection, tcx);
+    let Some(prefix_slot) = result.slot_table.place_head_slot(prefix_place, body, tcx) else {
+        return vec![];
+    };
+
+    let Some(written_slots) = result.slot_table.place_slots(place, body, tcx) else {
+        return vec![];
+    };
+
+    boundary_param_write_targets_for_slots(prefix_slot, written_slots, result)
+}
+
+fn boundary_param_write_targets_for_slots(
+    prefix_slot: SlotIdx,
+    written_slots: impl IntoIterator<Item = SlotIdx>,
+    result: &ArrayLocalProvenance,
+) -> Vec<(ArgWriteTarget, SlotIdx)> {
+    let Some(prefix_path) = result
+        .slot_table
+        .slot_infos
+        .get(prefix_slot)
+        .map(|info| info.path.clone())
+    else {
+        return vec![];
+    };
+    let Some(bases) = result.provenance.reachable_bases.get(&PfgNode::Slot(prefix_slot)) else {
+        return vec![];
+    };
+
+    let mut targets = vec![];
+    for slot in written_slots {
+        let Some(info) = result.slot_table.slot_infos.get(slot) else {
+            continue;
+        };
+        let Some(relative_path) = info.path.as_slice().strip_prefix(prefix_path.as_slice()) else {
+            continue;
+        };
+        if relative_path.is_empty() {
+            continue;
+        }
+        for base in bases {
+            let BaseId::Param { local, slot: base_slot } = base else {
+                continue;
+            };
+            let Some(arg_index) = param_index_for_local(*local) else {
+                continue;
+            };
+            let Some(base_path) = result
+                .slot_table
+                .slot_infos
+                .get(*base_slot)
+                .map(|info| info.path.clone())
+            else {
+                continue;
+            };
+            let mut target_path = base_path;
+            target_path.extend(relative_path.iter().cloned());
+            targets.push((
+                ArgWriteTarget {
+                    arg_index,
+                    path: target_path,
+                },
+                slot,
+            ));
+        }
+    }
+
+    targets
+}
+
+fn boundary_unknown_call_arg_write_targets_for_place<'tcx>(
+    place: Place<'tcx>,
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    result: &ArrayLocalProvenance,
+) -> Vec<ArgWriteTarget> {
+    let Some(place_slots) = result.slot_table.place_slots(place, body, tcx) else {
+        return vec![];
+    };
+    let Some(prefix_slot) = place_slots.clone().next() else {
+        return vec![];
+    };
+
+    boundary_param_write_targets_for_slots(
+        prefix_slot,
+        place_slots.skip(1).filter(|slot| {
+            result
+                .slot_table
+                .slot_infos
+                .get(*slot)
+                .is_some_and(|info| info.depth > 0)
+        }),
+        result,
+    )
+    .into_iter()
+    .map(|(target, _slot)| target)
+    .collect()
+}
+
+fn boundary_arg_write_targets<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    result: &ArrayLocalProvenance,
+) -> Vec<(ArgWriteTarget, SlotIdx)> {
+    let mut targets = vec![];
+
+    for (_block, block_data) in body.basic_blocks.iter_enumerated() {
+        for statement in &block_data.statements {
+            let StatementKind::Assign(box (place, _)) = &statement.kind else {
+                continue;
+            };
+            targets.extend(boundary_arg_write_targets_for_place(*place, body, tcx, result));
+        }
+    }
+
+    targets
+}
+
+fn boundary_unknown_arg_write_targets<'tcx>(
+    body: &Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    result: &ArrayLocalProvenance,
+) -> Vec<ArgWriteTarget> {
+    let mut targets = vec![];
+
+    for (_block, block_data) in body.basic_blocks.iter_enumerated() {
+        let Some(terminator) = &block_data.terminator else {
+            continue;
+        };
+        let TerminatorKind::Call { func, args, .. } = &terminator.kind else {
+            continue;
+        };
+        if call_name(tcx, func)
+            .as_ref()
+            .is_some_and(|(def_id, name)| call_no_writes(tcx, *def_id, name))
+        {
+            continue;
+        }
+
+        for arg in args {
+            let Some(place) = operand_place(&arg.node) else {
+                continue;
+            };
+            let arg_ty = place.ty(body, tcx).ty;
+            if let Some(inner) = arg_ty.builtin_deref(true)
+                && count_slots(inner, tcx, &mut FxHashSet::default()) > 0
+            {
+                targets.extend(boundary_unknown_call_arg_write_targets_for_place(
+                    place,
+                    body,
+                    tcx,
+                    result,
+                ));
+            }
+        }
+    }
+
+    targets
+}
+
+fn build_function_summary<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    _def_id: LocalDefId,
+    body: &Body<'tcx>,
+    result: &ArrayLocalProvenance,
+) -> FunctionSummary {
+    let mut summary = FunctionSummary::default();
+
+    for (slot, path) in return_slot_paths(body, tcx, result) {
+        let node = PfgNode::Slot(slot);
+        let Some(bases) = result.provenance.reachable_bases.get(&node) else {
+            summary.unknown_return_slots.push(path);
+            continue;
+        };
+        let mut emitted = false;
+        for base in bases {
+            let src = summary_source_for_base(base, result);
+            summary.return_flows.push(SummaryFlow {
+                dst_return_path: path.clone(),
+                src,
+            });
+            emitted = true;
+        }
+        if !emitted {
+            summary.unknown_return_slots.push(path);
+        }
+    }
+
+    for (target, written_slot) in boundary_arg_write_targets(body, tcx, result) {
+        let Some(bases) = result
+            .provenance
+            .reachable_bases
+            .get(&PfgNode::Slot(written_slot))
+        else {
+            summary.unknown_arg_writes.push(target);
+            continue;
+        };
+
+        let mut emitted = false;
+        for base in bases {
+            if is_self_arg_target_base(base, &target, result) {
+                continue;
+            }
+            let src = summary_source_for_base(base, result);
+            summary.arg_write_flows.push(ArgWriteFlow {
+                dst_arg_index: target.arg_index,
+                dst_path: target.path.clone(),
+                src,
+            });
+            emitted = true;
+        }
+
+        if !emitted {
+            summary.unknown_arg_writes.push(target);
+        }
+    }
+
+    for target in boundary_unknown_arg_write_targets(body, tcx, result) {
+        summary.unknown_arg_writes.push(target);
+    }
+
+    summary.normalize();
+    summary
 }
 
 fn classify_base(base: &BaseId) -> BaseClassification {

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -120,10 +120,18 @@ pub struct ProvenanceResult {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct FunctionSummary {
+    completeness: SummaryCompleteness,
     return_flows: Vec<SummaryFlow>,
     arg_write_flows: Vec<ArgWriteFlow>,
     unknown_return_slots: Vec<Vec<SlotPathElem>>,
     unknown_arg_writes: Vec<ArgWriteTarget>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum SummaryCompleteness {
+    Complete,
+    #[default]
+    Incomplete,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -163,6 +171,27 @@ pub struct ArrayLocalProvenance {
     pub graph: PointerFlowGraph,
     pub provenance: ProvenanceResult,
     pub base_classifications: FxHashMap<BaseId, BaseClassification>,
+    pub(crate) call_effects: FxHashMap<Location, CallEffects>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct InstantiatedArgWrite {
+    pub(crate) dst_arg_index: usize,
+    pub(crate) destination: SlotIdx,
+    pub(crate) sources: Vec<PfgNode>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct InstantiatedUnknownArgWrite {
+    pub(crate) dst_arg_index: usize,
+    pub(crate) destination: SlotIdx,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct CallEffects {
+    pub(crate) complete: bool,
+    pub(crate) writes: Vec<InstantiatedArgWrite>,
+    pub(crate) unknown_writes: Vec<InstantiatedUnknownArgWrite>,
 }
 
 pub struct RewriteGroup {
@@ -177,6 +206,22 @@ pub struct RewriteGroup {
     /// true when the base slot is written via direct (trackable) assignments only
     /// while members are live; the rewriter must use index-tracking for this group.
     pub index_tracked: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PreservedBaseCall {
+    pub(crate) location: Location,
+    pub(crate) affected_arguments: Vec<usize>,
+    pub(crate) writes_base_binding: bool,
+}
+
+pub(crate) enum RewriteGroupStatus {
+    Ready(RewriteGroup),
+    #[allow(dead_code)]
+    PreservedAcrossCalls {
+        group: RewriteGroup,
+        calls: Vec<PreservedBaseCall>,
+    },
 }
 
 #[derive(Clone, Debug, Default)]
@@ -278,11 +323,8 @@ impl ProvenanceResult {
 }
 
 impl FunctionSummary {
-    fn is_empty(&self) -> bool {
-        self.return_flows.is_empty()
-            && self.arg_write_flows.is_empty()
-            && self.unknown_return_slots.is_empty()
-            && self.unknown_arg_writes.is_empty()
+    fn is_complete(&self) -> bool {
+        self.completeness == SummaryCompleteness::Complete
     }
 
     fn normalize(&mut self) {
@@ -468,9 +510,11 @@ fn analyze_body_with_summaries<'tcx>(
         graph: PointerFlowGraph::default(),
         rhs_map,
         direct_param_slots: FxHashSet::default(),
+        call_effects: FxHashMap::default(),
     };
     collector.collect();
     let graph = collector.graph;
+    let call_effects = collector.call_effects;
     let provenance = solve_reachable_bases(&graph);
     let base_classifications = graph
         .bases
@@ -483,6 +527,7 @@ fn analyze_body_with_summaries<'tcx>(
         graph,
         provenance,
         base_classifications,
+        call_effects,
     }
 }
 
@@ -637,6 +682,22 @@ pub fn select_rewrite_groups<'a, 'tcx>(
     def_id: LocalDefId,
     context: RewriteSelectionContext<'a, 'tcx>,
 ) -> Vec<RewriteGroup> {
+    classify_rewrite_groups(provenance, body, mutability_result, def_id, context)
+        .into_iter()
+        .filter_map(|status| match status {
+            RewriteGroupStatus::Ready(group) => Some(group),
+            RewriteGroupStatus::PreservedAcrossCalls { .. } => None,
+        })
+        .collect()
+}
+
+pub(crate) fn classify_rewrite_groups<'a, 'tcx>(
+    provenance: &ArrayLocalProvenance,
+    body: &Body<'tcx>,
+    mutability_result: &MutabilityResult,
+    def_id: LocalDefId,
+    context: RewriteSelectionContext<'a, 'tcx>,
+) -> Vec<RewriteGroupStatus> {
     let mut groups = vec![];
     let live_after = compute_live_after_by_location(context.tcx, body);
 
@@ -757,19 +818,31 @@ pub fn select_rewrite_groups<'a, 'tcx>(
             &member_roots,
             &stability_context,
         );
-        let index_tracked = match stability {
-            SelectionStability::Stable => false,
-            SelectionStability::IndexTracked => true,
+        let (index_tracked, preserved_calls) = match stability {
+            SelectionStability::Stable => (false, vec![]),
+            SelectionStability::IndexTracked => (true, vec![]),
+            SelectionStability::PreservedAcrossCalls {
+                index_tracked,
+                calls,
+            } => (index_tracked, calls),
             SelectionStability::Unstable => continue,
         };
 
-        groups.push(RewriteGroup {
+        let group = RewriteGroup {
             base: base.clone(),
             base_local,
             base_slot_offset,
             members,
             index_tracked,
-        });
+        };
+        if preserved_calls.is_empty() {
+            groups.push(RewriteGroupStatus::Ready(group));
+        } else {
+            groups.push(RewriteGroupStatus::PreservedAcrossCalls {
+                group,
+                calls: preserved_calls,
+            });
+        }
     }
 
     groups
@@ -1017,6 +1090,11 @@ enum SelectionStability {
     /// base slot written only via direct (trackable) assignments while members live
     /// — select with `index_tracked = true`.
     IndexTracked,
+    /// all relevant summarized calls preserve the group's base.
+    PreservedAcrossCalls {
+        index_tracked: bool,
+        calls: Vec<PreservedBaseCall>,
+    },
     /// aliased or call-based writes present — reject.
     Unstable,
 }
@@ -1054,14 +1132,110 @@ fn is_base_stable_for_selection(
                 SelectionStability::Unstable
             }
         }
-        BaseId::Param { slot, .. } => {
-            is_param_base_stable_for_selection(base_local, *slot, members, member_roots, context)
-        }
+        BaseId::Param { slot, .. } => is_param_base_stable_for_selection(
+            base,
+            base_local,
+            *slot,
+            members,
+            member_roots,
+            context,
+        ),
         _ => SelectionStability::Unstable,
     }
 }
 
+fn preserved_base_call<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    location: Location,
+    base: &BaseId,
+    base_local: Local,
+    member_roots: &FxHashSet<Local>,
+    body: &Body<'tcx>,
+    provenance: &ArrayLocalProvenance,
+) -> Option<Option<PreservedBaseCall>> {
+    let effects = provenance.call_effects.get(&location)?;
+    if !effects.complete {
+        return None;
+    }
+
+    let block_data = &body.basic_blocks[location.block];
+    if location.statement_index != block_data.statements.len() {
+        return None;
+    }
+    let TerminatorKind::Call { args, .. } = &block_data.terminator.as_ref()?.kind else {
+        return None;
+    };
+
+    let target_root = |arg_index: usize| -> Option<Local> {
+        let place = operand_place(&args.get(arg_index)?.node)?;
+        let head_slot = provenance
+            .slot_table
+            .place_slots(place, body, tcx)?
+            .next()?;
+        let bases = provenance
+            .provenance
+            .reachable_bases
+            .get(&PfgNode::Slot(head_slot))?;
+        let mut roots = FxHashSet::default();
+        for base in bases {
+            let BaseId::RawBorrow {
+                target: Some(target),
+                ..
+            } = base
+            else {
+                return None;
+            };
+            roots.insert(provenance.slot_table.slot_infos.get(*target)?.root);
+        }
+        (roots.len() == 1)
+            .then(|| roots.into_iter().next())
+            .flatten()
+    };
+
+    let mut affected_arguments = FxHashSet::default();
+    let mut writes_base_binding = false;
+    for write in &effects.writes {
+        let root = target_root(write.dst_arg_index)?;
+        let relevant = root == base_local || member_roots.contains(&root);
+        if !relevant {
+            continue;
+        }
+        if write.sources.is_empty()
+            || write.sources.iter().any(|source| {
+                let source_base = match source {
+                    PfgNode::Base(source_base) => Some(source_base.clone()),
+                    _ => provenance.provenance.unique_non_null_base(source),
+                };
+                source_base.as_ref() != Some(base)
+            })
+        {
+            return None;
+        }
+        affected_arguments.insert(write.dst_arg_index);
+        writes_base_binding |= root == base_local;
+    }
+
+    for write in &effects.unknown_writes {
+        let root = target_root(write.dst_arg_index)?;
+        if root == base_local || member_roots.contains(&root) {
+            return None;
+        }
+    }
+
+    if affected_arguments.is_empty() {
+        return Some(None);
+    }
+    let mut affected_arguments: Vec<_> = affected_arguments.into_iter().collect();
+    affected_arguments.sort_unstable();
+    Some(Some(PreservedBaseCall {
+        location,
+        affected_arguments,
+        writes_base_binding,
+    }))
+}
+
 fn is_param_base_stable_for_selection(
+    base: &BaseId,
     base_local: Local,
     base_slot: SlotIdx,
     members: &[SlotIdx],
@@ -1073,6 +1247,11 @@ fn is_param_base_stable_for_selection(
     if dependent_locals.is_empty() {
         return SelectionStability::Stable;
     }
+    let all_member_roots: FxHashSet<Local> = members
+        .iter()
+        .filter_map(|slot| context.provenance.slot_table.slot_infos.get(*slot))
+        .map(|info| info.root)
+        .collect();
 
     let base_path_contains_pointee = slot_path_contains_pointee(context.provenance, base_slot);
 
@@ -1090,9 +1269,13 @@ fn is_param_base_stable_for_selection(
     };
 
     let mut has_direct_write = false;
+    let mut preserved_calls = vec![];
 
     for (block, block_data) in context.body.basic_blocks.iter_enumerated() {
-        for statement_index in 0..block_data.statements.len() {
+        for statement_index in 0..=block_data.statements.len() {
+            if statement_index == block_data.statements.len() && block_data.terminator.is_none() {
+                continue;
+            }
             let location = Location {
                 block,
                 statement_index,
@@ -1119,6 +1302,24 @@ fn is_param_base_stable_for_selection(
                 ) {
                     continue;
                 } else {
+                    if context.provenance.call_effects.contains_key(&location) {
+                        match preserved_base_call(
+                            context.tcx,
+                            location,
+                            base,
+                            base_local,
+                            &all_member_roots,
+                            context.body,
+                            context.provenance,
+                        ) {
+                            None => return SelectionStability::Unstable,
+                            Some(None) => continue,
+                            Some(Some(call)) => {
+                                preserved_calls.push(call);
+                                continue;
+                            }
+                        }
+                    }
                     // only run alias/call sub-checks when the direct check did not
                     // already account for the write; Andersen's all_writes includes
                     // return-value assignments so it would double-count direct writes.
@@ -1147,62 +1348,14 @@ fn is_param_base_stable_for_selection(
                 }
             }
         }
-
-        if block_data.terminator.is_some() {
-            let location = Location {
-                block,
-                statement_index: block_data.statements.len(),
-            };
-            let any_member_live = context
-                .live_after
-                .get(&location)
-                .is_some_and(|live| dependent_locals.iter().any(|local| live.contains(*local)));
-            if any_member_live {
-                let is_direct = direct_write_overlaps_slot(
-                    context.body,
-                    context.tcx,
-                    context.provenance,
-                    location,
-                    base_slot,
-                );
-                if is_direct {
-                    has_direct_write = true;
-                } else if location_writes_through_dependent_member(
-                    context.body,
-                    context.tcx,
-                    location,
-                    &dependent_locals,
-                ) {
-                    continue;
-                } else {
-                    let is_alias = base_locs.as_ref().is_some_and(|base_locs| {
-                        location_writes_base_storage(
-                            context.points_to,
-                            context.def_id,
-                            location,
-                            base_locs,
-                        )
-                    });
-                    let is_call = base_locs.as_ref().is_some_and(|base_locs| {
-                        call_may_write_base_storage(
-                            context.points_to,
-                            context.body,
-                            context.tcx,
-                            context.provenance,
-                            context.def_id,
-                            location,
-                            base_locs,
-                        )
-                    });
-                    if is_alias || is_call {
-                        return SelectionStability::Unstable;
-                    }
-                }
-            }
-        }
     }
 
-    if has_direct_write {
+    if !preserved_calls.is_empty() {
+        SelectionStability::PreservedAcrossCalls {
+            index_tracked: has_direct_write,
+            calls: preserved_calls,
+        }
+    } else if has_direct_write {
         SelectionStability::IndexTracked
     } else {
         SelectionStability::Stable
@@ -1858,6 +2011,7 @@ struct Collector<'a, 'tcx> {
     graph: PointerFlowGraph,
     rhs_map: FxHashMap<Local, Vec<AssignRhs<'tcx>>>,
     direct_param_slots: FxHashSet<SlotIdx>,
+    call_effects: FxHashMap<Location, CallEffects>,
 }
 
 impl<'tcx> Collector<'_, 'tcx> {
@@ -2072,12 +2226,12 @@ impl<'tcx> Collector<'_, 'tcx> {
         else {
             return false;
         };
-        if summary.is_empty() {
+        if !summary.is_complete() {
             return false;
         }
 
         let mut return_edges = Vec::new();
-        let mut arg_write_edges = Vec::new();
+        let mut arg_write_edges: FxHashMap<(usize, SlotIdx), Vec<PfgNode>> = FxHashMap::default();
         let mut unknown_returns = Vec::new();
         let mut unknown_arg_writes = Vec::new();
 
@@ -2099,7 +2253,13 @@ impl<'tcx> Collector<'_, 'tcx> {
             else {
                 return false;
             };
-            arg_write_edges.push((src, dst));
+            let PfgNode::Slot(destination) = dst else {
+                return false;
+            };
+            arg_write_edges
+                .entry((flow.dst_arg_index, destination))
+                .or_default()
+                .push(src);
         }
 
         for path in &summary.unknown_return_slots {
@@ -2113,21 +2273,46 @@ impl<'tcx> Collector<'_, 'tcx> {
             let Some(dst) = self.argument_path_node(args, target.arg_index, &target.path) else {
                 return false;
             };
-            unknown_arg_writes.push(dst);
+            let PfgNode::Slot(destination) = dst else {
+                return false;
+            };
+            unknown_arg_writes.push(InstantiatedUnknownArgWrite {
+                dst_arg_index: target.arg_index,
+                destination,
+            });
         }
 
-        for (src, dst) in return_edges.into_iter().chain(arg_write_edges) {
+        for (src, dst) in return_edges {
             if let PfgNode::Base(base) = &src {
                 self.graph.add_base(base.clone());
             }
             self.graph.add_edge(src, dst);
         }
 
+        let mut writes = Vec::with_capacity(arg_write_edges.len());
+        for ((dst_arg_index, destination), sources) in arg_write_edges {
+            for src in &sources {
+                if let PfgNode::Base(base) = src {
+                    self.graph.add_base(base.clone());
+                }
+                self.graph.add_edge(src.clone(), PfgNode::Slot(destination));
+            }
+            writes.push(InstantiatedArgWrite {
+                dst_arg_index,
+                destination,
+                sources,
+            });
+        }
+        writes.sort_by_key(|write| (write.dst_arg_index, write.destination));
+        unknown_arg_writes.sort_by_key(|write| (write.dst_arg_index, write.destination));
+
         for dst in unknown_returns {
-            self.graph.add_base_edge(BaseId::OpaqueReturn { location }, dst);
+            self.graph
+                .add_base_edge(BaseId::OpaqueReturn { location }, dst);
         }
 
-        for dst in unknown_arg_writes {
+        for write in &unknown_arg_writes {
+            let dst = PfgNode::Slot(write.destination);
             if self.should_skip_unknown_memory_load_on_node(&dst) {
                 continue;
             }
@@ -2139,6 +2324,15 @@ impl<'tcx> Collector<'_, 'tcx> {
                 dst,
             );
         }
+
+        self.call_effects.insert(
+            location,
+            CallEffects {
+                complete: true,
+                writes,
+                unknown_writes: unknown_arg_writes,
+            },
+        );
 
         true
     }
@@ -3134,7 +3328,7 @@ fn slot_path_from_projection<V, T>(
         .collect()
 }
 
-fn is_self_arg_target_base(
+fn is_arg_target_initial_base(
     base: &BaseId,
     target: &ArgWriteTarget,
     result: &ArrayLocalProvenance,
@@ -3171,8 +3365,19 @@ fn return_slot_paths<'tcx>(
                         .map(|info| (slot, info.path.clone()))
                 })
                 .collect()
-    })
-    .unwrap_or_default()
+        })
+        .unwrap_or_default()
+}
+
+enum BoundaryWriteDiscovery {
+    NotBoundary,
+    Complete(Vec<(ArgWriteTarget, SlotIdx)>),
+    Incomplete,
+}
+
+struct BoundaryArgWrites {
+    targets: Vec<(ArgWriteTarget, SlotIdx)>,
+    complete: bool,
 }
 
 fn boundary_arg_write_targets_for_place<'tcx>(
@@ -3180,66 +3385,112 @@ fn boundary_arg_write_targets_for_place<'tcx>(
     body: &Body<'tcx>,
     tcx: TyCtxt<'tcx>,
     result: &ArrayLocalProvenance,
-) -> Vec<(ArgWriteTarget, SlotIdx)> {
+) -> BoundaryWriteDiscovery {
     let Some(deref_index) = place
         .projection
         .iter()
         .position(|elem| matches!(elem, ProjectionElem::Deref))
     else {
-        return vec![];
+        return BoundaryWriteDiscovery::NotBoundary;
     };
 
     let prefix_projection = &place.projection[..deref_index];
     if slot_path_from_projection(prefix_projection).is_none() {
-        return vec![];
+        return BoundaryWriteDiscovery::Incomplete;
     }
 
     let prefix_place = Place::from(place.local).project_deeper(prefix_projection, tcx);
-    let Some(prefix_slot) = result.slot_table.place_head_slot(prefix_place, body, tcx) else {
-        return vec![];
+    let Some(prefix_slot) = result
+        .slot_table
+        .place_slots(prefix_place, body, tcx)
+        .and_then(|mut slots| slots.next())
+    else {
+        return BoundaryWriteDiscovery::Incomplete;
     };
 
     let Some(written_slots) = result.slot_table.place_slots(place, body, tcx) else {
-        return vec![];
+        return BoundaryWriteDiscovery::Incomplete;
     };
 
-    boundary_param_write_targets_for_slots(prefix_slot, written_slots, result)
+    let writes = boundary_param_write_targets_for_slots(prefix_slot, written_slots, result);
+    if !writes.complete {
+        BoundaryWriteDiscovery::Incomplete
+    } else if writes.targets.is_empty() {
+        BoundaryWriteDiscovery::NotBoundary
+    } else {
+        BoundaryWriteDiscovery::Complete(writes.targets)
+    }
 }
 
 fn boundary_param_write_targets_for_slots(
     prefix_slot: SlotIdx,
     written_slots: impl IntoIterator<Item = SlotIdx>,
     result: &ArrayLocalProvenance,
-) -> Vec<(ArgWriteTarget, SlotIdx)> {
+) -> BoundaryArgWrites {
     let Some(prefix_path) = result
         .slot_table
         .slot_infos
         .get(prefix_slot)
         .map(|info| info.path.clone())
     else {
-        return vec![];
+        return BoundaryArgWrites {
+            targets: vec![],
+            complete: false,
+        };
     };
-    let Some(bases) = result.provenance.reachable_bases.get(&PfgNode::Slot(prefix_slot)) else {
-        return vec![];
+    let Some(bases) = result
+        .provenance
+        .reachable_bases
+        .get(&PfgNode::Slot(prefix_slot))
+    else {
+        return BoundaryArgWrites {
+            targets: vec![],
+            complete: false,
+        };
     };
+
+    let param_bases: Vec<_> = bases
+        .iter()
+        .filter_map(|base| {
+            let BaseId::Param { local, slot } = base else {
+                return None;
+            };
+            Some((*local, *slot))
+        })
+        .collect();
+    if param_bases.is_empty() {
+        return BoundaryArgWrites {
+            targets: vec![],
+            complete: true,
+        };
+    }
 
     let mut targets = vec![];
     for slot in written_slots {
         let Some(info) = result.slot_table.slot_infos.get(slot) else {
-            continue;
+            return BoundaryArgWrites {
+                targets,
+                complete: false,
+            };
         };
         let Some(relative_path) = info.path.as_slice().strip_prefix(prefix_path.as_slice()) else {
-            continue;
+            return BoundaryArgWrites {
+                targets,
+                complete: false,
+            };
         };
         if relative_path.is_empty() {
-            continue;
-        }
-        for base in bases {
-            let BaseId::Param { local, slot: base_slot } = base else {
-                continue;
+            return BoundaryArgWrites {
+                targets,
+                complete: false,
             };
+        }
+        for (local, base_slot) in &param_bases {
             let Some(arg_index) = param_index_for_local(*local) else {
-                continue;
+                return BoundaryArgWrites {
+                    targets,
+                    complete: false,
+                };
             };
             let Some(base_path) = result
                 .slot_table
@@ -3247,7 +3498,10 @@ fn boundary_param_write_targets_for_slots(
                 .get(*base_slot)
                 .map(|info| info.path.clone())
             else {
-                continue;
+                return BoundaryArgWrites {
+                    targets,
+                    complete: false,
+                };
             };
             let mut target_path = base_path;
             target_path.extend(relative_path.iter().cloned());
@@ -3261,7 +3515,10 @@ fn boundary_param_write_targets_for_slots(
         }
     }
 
-    targets
+    BoundaryArgWrites {
+        targets,
+        complete: true,
+    }
 }
 
 fn boundary_unknown_call_arg_write_targets_for_place<'tcx>(
@@ -3288,6 +3545,7 @@ fn boundary_unknown_call_arg_write_targets_for_place<'tcx>(
         }),
         result,
     )
+    .targets
     .into_iter()
     .map(|(target, _slot)| target)
     .collect()
@@ -3297,19 +3555,24 @@ fn boundary_arg_write_targets<'tcx>(
     body: &Body<'tcx>,
     tcx: TyCtxt<'tcx>,
     result: &ArrayLocalProvenance,
-) -> Vec<(ArgWriteTarget, SlotIdx)> {
+) -> BoundaryArgWrites {
     let mut targets = vec![];
+    let mut complete = true;
 
     for (_block, block_data) in body.basic_blocks.iter_enumerated() {
         for statement in &block_data.statements {
             let StatementKind::Assign(box (place, _)) = &statement.kind else {
                 continue;
             };
-            targets.extend(boundary_arg_write_targets_for_place(*place, body, tcx, result));
+            match boundary_arg_write_targets_for_place(*place, body, tcx, result) {
+                BoundaryWriteDiscovery::NotBoundary => {}
+                BoundaryWriteDiscovery::Complete(discovered) => targets.extend(discovered),
+                BoundaryWriteDiscovery::Incomplete => complete = false,
+            }
         }
     }
 
-    targets
+    BoundaryArgWrites { targets, complete }
 }
 
 fn boundary_unknown_arg_write_targets<'tcx>(
@@ -3342,10 +3605,7 @@ fn boundary_unknown_arg_write_targets<'tcx>(
                 && count_slots(inner, tcx, &mut FxHashSet::default()) > 0
             {
                 targets.extend(boundary_unknown_call_arg_write_targets_for_place(
-                    place,
-                    body,
-                    tcx,
-                    result,
+                    place, body, tcx, result,
                 ));
             }
         }
@@ -3360,7 +3620,10 @@ fn build_function_summary<'tcx>(
     body: &Body<'tcx>,
     result: &ArrayLocalProvenance,
 ) -> FunctionSummary {
-    let mut summary = FunctionSummary::default();
+    let mut summary = FunctionSummary {
+        completeness: SummaryCompleteness::Complete,
+        ..FunctionSummary::default()
+    };
 
     for (slot, path) in return_slot_paths(body, tcx, result) {
         let node = PfgNode::Slot(slot);
@@ -3382,7 +3645,11 @@ fn build_function_summary<'tcx>(
         }
     }
 
-    for (target, written_slot) in boundary_arg_write_targets(body, tcx, result) {
+    let boundary_writes = boundary_arg_write_targets(body, tcx, result);
+    if !boundary_writes.complete {
+        summary.completeness = SummaryCompleteness::Incomplete;
+    }
+    for (target, written_slot) in boundary_writes.targets {
         let Some(bases) = result
             .provenance
             .reachable_bases
@@ -3393,8 +3660,11 @@ fn build_function_summary<'tcx>(
         };
 
         let mut emitted = false;
+        let has_non_initial_base = bases
+            .iter()
+            .any(|base| !is_arg_target_initial_base(base, &target, result));
         for base in bases {
-            if is_self_arg_target_base(base, &target, result) {
+            if has_non_initial_base && is_arg_target_initial_base(base, &target, result) {
                 continue;
             }
             let src = summary_source_for_base(base, result);

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -2539,7 +2539,7 @@ impl<'tcx> Collector<'_, 'tcx> {
                 self.graph.add_base_edge(
                     BaseId::Unknown {
                         location,
-                        reason: UnknownReason::NullLike,
+                        reason: constant_pointer_reason(operand, self.tcx),
                     },
                     dst,
                 );
@@ -2564,7 +2564,7 @@ impl<'tcx> Collector<'_, 'tcx> {
                 self.graph.add_base_edge(
                     BaseId::Unknown {
                         location,
-                        reason: UnknownReason::NullLike,
+                        reason: constant_pointer_reason(operand, self.tcx),
                     },
                     dst,
                 );
@@ -3105,7 +3105,8 @@ fn is_null_ptr_call(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
 }
 
 /// Returns true when `operand` is the integer constant zero, i.e. `0 as *mut T`.
-/// Used to classify `PointerWithExposedProvenance` casts of zero as NullLike.
+/// Used to classify the zero sentinel as NullLike, both for
+/// `PointerWithExposedProvenance` casts and in `constant_pointer_reason`.
 fn is_zero_int_operand<'tcx>(operand: &Operand<'tcx>, _tcx: TyCtxt<'tcx>) -> bool {
     let Some(const_op) = operand.constant() else {
         return false;
@@ -3117,6 +3118,20 @@ fn is_zero_int_operand<'tcx>(operand: &Operand<'tcx>, _tcx: TyCtxt<'tcx>) -> boo
         return false;
     };
     int_val.to_bits(int_val.size()) == 0
+}
+
+/// classifies a constant pointer operand for the operand collectors: the
+/// integer-zero sentinel stays `NullLike` (transparent in unique-base
+/// computation), while any other constant pointer (string/byte literal,
+/// static) is `ConstantPointer` (opaque), so a cursor reassigned to it loses
+/// base uniqueness and is excluded at selection rather than rescued by the
+/// rewriter's prune pass.
+fn constant_pointer_reason<'tcx>(operand: &Operand<'tcx>, tcx: TyCtxt<'tcx>) -> UnknownReason {
+    if is_zero_int_operand(operand, tcx) {
+        UnknownReason::NullLike
+    } else {
+        UnknownReason::ConstantPointer
+    }
 }
 
 fn call_propagates_first_arg<'tcx>(

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -483,6 +483,15 @@ pub fn array_local_provenance_analysis(
     results
 }
 
+pub fn analyze_body<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+    body: &Body<'tcx>,
+    alloc_fns: &FxHashSet<LocalDefId>,
+) -> ArrayLocalProvenance {
+    analyze_body_with_summaries(tcx, def_id, body, alloc_fns, None)
+}
+
 fn analyze_body_with_summaries<'tcx>(
     tcx: TyCtxt<'tcx>,
     _def_id: LocalDefId,

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -1001,14 +1001,14 @@ fn pointer_origin_map<'tcx>(
         let Some(dst) = destination.as_local() else {
             continue;
         };
-        if let Some((_, name)) = call_name(tcx, func)
-            && (is_pointer_arithmetic(&name) || is_as_ptr(&name))
+        if let Some((def_id, name)) = call_name(tcx, func)
+            && (is_pointer_arithmetic(tcx, def_id, &name) || is_as_ptr(tcx, def_id, &name))
             && let Some(arg) = args.first()
             && let Some(place) = operand_place(&arg.node)
         {
             origins.entry(dst).or_default().push(PointerOrigin {
                 source: place.local,
-                uses_pointer_arithmetic: is_pointer_arithmetic(&name),
+                uses_pointer_arithmetic: is_pointer_arithmetic(tcx, def_id, &name),
                 uses_pointer_cast: false,
             });
         }
@@ -1903,8 +1903,8 @@ fn build_rhs_map<'tcx>(
         let Some(dest_local) = destination.as_local() else {
             continue;
         };
-        if let Some((_, name)) = call_name(tcx, func)
-            && (is_pointer_arithmetic(&name) || is_as_ptr(&name))
+        if let Some((def_id, name)) = call_name(tcx, func)
+            && (is_pointer_arithmetic(tcx, def_id, &name) || is_as_ptr(tcx, def_id, &name))
             && let Some(arg) = args.first()
             && let Some(place) = operand_place(&arg.node)
         {
@@ -2377,7 +2377,7 @@ impl<'tcx> Collector<'_, 'tcx> {
         }
 
         if let Some((def_id, name)) = call {
-            if is_pointer_arithmetic(&name) {
+            if is_pointer_arithmetic(self.tcx, def_id, &name) {
                 let Some(dst) = self.destination_node(*destination, location) else {
                     return;
                 };
@@ -2413,7 +2413,7 @@ impl<'tcx> Collector<'_, 'tcx> {
                 return;
             }
 
-            if is_as_ptr(&name)
+            if is_as_ptr(self.tcx, def_id, &name)
                 && let Some(arg) = args.first()
                 && let Some(place) = operand_place(&arg.node)
             {
@@ -2430,7 +2430,7 @@ impl<'tcx> Collector<'_, 'tcx> {
                 return;
             }
 
-            if is_heap_alloc_call(self.tcx, def_id, &name, self.alloc_fns) {
+            if is_heap_alloc_call(self.tcx, def_id, self.alloc_fns) {
                 let Some(dst) = self.destination_node(*destination, location) else {
                     return;
                 };
@@ -3065,24 +3065,36 @@ fn call_name(tcx: TyCtxt<'_>, func: &Operand<'_>) -> Option<(DefId, String)> {
     Some((*def_id, tcx.def_path_str(*def_id)))
 }
 
-fn is_pointer_arithmetic(name: &str) -> bool {
-    matches!(
-        name.rsplit("::").next(),
-        Some(
-            "offset"
-                | "wrapping_offset"
-                | "byte_offset"
-                | "wrapping_byte_offset"
-                | "add"
-                | "wrapping_add"
-                | "sub"
-                | "wrapping_sub"
+/// Returns true only for the core/std inherent raw-pointer arithmetic
+/// methods. The crate and `::ptr::` path checks keep user-defined functions
+/// that merely share these names (common in translated C code, e.g. a free
+/// function `add`) from being granted base-preserving semantics.
+fn is_pointer_arithmetic(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
+    let crate_name = tcx.crate_name(def_id.krate);
+    matches!(crate_name.as_str(), "core" | "std")
+        && name.contains("::ptr::")
+        && matches!(
+            name.rsplit("::").next(),
+            Some(
+                "offset"
+                    | "wrapping_offset"
+                    | "byte_offset"
+                    | "wrapping_byte_offset"
+                    | "add"
+                    | "wrapping_add"
+                    | "sub"
+                    | "wrapping_sub"
+            )
         )
-    )
 }
 
-fn is_as_ptr(name: &str) -> bool {
-    matches!(name.rsplit("::").next(), Some("as_ptr" | "as_mut_ptr"))
+/// Returns true only for the core/std slice/array `as_ptr`/`as_mut_ptr`
+/// methods, not for arbitrary functions sharing those names.
+fn is_as_ptr(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
+    let crate_name = tcx.crate_name(def_id.krate);
+    matches!(crate_name.as_str(), "core" | "std")
+        && (name.contains("::slice::") || name.contains("::array::"))
+        && matches!(name.rsplit("::").next(), Some("as_ptr" | "as_mut_ptr"))
 }
 
 fn call_no_writes(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
@@ -3209,18 +3221,10 @@ fn is_empty_array_ref_ty<'tcx>(ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) -> bool {
     len.try_to_target_usize(tcx) == Some(0)
 }
 
-fn is_heap_alloc_call(
-    tcx: TyCtxt<'_>,
-    def_id: DefId,
-    name: &str,
-    alloc_fns: &FxHashSet<LocalDefId>,
-) -> bool {
-    if matches!(
-        name.rsplit("::").next(),
-        Some("malloc" | "calloc" | "realloc")
-    ) {
-        return true;
-    }
+/// Returns true for allocator shims found by Andersen pre-analysis and for
+/// the foreign libc allocators. A local Rust function that merely shares an
+/// allocator name gets no heap-alloc provenance.
+fn is_heap_alloc_call(tcx: TyCtxt<'_>, def_id: DefId, alloc_fns: &FxHashSet<LocalDefId>) -> bool {
     def_id
         .as_local()
         .is_some_and(|local_def_id| alloc_fns.contains(&local_def_id))

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -675,6 +675,9 @@ pub struct RewriteSelectionContext<'a, 'tcx> {
     pub points_to: &'a andersen::AnalysisResult,
 }
 
+// only used by the analysis test harness now; the rewriter pass calls
+// `classify_rewrite_groups` directly so it can also trace discarded statuses.
+#[cfg(test)]
 pub fn select_rewrite_groups<'a, 'tcx>(
     provenance: &ArrayLocalProvenance,
     body: &Body<'tcx>,

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -483,6 +483,7 @@ pub fn array_local_provenance_analysis(
     results
 }
 
+#[cfg(test)]
 pub fn analyze_body<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -483,15 +483,6 @@ pub fn array_local_provenance_analysis(
     results
 }
 
-pub fn analyze_body<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    def_id: LocalDefId,
-    body: &Body<'tcx>,
-    alloc_fns: &FxHashSet<LocalDefId>,
-) -> ArrayLocalProvenance {
-    analyze_body_with_summaries(tcx, def_id, body, alloc_fns, None)
-}
-
 fn analyze_body_with_summaries<'tcx>(
     tcx: TyCtxt<'tcx>,
     _def_id: LocalDefId,
@@ -774,7 +765,7 @@ pub(crate) fn classify_rewrite_groups<'a, 'tcx>(
         // simultaneous-liveness gate: require at least one MIR location where the
         // mutability condition holds for the subset of member locals that are live there.
         // `live_after` tracks MIR locals (not slots), so a struct root being live means
-        // all its fields are considered potentially live — a sound over-approximation.
+        // all its fields are considered potentially live
         let has_conflict = live_after.values().any(|live| {
             let live_mut_count = local_mut_roots
                 .iter()
@@ -893,11 +884,6 @@ fn member_pointer_elements_match_base_element<'tcx>(
     })
 }
 
-/// true when two element types have the same size, so an index counted in one
-/// unit advances the same number of bytes in the other; alignment is also
-/// required to match as extra conservatism for the rare same-size/different-align
-/// case. both must be sized with a computable layout; otherwise returns false
-/// (fail closed).
 fn element_tys_same_size_align<'tcx>(
     body: &Body<'tcx>,
     tcx: TyCtxt<'tcx>,
@@ -2598,38 +2584,20 @@ impl<'tcx> Collector<'_, 'tcx> {
         }
     }
 
-    /// Range-based helper for source places.
-    ///
-    /// Returns the full `Range<SlotIdx>` covering all pointer slots in `place`.
-    /// Returns `None` when the projection is unsupported or the place has no
-    /// pointer slots (i.e. the slot range would be empty).
     fn source_slots(&self, place: Place<'tcx>) -> Option<Range<SlotIdx>> {
         let slots = self.slot_table.place_slots(place, self.body, self.tcx)?;
         if slots.is_empty() { None } else { Some(slots) }
     }
 
-    /// Range-based helper for destination places.
-    ///
-    /// Returns the full `Range<SlotIdx>` covering all pointer slots in `place`.
-    /// Returns `None` when the projection is unsupported or the place has no
-    /// pointer slots (i.e. the slot range would be empty).
     fn destination_slots(&self, place: Place<'tcx>) -> Option<Range<SlotIdx>> {
         let slots = self.slot_table.place_slots(place, self.body, self.tcx)?;
         if slots.is_empty() { None } else { Some(slots) }
     }
 
-    /// Returns the head `PfgNode` for `place` by looking up the first slot via
-    /// `source_slots`.  Unlike `place_head_slot`, this is not restricted to
-    /// places whose top-level type is a raw pointer: it works for any place
-    /// whose slot range is non-empty (e.g. a struct that contains pointer fields).
     fn source_node(&self, place: Place<'tcx>) -> Option<PfgNode> {
         self.source_slots(place)?.next().map(PfgNode::Slot)
     }
 
-    /// Returns the head `PfgNode` (first slot in the slot range) for `place`
-    /// by delegating to `destination_slots`.
-    /// When the slot range is empty or the projection is unsupported,
-    /// inserts an `Unknown` base into the graph and returns `None`.
     fn destination_node(&mut self, place: Place<'tcx>, location: Location) -> Option<PfgNode> {
         if let Some(mut slots) = self.destination_slots(place) {
             slots.next().map(PfgNode::Slot)
@@ -2648,7 +2616,7 @@ impl<'tcx> Collector<'_, 'tcx> {
         };
         // Only mark true pointee slots (depth > 0) as unknown; sibling field
         // slots in a struct destination (depth = 0) are NOT pointees and must
-        // not be polluted here — their provenance comes from the call itself.
+        // not be polluted here.
         for slot in slots.skip(1) {
             if self.slot_table.slot_infos[slot].depth == 0 {
                 continue;
@@ -2694,9 +2662,7 @@ impl<'tcx> Collector<'_, 'tcx> {
     ///
     /// When the borrowed place is a simple `*local_ptr` (deref of a raw pointer),
     /// propagate provenance from `local_ptr`'s slot rather than minting a fresh
-    /// `RawBorrow` base.  This lets bases established by pointer-arithmetic call
-    /// handlers (`is_pointer_arithmetic`, `is_as_ptr`) flow through re-borrow
-    /// patterns like `&mut *offset_result as *mut T`.
+    /// `RawBorrow` base.
     fn collect_raw_borrow_flow(
         &mut self,
         lhs: Place<'tcx>,
@@ -2705,10 +2671,8 @@ impl<'tcx> Collector<'_, 'tcx> {
         dst_slots: &std::ops::Range<SlotIdx>,
         location: Location,
     ) {
-        // for `*local_ptr` (raw pointer or reference), inherit its existing
-        // provenance instead of minting a fresh RawBorrow base.  The reborrow
-        // pattern `&mut *(_5: *mut T)` gives `_4: &mut T`, and `&raw mut *(_4:
-        // &mut T)` gives `_3: *mut T`.  Both steps must propagate through.
+        // The reborrow pattern `&mut *(_5: *mut T)` gives `_4: &mut T`,
+        // and `&raw mut *(_4: &mut T)` gives `_3: *mut T`.
         let propagated = if let [ProjectionElem::Deref] = place.projection.as_ref()
             && (self.local_ty(place.local).is_raw_ptr() || self.local_ty(place.local).is_ref())
             && let Some(slot) = self.slot_table.local_head_slot(place.local)
@@ -3082,8 +3046,6 @@ fn is_pointer_arithmetic(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
         )
 }
 
-/// Returns true only for the core/std slice/array `as_ptr`/`as_mut_ptr`
-/// methods, not for arbitrary functions sharing those names.
 fn is_as_ptr(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
     let crate_name = tcx.crate_name(def_id.krate);
     matches!(crate_name.as_str(), "core" | "std")
@@ -3098,9 +3060,6 @@ fn call_no_writes(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
         && matches!(name.rsplit("::").next(), Some("is_null"))
 }
 
-/// Returns `true` for `core::ptr::null()` / `core::ptr::null_mut()` and
-/// the inherent `<*mut T>::null()` / `<*const T>::null()` methods, which
-/// always produce a null (zero) pointer and carry no real provenance.
 fn is_null_ptr_call(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
     let crate_name = tcx.crate_name(def_id.krate);
     matches!(crate_name.as_str(), "core" | "std")
@@ -3108,8 +3067,6 @@ fn is_null_ptr_call(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> bool {
 }
 
 /// Returns true when `operand` is the integer constant zero, i.e. `0 as *mut T`.
-/// Used to classify the zero sentinel as NullLike, both for
-/// `PointerWithExposedProvenance` casts and in `constant_pointer_reason`.
 fn is_zero_int_operand<'tcx>(operand: &Operand<'tcx>, _tcx: TyCtxt<'tcx>) -> bool {
     let Some(const_op) = operand.constant() else {
         return false;
@@ -3123,12 +3080,6 @@ fn is_zero_int_operand<'tcx>(operand: &Operand<'tcx>, _tcx: TyCtxt<'tcx>) -> boo
     int_val.to_bits(int_val.size()) == 0
 }
 
-/// classifies a constant pointer operand for the operand collectors: the
-/// integer-zero sentinel stays `NullLike` (transparent in unique-base
-/// computation), while any other constant pointer (string/byte literal,
-/// static) is `ConstantPointer` (opaque), so a cursor reassigned to it loses
-/// base uniqueness and is excluded at selection rather than rescued by the
-/// rewriter's prune pass.
 fn constant_pointer_reason<'tcx>(operand: &Operand<'tcx>, tcx: TyCtxt<'tcx>) -> UnknownReason {
     if is_zero_int_operand(operand, tcx) {
         UnknownReason::NullLike

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -4,7 +4,10 @@ use rustc_hir::{self as hir, ItemKind, OwnerNode, PatKind, intravisit};
 use typed_arena::Arena;
 use utils::ty_shape;
 
-use super::{BaseAdmissibility, BaseId, PfgNode, analyze_body};
+use super::{
+    BaseAdmissibility, BaseId, PfgNode, UnknownReason, analyze_body,
+    array_local_provenance_analysis,
+};
 use crate::{
     analyses::type_qualifier::foster::mutability::mutability_analysis,
     rewriter::array_local_index_rewriter::group_has_rewritable_binding, utils::rustc::RustProgram,
@@ -67,6 +70,58 @@ fn run_analysis(code: &str) -> FxHashMap<(String, String), LocalFacts> {
             let fn_name = tcx.item_name(did.to_def_id()).to_string();
             let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
             let result = analyze_body(tcx, did, &body, &alloc_fns);
+            let hir_to_mir = utils::ir::map_thir_to_mir(did, false, tcx);
+            let hir_body = tcx.hir_body_owned_by(did);
+            let bindings = collect_bindings(hir_body);
+
+            for (hir_id, local) in &hir_to_mir.binding_to_local {
+                let Some(var_name) = bindings.get(hir_id) else {
+                    continue;
+                };
+                let bases = result
+                    .slot_table
+                    .local_head_slot(*local)
+                    .and_then(|slot| {
+                        result
+                            .provenance
+                            .reachable_bases
+                            .get(&PfgNode::Slot(slot))
+                            .cloned()
+                    })
+                    .unwrap_or_default();
+                let unique = result.unique_base_of_local(*local);
+                let admissibility = unique
+                    .as_ref()
+                    .map(|base| result.admissibility_of_base(base));
+                facts.insert(
+                    (fn_name.clone(), var_name.clone()),
+                    LocalFacts {
+                        bases,
+                        unique,
+                        admissibility,
+                    },
+                );
+            }
+        }
+
+        facts
+    })
+    .unwrap()
+}
+
+fn run_interprocedural_analysis(code: &str) -> FxHashMap<(String, String), LocalFacts> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let rust_program = build_rust_program(tcx);
+        let alloc_fns = FxHashSet::default();
+        let results = array_local_provenance_analysis(&rust_program, &alloc_fns);
+        let mut facts = FxHashMap::default();
+
+        for &did in &rust_program.functions {
+            let fn_name = tcx.item_name(did.to_def_id()).to_string();
+            let _body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+            let result = results
+                .get(&did)
+                .unwrap_or_else(|| panic!("missing provenance result for {fn_name}"));
             let hir_to_mir = utils::ir::map_thir_to_mir(did, false, tcx);
             let hir_body = tcx.hir_body_owned_by(did);
             let bindings = collect_bindings(hir_body);
@@ -223,6 +278,27 @@ fn assert_unique_param(fact: &LocalFacts) {
     assert_eq!(
         fact.admissibility,
         Some(BaseAdmissibility::DirectlyRewriteable)
+    );
+}
+
+fn assert_has_only_nulltransparent_base(fact: &LocalFacts, expected: &BaseId) {
+    let non_null_bases: Vec<_> = fact
+        .bases
+        .iter()
+        .filter(|base| {
+            !matches!(
+                base,
+                BaseId::Unknown {
+                    reason: UnknownReason::NullLike,
+                    ..
+                }
+            )
+        })
+        .collect();
+    assert_eq!(
+        non_null_bases,
+        vec![expected],
+        "expected exactly one non-null base {expected:?}, got {fact:#?}"
     );
 }
 
@@ -1159,6 +1235,301 @@ fn array_local_provenance_call_returning_raw_pointer_non_regression() {
         q.admissibility,
         Some(BaseAdmissibility::TrackOnly),
         "OpaqueReturn base must be TrackOnly: {q:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_direct_callee_arg_write_preserves_base() {
+    let map = run_interprocedural_analysis(
+        r#"
+        pub unsafe fn helper(src: *mut i32, out: *mut *mut i32) {
+            *out = src;
+        }
+
+        pub unsafe fn f(p: *mut i32, i: usize) {
+            let q = p.add(i);
+            let mut into: *mut i32 = core::ptr::null_mut();
+            helper(q, &raw mut into);
+            let r = into.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    let into = facts(&map, "f", "into");
+    let r = facts(&map, "f", "r");
+    assert_unique_param(q);
+    assert_has_only_nulltransparent_base(into, q.unique.as_ref().unwrap());
+    assert_has_only_nulltransparent_base(r, q.unique.as_ref().unwrap());
+}
+
+#[test]
+fn array_local_provenance_direct_callee_arg_write_from_first_param_cjson_shape() {
+    let map = run_interprocedural_analysis(
+        r#"
+        pub type c_char = i8;
+
+        pub unsafe fn minify_string(src: *mut c_char, out: *mut *mut c_char) {
+            *out = src;
+        }
+
+        pub unsafe fn cjson_minify(json: *mut c_char) {
+            let mut into = json;
+            let q = json.add(1);
+            minify_string(q, &raw mut into);
+            let r = into.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "cjson_minify", "q");
+    let into = facts(&map, "cjson_minify", "into");
+    let r = facts(&map, "cjson_minify", "r");
+    assert_unique_param(q);
+    assert_eq!(into.unique, q.unique, "into should keep q/json base: {into:#?}");
+    assert_eq!(r.unique, q.unique, "r should keep q/json base: {r:#?}");
+}
+
+#[test]
+fn array_local_provenance_direct_callee_unknown_arg_write_preserves_direct_param_copy_slot() {
+    let map = run_interprocedural_analysis(
+        r#"
+        unsafe extern "C" {
+            fn unknown(out: *mut *mut i32);
+        }
+
+        pub unsafe fn helper(out: *mut *mut i32) {
+            let alias = out;
+            unknown(alias);
+        }
+
+        pub unsafe fn f(out: *mut *mut i32) {
+            helper(out);
+            let q = *out;
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::Param { .. })),
+        "summary fallback should preserve the direct-param base for q: {q:#?}"
+    );
+    assert!(
+        !q.bases.iter().any(|base| {
+            matches!(
+                base,
+                BaseId::Unknown {
+                    reason: UnknownReason::UnsupportedMemoryLoad,
+                    ..
+                }
+            )
+        }),
+        "summary fallback should not add UnsupportedMemoryLoad to q: {q:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_direct_callee_unknown_arg_write_uses_summarized_param_index() {
+    let map = run_interprocedural_analysis(
+        r#"
+        unsafe extern "C" {
+            fn unknown(out: *mut *mut i32);
+        }
+
+        pub unsafe fn helper(scratch: *mut *mut i32, out: *mut *mut i32) {
+            let alias = out;
+            unknown(alias);
+            let _ = scratch;
+        }
+
+        pub unsafe fn f(p: *mut i32, out: *mut *mut i32) {
+            let mut local = p;
+            helper(&raw mut local, out);
+            let q = local;
+            let r = *out;
+            let _ = (q, r);
+        }
+        "#,
+    );
+
+    let local = facts(&map, "f", "local");
+    let q = facts(&map, "f", "q");
+    let r = facts(&map, "f", "r");
+
+    assert_unique_param(q);
+    assert_eq!(
+        local.unique, q.unique,
+        "wrong unknown-write summary target should not poison local: {local:#?}"
+    );
+    assert_unique_param(r);
+    assert_ne!(r.unique, q.unique, "r should track out, not p: {r:#?}");
+    assert!(
+        !q.bases.iter().any(|base| {
+            matches!(
+                base,
+                BaseId::Unknown {
+                    reason: UnknownReason::UnsupportedMemoryLoad,
+                    ..
+                }
+            )
+        }),
+        "q should not gain UnsupportedMemoryLoad from the scratch argument: {q:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_direct_callee_return_preserves_param_base() {
+    let map = run_interprocedural_analysis(
+        r#"
+        pub unsafe fn advance(p: *mut i32, i: usize) -> *mut i32 {
+            p.add(i)
+        }
+
+        pub unsafe fn f(p: *mut i32, i: usize) {
+            let q = advance(p, i);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    let r = facts(&map, "f", "r");
+    assert_unique_param(q);
+    assert_eq!(r.unique, q.unique, "r should keep q's base: {r:#?}");
+}
+
+#[test]
+fn array_local_provenance_direct_callee_return_through_pointer_arithmetic() {
+    let map = run_interprocedural_analysis(
+        r#"
+        pub unsafe fn advance_twice(p: *mut i32, i: usize) -> *mut i32 {
+            let q = p.add(i);
+            q.add(1)
+        }
+
+        pub unsafe fn f(p: *mut i32, i: usize) {
+            let q = advance_twice(p, i);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    let r = facts(&map, "f", "r");
+    assert_unique_param(q);
+    assert_eq!(r.unique, q.unique, "r should keep q's base: {r:#?}");
+}
+
+#[test]
+fn array_local_provenance_extern_call_stays_conservative() {
+    let map = run_interprocedural_analysis(
+        r#"
+        unsafe extern "C" {
+            fn helper(src: *mut i32, out: *mut *mut i32);
+        }
+
+        pub unsafe fn f(p: *mut i32, i: usize) {
+            let q = p.add(i);
+            let mut into: *mut i32 = core::ptr::null_mut();
+            helper(q, &raw mut into);
+            let r = into.add(1);
+            let _ = r;
+        }
+        "#,
+    );
+
+    let into = facts(&map, "f", "into");
+    assert!(
+        !into.bases.iter().any(|base| matches!(base, BaseId::Param { .. })),
+        "unknown callee write should not introduce a param base: {into:#?}"
+    );
+    assert!(
+        into
+            .bases
+            .iter()
+            .any(|base| !matches!(
+                base,
+                BaseId::Unknown {
+                    reason: UnknownReason::NullLike,
+                    ..
+                }
+            )),
+        "unknown callee write should keep at least one non-null-like conservative base: {into:#?}"
+    );
+    assert!(
+        into.unique.is_none() || matches!(into.unique, Some(BaseId::Unknown { .. })),
+        "extern call should not be trusted as a direct local summary: {into:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_direct_callee_unknown_write_stays_rejected() {
+    let map = run_interprocedural_analysis(
+        r#"
+        unsafe extern "C" {
+            fn make() -> *mut i32;
+        }
+
+        pub unsafe fn helper(out: *mut *mut i32) {
+            *out = make();
+        }
+
+        pub unsafe fn f(p: *mut i32, i: usize) {
+            let q = p.add(i);
+            let mut into: *mut i32 = core::ptr::null_mut();
+            helper(&raw mut into);
+            let r = into.add(1);
+            let _ = (q, r);
+        }
+        "#,
+    );
+
+    let into = facts(&map, "f", "into");
+    assert!(
+        into.unique.is_none() || into.admissibility != Some(BaseAdmissibility::DirectlyRewriteable),
+        "unknown callee write should not become rewriteable: {into:#?}"
+    );
+}
+
+#[test]
+fn array_local_provenance_recursive_summary_does_not_panic() {
+    let map = run_interprocedural_analysis(
+        r#"
+        pub unsafe fn rec(p: *mut i32, n: usize) -> *mut i32 {
+            if n == 0 {
+                p
+            } else {
+                rec(p.add(1), n - 1)
+            }
+        }
+
+        pub unsafe fn f(p: *mut i32, n: usize) {
+            let q = rec(p, n);
+            let _ = q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        q.bases.iter().any(|base| matches!(base, BaseId::Param { .. })),
+        "recursive summary should keep a Param base in the conservative result: {q:#?}"
+    );
+    assert!(
+        q.bases
+            .iter()
+            .any(|base| matches!(base, BaseId::OpaqueReturn { .. })),
+        "recursive summary should keep an OpaqueReturn base in the conservative result: {q:#?}"
+    );
+    assert!(
+        q.unique.is_none(),
+        "recursive summary should stay conservative and non-unique: {q:#?}"
     );
 }
 

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::{
     analyses::type_qualifier::foster::mutability::mutability_analysis,
     rewriter::array_local_index_rewriter::{
-        group_has_rewritable_binding, group_suppresses_caller_visible_store,
+        group_has_rewritable_binding, group_needs_live_base_rewrite,
     },
     utils::rustc::RustProgram,
 };
@@ -172,7 +172,7 @@ struct RewriteGroupFacts {
     member_root_names: FxHashSet<String>,
     index_tracked: bool,
     has_rewritable_binding: bool,
-    suppresses_caller_visible_store: bool,
+    needs_live_base_rewrite: bool,
     kind: &'static str,
     writes_base_binding: bool,
     preserved_call_count: usize,
@@ -249,8 +249,8 @@ fn run_rewrite_groups_with_points_to(
                     };
                     let has_rewritable_binding =
                         group_has_rewritable_binding(tcx, did, &body, result, &group);
-                    let suppresses_caller_visible_store =
-                        group_suppresses_caller_visible_store(result, &group);
+                    let needs_live_base_rewrite =
+                        group_needs_live_base_rewrite(result, &group);
                     let member_names = group
                         .members
                         .iter()
@@ -280,7 +280,7 @@ fn run_rewrite_groups_with_points_to(
                         kind,
                         index_tracked: group.index_tracked,
                         has_rewritable_binding,
-                        suppresses_caller_visible_store,
+                        needs_live_base_rewrite,
                         writes_base_binding,
                         preserved_call_count,
                     }
@@ -2493,11 +2493,11 @@ fn group_has_rewritable_binding_for_field_base_group() {
 }
 
 #[test]
-fn index_tracked_pointee_field_base_group_is_flagged_store_suppressing() {
+fn index_tracked_pointee_field_base_group_is_flagged_live_base() {
     // cp_block shape: the base slot (*state).out lives behind a parameter
     // pointer; turning its direct store into an index update would hide the
-    // advanced pointer from the caller, so the rewriter must skip the group
-    // even though selection still classifies it as index_tracked.
+    // advanced pointer from the caller, so the rewriter uses the live-field /
+    // shadow-counter scheme (approach D) and flags the group accordingly.
     let groups = run_rewrite_groups_with_points_to(
         RewriteGroupFactMode::ReadyOnly,
         r#"
@@ -2524,15 +2524,15 @@ fn index_tracked_pointee_field_base_group_is_flagged_store_suppressing() {
         .find(|group| group.index_tracked && group.member_names.contains("state.out"))
         .unwrap_or_else(|| panic!("expected index_tracked state.out group: {f_groups:#?}"));
     assert!(
-        group.suppresses_caller_visible_store,
-        "index-tracked pointee field base must be flagged store-suppressing: {group:#?}"
+        group.needs_live_base_rewrite,
+        "index-tracked pointee field base must be flagged needs_live_base_rewrite: {group:#?}"
     );
 }
 
 #[test]
-fn index_tracked_by_value_field_base_group_is_not_flagged_store_suppressing() {
+fn index_tracked_by_value_field_base_group_is_not_flagged_live_base() {
     // pair.a lives in the by-value parameter copy; suppressing its store is
-    // invisible to the caller, so the group stays plannable.
+    // invisible to the caller, so the group stays plannable without live-base.
     let groups = run_rewrite_groups_with_points_to(
         RewriteGroupFactMode::ReadyOnly,
         r#"
@@ -2558,13 +2558,13 @@ fn index_tracked_by_value_field_base_group_is_not_flagged_store_suppressing() {
         .find(|group| group.index_tracked && group.member_names.contains("qa"))
         .unwrap_or_else(|| panic!("expected index_tracked pair.a group: {f_groups:#?}"));
     assert!(
-        !group.suppresses_caller_visible_store,
+        !group.needs_live_base_rewrite,
         "by-value field base writes a local copy and must stay plannable: {group:#?}"
     );
 }
 
 #[test]
-fn index_tracked_top_level_param_group_is_not_flagged_store_suppressing() {
+fn index_tracked_top_level_param_group_is_not_flagged_live_base() {
     // p is a by-value parameter binding; reassigning it is caller-invisible.
     let groups = run_rewrite_groups_with_points_to(
         RewriteGroupFactMode::ReadyOnly,
@@ -2584,7 +2584,7 @@ fn index_tracked_top_level_param_group_is_not_flagged_store_suppressing() {
         .find(|group| group.index_tracked && group.member_names.contains("q"))
         .unwrap_or_else(|| panic!("expected index_tracked param group: {f_groups:#?}"));
     assert!(
-        !group.suppresses_caller_visible_store,
+        !group.needs_live_base_rewrite,
         "top-level param cursor must stay plannable: {group:#?}"
     );
 }

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -249,8 +249,7 @@ fn run_rewrite_groups_with_points_to(
                     };
                     let has_rewritable_binding =
                         group_has_rewritable_binding(tcx, did, &body, result, &group);
-                    let needs_live_base_rewrite =
-                        group_needs_live_base_rewrite(result, &group);
+                    let needs_live_base_rewrite = group_needs_live_base_rewrite(result, &group);
                     let member_names = group
                         .members
                         .iter()

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -2507,7 +2507,7 @@ fn index_tracked_pointee_field_base_group_is_flagged_live_base() {
     // cp_block shape: the base slot (*state).out lives behind a parameter
     // pointer; turning its direct store into an index update would hide the
     // advanced pointer from the caller, so the rewriter uses the live-field /
-    // shadow-counter scheme (approach D) and flags the group accordingly.
+    // shadow-counter scheme and flags the group accordingly.
     let groups = run_rewrite_groups_with_points_to(
         RewriteGroupFactMode::ReadyOnly,
         r#"

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -60,6 +60,7 @@ fn collect_bindings(body: &hir::Body<'_>) -> FxHashMap<hir::HirId, String> {
 struct LocalFacts {
     bases: FxHashSet<BaseId>,
     unique: Option<BaseId>,
+    unique_non_null: Option<BaseId>,
     admissibility: Option<BaseAdmissibility>,
 }
 
@@ -93,6 +94,10 @@ fn run_analysis(code: &str) -> FxHashMap<(String, String), LocalFacts> {
                     })
                     .unwrap_or_default();
                 let unique = result.unique_base_of_local(*local);
+                let unique_non_null = result
+                    .slot_table
+                    .local_head_slot(*local)
+                    .and_then(|slot| result.provenance.unique_non_null_base(&PfgNode::Slot(slot)));
                 let admissibility = unique
                     .as_ref()
                     .map(|base| result.admissibility_of_base(base));
@@ -101,6 +106,7 @@ fn run_analysis(code: &str) -> FxHashMap<(String, String), LocalFacts> {
                     LocalFacts {
                         bases,
                         unique,
+                        unique_non_null,
                         admissibility,
                     },
                 );
@@ -145,6 +151,10 @@ fn run_interprocedural_analysis(code: &str) -> FxHashMap<(String, String), Local
                     })
                     .unwrap_or_default();
                 let unique = result.unique_base_of_local(*local);
+                let unique_non_null = result
+                    .slot_table
+                    .local_head_slot(*local)
+                    .and_then(|slot| result.provenance.unique_non_null_base(&PfgNode::Slot(slot)));
                 let admissibility = unique
                     .as_ref()
                     .map(|base| result.admissibility_of_base(base));
@@ -153,6 +163,7 @@ fn run_interprocedural_analysis(code: &str) -> FxHashMap<(String, String), Local
                     LocalFacts {
                         bases,
                         unique,
+                        unique_non_null,
                         admissibility,
                     },
                 );
@@ -2698,5 +2709,110 @@ fn select_rewrite_groups_rejects_size_mismatched_cast_cursor() {
                 && group.member_names.contains("small")
         }),
         "size-mismatched cast cursor must not be selected into the base group: {f_groups:#?}"
+    );
+}
+
+#[test]
+fn constant_pointer_string_literal_is_not_nulllike() {
+    // a cursor reassigned to a byte-string literal must get a ConstantPointer
+    // base (opaque), not a transparent NullLike base.
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(p: *const i8, cond: bool) {
+            let mut q: *const i8 = p.offset(1);
+            if cond {
+                q = b"x\0" as *const u8 as *const i8;
+            }
+            let _ = *q;
+            let _ = *p;
+        }
+        "#,
+    );
+    let q = facts(&map, "f", "q");
+    assert!(
+        q.bases.iter().any(|b| matches!(
+            b,
+            BaseId::Unknown {
+                reason: UnknownReason::ConstantPointer,
+                ..
+            }
+        )),
+        "string-literal reassignment must produce a ConstantPointer base: {q:#?}"
+    );
+    assert!(
+        !q.bases.iter().any(|b| matches!(
+            b,
+            BaseId::Unknown {
+                reason: UnknownReason::NullLike,
+                ..
+            }
+        )),
+        "string-literal reassignment must not be classified NullLike: {q:#?}"
+    );
+}
+
+#[test]
+fn constant_pointer_string_literal_breaks_unique_non_null_base() {
+    // because ConstantPointer is opaque, the cursor no longer has a unique
+    // non-null base, so it is excluded at selection time.
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(p: *const i8, cond: bool) {
+            let mut q: *const i8 = p.offset(1);
+            if cond {
+                q = b"x\0" as *const u8 as *const i8;
+            }
+            let _ = *q;
+            let _ = *p;
+        }
+        "#,
+    );
+    let q = facts(&map, "f", "q");
+    assert_eq!(
+        q.unique_non_null, None,
+        "string-literal reassignment must remove the unique non-null base: {q:#?}"
+    );
+}
+
+#[test]
+fn null_sentinel_reassignment_stays_transparent() {
+    // regression: the 0-as-pointer null sentinel must remain a transparent
+    // NullLike base so null-initialized cursors keep a unique non-null base.
+    let map = run_analysis(
+        r#"
+        pub unsafe fn f(p: *const i8, cond: bool) {
+            let mut q: *const i8 = p.offset(1);
+            if cond {
+                q = 0 as *const i8;
+            }
+            let _ = *q;
+            let _ = *p;
+        }
+        "#,
+    );
+    let q = facts(&map, "f", "q");
+    assert!(
+        q.bases.iter().any(|b| matches!(
+            b,
+            BaseId::Unknown {
+                reason: UnknownReason::NullLike,
+                ..
+            }
+        )),
+        "null sentinel must stay NullLike: {q:#?}"
+    );
+    assert!(
+        !q.bases.iter().any(|b| matches!(
+            b,
+            BaseId::Unknown {
+                reason: UnknownReason::ConstantPointer,
+                ..
+            }
+        )),
+        "null sentinel must not become ConstantPointer: {q:#?}"
+    );
+    assert!(
+        matches!(q.unique_non_null, Some(BaseId::Param { .. })),
+        "null sentinel must keep a unique non-null Param base: {q:#?}"
     );
 }

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -2665,3 +2665,38 @@ fn foreign_malloc_is_heap_alloc() {
         "foreign malloc must keep heap-alloc provenance, got {q:#?}"
     );
 }
+
+#[test]
+fn select_rewrite_groups_rejects_size_mismatched_cast_cursor() {
+    // `small` is `seq as *mut i8` over an `*mut i32` base: the cast changes the
+    // pointee size (4 -> 1), so an index recorded in `small`'s i8 units would be
+    // wrong in `seq`'s i32 units. selection must reject the cast cursor.
+    let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
+        r#"
+        pub unsafe fn f(seq: *mut i32, len: usize) -> i32 {
+            let small = seq as *mut i8;
+            let mut i: usize = 0;
+            while i < len {
+                let v = *seq.offset(i as isize);
+                *small.offset(i as isize) = v as i8;
+                i = i.wrapping_add(1);
+            }
+            if *small.offset(0) != 0 {
+                return -10;
+            }
+            0
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    assert!(
+        !f_groups.iter().any(|group| {
+            matches!(group.base, BaseId::Param { .. })
+                && group.base_name.as_deref() == Some("seq")
+                && group.member_names.contains("small")
+        }),
+        "size-mismatched cast cursor must not be selected into the base group: {f_groups:#?}"
+    );
+}

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -2589,3 +2589,80 @@ fn index_tracked_top_level_param_group_is_not_flagged_store_suppressing() {
     );
 }
 
+#[test]
+fn user_defined_add_function_is_not_pointer_arithmetic() {
+    // a free function named `add` (common in translated C) must not be
+    // granted the base-preserving semantics of <*mut T>::add; the genuine
+    // inherent method keeps them.
+    let map = run_analysis(
+        r#"
+        pub unsafe fn add(p: *mut i32, _n: i32) -> *mut i32 {
+            p
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let q = add(p, 1);
+            let r = p.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::OpaqueReturn { .. })),
+        "user-defined add must yield an opaque return, got {q:#?}"
+    );
+    let r = facts(&map, "f", "r");
+    assert_unique_param(r);
+}
+
+#[test]
+fn local_function_named_malloc_is_not_heap_alloc() {
+    let map = run_analysis(
+        r#"
+        pub unsafe fn malloc(_size: usize) -> *mut u8 {
+            core::ptr::null_mut()
+        }
+
+        pub unsafe fn f() {
+            let q = malloc(8);
+            let _ = *q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        !q.bases
+            .iter()
+            .any(|base| matches!(base, BaseId::HeapAlloc { .. })),
+        "local fn named malloc must not get heap-alloc provenance: {q:#?}"
+    );
+    assert!(
+        matches!(q.unique, Some(BaseId::OpaqueReturn { .. })),
+        "local fn named malloc must yield an opaque return, got {q:#?}"
+    );
+}
+
+#[test]
+fn foreign_malloc_is_heap_alloc() {
+    let map = run_analysis(
+        r#"
+        unsafe extern "C" {
+            fn malloc(size: usize) -> *mut u8;
+        }
+
+        pub unsafe fn f() {
+            let q = malloc(8);
+            let _ = *q;
+        }
+        "#,
+    );
+
+    let q = facts(&map, "f", "q");
+    assert!(
+        matches!(q.unique, Some(BaseId::HeapAlloc { .. })),
+        "foreign malloc must keep heap-alloc provenance, got {q:#?}"
+    );
+}

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -10,7 +10,10 @@ use super::{
 };
 use crate::{
     analyses::type_qualifier::foster::mutability::mutability_analysis,
-    rewriter::array_local_index_rewriter::group_has_rewritable_binding, utils::rustc::RustProgram,
+    rewriter::array_local_index_rewriter::{
+        group_has_rewritable_binding, group_suppresses_caller_visible_store,
+    },
+    utils::rustc::RustProgram,
 };
 
 fn build_rust_program(tcx: rustc_middle::ty::TyCtxt<'_>) -> RustProgram<'_> {
@@ -169,6 +172,7 @@ struct RewriteGroupFacts {
     member_root_names: FxHashSet<String>,
     index_tracked: bool,
     has_rewritable_binding: bool,
+    suppresses_caller_visible_store: bool,
     kind: &'static str,
     writes_base_binding: bool,
     preserved_call_count: usize,
@@ -245,6 +249,8 @@ fn run_rewrite_groups_with_points_to(
                     };
                     let has_rewritable_binding =
                         group_has_rewritable_binding(tcx, did, &body, result, &group);
+                    let suppresses_caller_visible_store =
+                        group_suppresses_caller_visible_store(result, &group);
                     let member_names = group
                         .members
                         .iter()
@@ -274,6 +280,7 @@ fn run_rewrite_groups_with_points_to(
                         kind,
                         index_tracked: group.index_tracked,
                         has_rewritable_binding,
+                        suppresses_caller_visible_store,
                         writes_base_binding,
                         preserved_call_count,
                     }
@@ -2484,3 +2491,101 @@ fn group_has_rewritable_binding_for_field_base_group() {
         "expected has_rewritable_binding=true for the field-base group, got: {process_groups:?}"
     );
 }
+
+#[test]
+fn index_tracked_pointee_field_base_group_is_flagged_store_suppressing() {
+    // cp_block shape: the base slot (*state).out lives behind a parameter
+    // pointer; turning its direct store into an index update would hide the
+    // advanced pointer from the caller, so the rewriter must skip the group
+    // even though selection still classifies it as index_tracked.
+    let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
+        r#"
+        pub struct State {
+            pub out: *mut i8,
+        }
+
+        unsafe extern "C" {
+            fn process(state: *mut State);
+        }
+
+        pub unsafe fn f(state: *mut State, backward: usize, n: usize) {
+            process(state);
+            let src: *const i8 = ((*state).out as *const i8).sub(backward);
+            (*state).out = ((*state).out).add(n);
+            let _keep: *const i8 = src;
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    let group = f_groups
+        .iter()
+        .find(|group| group.index_tracked && group.member_names.contains("state.out"))
+        .unwrap_or_else(|| panic!("expected index_tracked state.out group: {f_groups:#?}"));
+    assert!(
+        group.suppresses_caller_visible_store,
+        "index-tracked pointee field base must be flagged store-suppressing: {group:#?}"
+    );
+}
+
+#[test]
+fn index_tracked_by_value_field_base_group_is_not_flagged_store_suppressing() {
+    // pair.a lives in the by-value parameter copy; suppressing its store is
+    // invisible to the caller, so the group stays plannable.
+    let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
+        r#"
+        pub struct Pair {
+            pub a: *mut i32,
+            pub b: *mut i32,
+        }
+
+        pub unsafe fn f(mut pair: Pair, i: usize) {
+            let qa = pair.a.add(i);
+            let qb = pair.b.add(i);
+            pair.a = pair.a.add(1);
+            let ra = qa.add(1);
+            let rb = qb.add(1);
+            let _ = (*ra, *rb);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    let group = f_groups
+        .iter()
+        .find(|group| group.index_tracked && group.member_names.contains("qa"))
+        .unwrap_or_else(|| panic!("expected index_tracked pair.a group: {f_groups:#?}"));
+    assert!(
+        !group.suppresses_caller_visible_store,
+        "by-value field base writes a local copy and must stay plannable: {group:#?}"
+    );
+}
+
+#[test]
+fn index_tracked_top_level_param_group_is_not_flagged_store_suppressing() {
+    // p is a by-value parameter binding; reassigning it is caller-invisible.
+    let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
+        r#"
+        pub unsafe fn f(mut p: *mut i32, i: usize) {
+            let q = p.add(i);
+            p = p.add(1);
+            let r = q.add(1);
+            let _ = (*q, *r);
+        }
+        "#,
+    );
+
+    let f_groups = groups.get("f").unwrap();
+    let group = f_groups
+        .iter()
+        .find(|group| group.index_tracked && group.member_names.contains("q"))
+        .unwrap_or_else(|| panic!("expected index_tracked param group: {f_groups:#?}"));
+    assert!(
+        !group.suppresses_caller_visible_store,
+        "top-level param cursor must stay plannable: {group:#?}"
+    );
+}
+

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -161,32 +161,6 @@ fn run_interprocedural_analysis(code: &str) -> FxHashMap<(String, String), Local
     .unwrap()
 }
 
-fn run_call_effects(code: &str) -> FxHashMap<String, Vec<(usize, usize, bool)>> {
-    ::utils::compilation::run_compiler_on_str(code, |tcx| {
-        let program = build_rust_program(tcx);
-        let results = array_local_provenance_analysis(&program, &FxHashSet::default());
-        program
-            .functions
-            .iter()
-            .map(|&did| {
-                let name = tcx.item_name(did.to_def_id()).to_string();
-                let mut effects = results[&did]
-                    .call_effects
-                    .values()
-                    .flat_map(|effect| {
-                        effect.writes.iter().map(|write| {
-                            (write.dst_arg_index, write.sources.len(), effect.complete)
-                        })
-                    })
-                    .collect::<Vec<_>>();
-                effects.sort();
-                (name, effects)
-            })
-            .collect()
-    })
-    .unwrap()
-}
-
 #[derive(Clone, Debug)]
 struct RewriteGroupFacts {
     base: BaseId,
@@ -195,112 +169,21 @@ struct RewriteGroupFacts {
     member_root_names: FxHashSet<String>,
     index_tracked: bool,
     has_rewritable_binding: bool,
-}
-
-#[derive(Clone, Debug)]
-struct RewriteGroupStatusFacts {
-    base_name: Option<String>,
-    member_names: FxHashSet<String>,
     kind: &'static str,
-    index_tracked: bool,
     writes_base_binding: bool,
     preserved_call_count: usize,
 }
 
-fn run_rewrite_groups_with_points_to(code: &str) -> FxHashMap<String, Vec<RewriteGroupFacts>> {
-    ::utils::compilation::run_compiler_on_str(code, |tcx| {
-        let rust_program = build_rust_program(tcx);
-        let mutability_result = mutability_analysis(&rust_program);
-
-        let arena = Arena::new();
-        let tss = ty_shape::get_ty_shapes(&arena, tcx, false);
-        let andersen_config = andersen::Config {
-            use_optimized_mir: false,
-            c_exposed_fns: FxHashSet::default(),
-        };
-        let pre_points_to = andersen::pre_analyze(&andersen_config, &tss, tcx);
-        let alloc_fns = pre_points_to.alloc_fns.clone();
-        let solutions = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
-        let points_to =
-            andersen::post_analyze(&andersen_config, pre_points_to, solutions, &tss, tcx);
-        let results = array_local_provenance_analysis(&rust_program, &alloc_fns);
-
-        let mut facts = FxHashMap::default();
-
-        for &did in &rust_program.functions {
-            let fn_name = tcx.item_name(did.to_def_id()).to_string();
-            let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
-            let result = &results[&did];
-            let groups = super::select_rewrite_groups(
-                result,
-                &body,
-                &mutability_result,
-                did,
-                super::RewriteSelectionContext {
-                    tcx,
-                    points_to: &points_to,
-                },
-            );
-
-            let mut local_names: FxHashMap<rustc_middle::mir::Local, String> = FxHashMap::default();
-            for dbg in &body.var_debug_info {
-                if let rustc_middle::mir::VarDebugInfoContents::Place(place) = &dbg.value
-                    && let Some(local) = place.as_local()
-                {
-                    local_names.entry(local).or_insert(dbg.name.to_string());
-                }
-            }
-
-            let rewritable: Vec<bool> = groups
-                .iter()
-                .map(|g| group_has_rewritable_binding(tcx, did, &body, &result, g))
-                .collect();
-            let group_facts = groups
-                .into_iter()
-                .zip(rewritable)
-                .map(|(group, has_rewritable_binding)| {
-                    let member_names = group
-                        .members
-                        .iter()
-                        .filter_map(|slot| {
-                            let info = &result.slot_table.slot_infos[*slot];
-                            super::source_var_identity_for_slot(tcx, &body, &local_names, info)
-                        })
-                        .collect();
-                    let member_root_names = group
-                        .members
-                        .iter()
-                        .filter_map(|slot| {
-                            let info = &result.slot_table.slot_infos[*slot];
-                            local_names.get(&info.root).cloned()
-                        })
-                        .collect();
-                    let base_name = super::base_slot_info(&result, &group)
-                        .and_then(|info| {
-                            super::source_var_identity_for_slot(tcx, &body, &local_names, info)
-                        })
-                        .or_else(|| local_names.get(&group.base_local).cloned());
-                    RewriteGroupFacts {
-                        base: group.base,
-                        base_name,
-                        member_names,
-                        member_root_names,
-                        index_tracked: group.index_tracked,
-                        has_rewritable_binding,
-                    }
-                })
-                .collect();
-            facts.insert(fn_name, group_facts);
-        }
-
-        facts
-    })
-    .unwrap()
+#[derive(Clone, Copy)]
+enum RewriteGroupFactMode {
+    ReadyOnly,
+    Detailed,
 }
 
-fn run_rewrite_group_statuses_with_points_to(
+fn run_rewrite_groups_with_points_to(
+    mode: RewriteGroupFactMode,
     code: &str,
-) -> FxHashMap<String, Vec<RewriteGroupStatusFacts>> {
+) -> FxHashMap<String, Vec<RewriteGroupFacts>> {
     ::utils::compilation::run_compiler_on_str(code, |tcx| {
         let rust_program = build_rust_program(tcx);
         let mutability_result = mutability_analysis(&rust_program);
@@ -323,16 +206,21 @@ fn run_rewrite_group_statuses_with_points_to(
             let fn_name = tcx.item_name(did.to_def_id()).to_string();
             let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
             let result = &results[&did];
-            let statuses = super::classify_rewrite_groups(
-                result,
-                &body,
-                &mutability_result,
-                did,
-                super::RewriteSelectionContext {
-                    tcx,
-                    points_to: &points_to,
-                },
-            );
+            let context = super::RewriteSelectionContext {
+                tcx,
+                points_to: &points_to,
+            };
+            let statuses = match mode {
+                RewriteGroupFactMode::ReadyOnly => {
+                    super::select_rewrite_groups(result, &body, &mutability_result, did, context)
+                        .into_iter()
+                        .map(super::RewriteGroupStatus::Ready)
+                        .collect()
+                }
+                RewriteGroupFactMode::Detailed => {
+                    super::classify_rewrite_groups(result, &body, &mutability_result, did, context)
+                }
+            };
 
             let mut local_names: FxHashMap<rustc_middle::mir::Local, String> = FxHashMap::default();
             for dbg in &body.var_debug_info {
@@ -355,6 +243,8 @@ fn run_rewrite_group_statuses_with_points_to(
                             calls.len(),
                         ),
                     };
+                    let has_rewritable_binding =
+                        group_has_rewritable_binding(tcx, did, &body, result, &group);
                     let member_names = group
                         .members
                         .iter()
@@ -363,16 +253,27 @@ fn run_rewrite_group_statuses_with_points_to(
                             super::source_var_identity_for_slot(tcx, &body, &local_names, info)
                         })
                         .collect();
+                    let member_root_names = group
+                        .members
+                        .iter()
+                        .filter_map(|slot| {
+                            let info = &result.slot_table.slot_infos[*slot];
+                            local_names.get(&info.root).cloned()
+                        })
+                        .collect();
                     let base_name = super::base_slot_info(result, &group)
                         .and_then(|info| {
                             super::source_var_identity_for_slot(tcx, &body, &local_names, info)
                         })
                         .or_else(|| local_names.get(&group.base_local).cloned());
-                    RewriteGroupStatusFacts {
+                    RewriteGroupFacts {
+                        base: group.base,
                         base_name,
                         member_names,
+                        member_root_names,
                         kind,
                         index_tracked: group.index_tracked,
+                        has_rewritable_binding,
                         writes_base_binding,
                         preserved_call_count,
                     }
@@ -430,6 +331,7 @@ fn assert_has_only_nulltransparent_base(fact: &LocalFacts, expected: &BaseId) {
 #[test]
 fn array_local_provenance_rewrite_groups_select_immutable_param_aliases() {
     let map = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(p: *mut i32, i: usize) {
             let q = p.add(i);
@@ -455,7 +357,8 @@ fn array_local_provenance_rewrite_groups_select_immutable_param_aliases() {
 
 #[test]
 fn classify_rewrite_groups_marks_cjson_calls_as_preserved() {
-    let statuses = run_rewrite_group_statuses_with_points_to(
+    let statuses = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::Detailed,
         r#"
         pub unsafe fn advance(input: &mut *mut i8) {
             *input = (*input).add(1);
@@ -488,7 +391,8 @@ fn classify_rewrite_groups_marks_cjson_calls_as_preserved() {
 
 #[test]
 fn classify_rewrite_groups_marks_member_only_call_as_preserved() {
-    let statuses = run_rewrite_group_statuses_with_points_to(
+    let statuses = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::Detailed,
         r#"
         pub unsafe fn advance(input: &mut *mut i32) {
             *input = (*input).add(1);
@@ -518,7 +422,8 @@ fn classify_rewrite_groups_marks_member_only_call_as_preserved() {
 
 #[test]
 fn classify_rewrite_groups_accepts_same_base_cross_argument_flow() {
-    let statuses = run_rewrite_group_statuses_with_points_to(
+    let statuses = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::Detailed,
         r#"
         pub unsafe fn copy_cursor(input: &mut *mut i32, output: &mut *mut i32) {
             *output = *input;
@@ -547,7 +452,8 @@ fn classify_rewrite_groups_accepts_same_base_cross_argument_flow() {
 
 #[test]
 fn classify_rewrite_groups_rejects_different_base_cross_argument_flow() {
-    let statuses = run_rewrite_group_statuses_with_points_to(
+    let statuses = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::Detailed,
         r#"
         pub unsafe fn copy_cursor(input: &mut *mut i32, output: &mut *mut i32) {
             *output = *input;
@@ -575,7 +481,8 @@ fn classify_rewrite_groups_rejects_different_base_cross_argument_flow() {
 
 #[test]
 fn classify_rewrite_groups_rejects_summarized_unknown_write() {
-    let statuses = run_rewrite_group_statuses_with_points_to(
+    let statuses = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::Detailed,
         r#"
         unsafe extern "C" {
             fn touch(input: *mut *mut i32);
@@ -607,7 +514,8 @@ fn classify_rewrite_groups_rejects_summarized_unknown_write() {
 
 #[test]
 fn classify_rewrite_groups_keeps_direct_assignment_ready() {
-    let statuses = run_rewrite_group_statuses_with_points_to(
+    let statuses = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::Detailed,
         r#"
         pub unsafe fn f(mut p: *mut i32) {
             let q = p.add(1);
@@ -633,6 +541,7 @@ fn classify_rewrite_groups_keeps_direct_assignment_ready() {
 #[test]
 fn select_rewrite_groups_excludes_preserved_call_groups() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn advance(input: &mut *mut i32) {
             *input = (*input).add(1);
@@ -652,6 +561,7 @@ fn select_rewrite_groups_excludes_preserved_call_groups() {
 #[test]
 fn select_rewrite_groups_accepts_mut_param_when_base_is_not_reassigned() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(mut p: *mut i32, i: usize) {
             let q = p.add(i);
@@ -676,6 +586,7 @@ fn select_rewrite_groups_accepts_mut_param_when_base_is_not_reassigned() {
 fn select_rewrite_groups_selects_as_index_tracked_when_param_directly_reassigned_while_member_live()
 {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(mut p: *mut i32, i: usize) {
             let q = p.add(i);
@@ -702,6 +613,7 @@ fn select_rewrite_groups_selects_as_index_tracked_when_param_directly_reassigned
 fn select_rewrite_groups_index_tracked_when_named_aggregate_member_live_after_direct_param_reassign()
  {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct Holder { pub ptr: *mut i32 }
 
@@ -733,6 +645,7 @@ fn select_rewrite_groups_index_tracked_when_named_aggregate_member_live_after_di
 #[test]
 fn select_rewrite_groups_rejects_mut_param_written_through_pointer_to_param() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(mut p: *mut i32, i: usize) {
             let pp = &raw mut p;
@@ -758,6 +671,7 @@ fn select_rewrite_groups_rejects_mut_param_written_through_pointer_to_param() {
 #[test]
 fn select_rewrite_groups_rejects_param_when_call_may_write_base_storage() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         unsafe extern "C" {
             fn touch(slot: *mut *mut i32);
@@ -785,6 +699,7 @@ fn select_rewrite_groups_rejects_param_when_call_may_write_base_storage() {
 #[test]
 fn select_rewrite_groups_rejects_param_when_by_value_aggregate_call_arg_contains_base_pointer() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct Holder {
             pub other: *mut i32,
@@ -820,6 +735,7 @@ fn select_rewrite_groups_rejects_param_when_by_value_aggregate_call_arg_contains
 #[test]
 fn select_rewrite_groups_rejects_param_when_projected_call_arg_may_write_base_storage() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct Holder {
             pub pp: *mut *mut i32,
@@ -851,6 +767,7 @@ fn select_rewrite_groups_rejects_param_when_projected_call_arg_may_write_base_st
 #[test]
 fn select_rewrite_groups_rejects_param_field_when_call_may_write_parent_aggregate() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct Pair {
             pub a: *mut i32,
@@ -883,6 +800,7 @@ fn select_rewrite_groups_rejects_param_field_when_call_may_write_parent_aggregat
 #[test]
 fn select_rewrite_groups_rejects_mut_param_field_written_through_pointer_to_field() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct S { pub n: i32, pub p: *mut i32 }
 
@@ -910,6 +828,7 @@ fn select_rewrite_groups_rejects_mut_param_field_written_through_pointer_to_fiel
 #[test]
 fn select_rewrite_groups_rejects_pointee_param_base_written_through_alias() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(p: *mut *mut i32, replacement: *mut i32, i: usize) {
             let pp = p;
@@ -935,6 +854,7 @@ fn select_rewrite_groups_rejects_pointee_param_base_written_through_alias() {
 #[test]
 fn select_rewrite_groups_index_tracked_for_mutated_struct_param_field() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct Pair {
             pub a: *mut i32,
@@ -996,7 +916,7 @@ fn select_rewrite_groups_live_is_null_does_not_destabilize_state_buffer_base() {
             let _ = ptr;
         }
         "#;
-    let groups = run_rewrite_groups_with_points_to(code);
+    let groups = run_rewrite_groups_with_points_to(RewriteGroupFactMode::ReadyOnly, code);
 
     let facts = groups.get("f").expect("missing facts for f");
     let _group = facts
@@ -1012,6 +932,7 @@ fn select_rewrite_groups_live_is_null_does_not_destabilize_state_buffer_base() {
 #[test]
 fn select_rewrite_groups_counts_named_local_field_as_source_var() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct Holder {
             pub ptr: *mut i32,
@@ -1038,6 +959,7 @@ fn select_rewrite_groups_counts_named_local_field_as_source_var() {
 #[test]
 fn select_rewrite_groups_does_not_count_array_element_as_source_var() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(p: *mut i32) {
             let mut slots = [core::ptr::null_mut()];
@@ -1073,6 +995,7 @@ fn select_rewrite_groups_does_not_count_array_element_as_source_var() {
 #[test]
 fn select_rewrite_groups_does_not_count_tuple_field_as_source_var() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(p: *mut i32) {
             let mut pair = (core::ptr::null_mut(), 1i32);
@@ -1108,6 +1031,7 @@ fn select_rewrite_groups_does_not_count_tuple_field_as_source_var() {
 #[test]
 fn select_rewrite_groups_accepts_mut_param_reassigned_before_members_exist() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(mut p: *mut i32, i: usize) {
             p = p.add(1);
@@ -1132,6 +1056,7 @@ fn select_rewrite_groups_accepts_mut_param_reassigned_before_members_exist() {
 #[test]
 fn array_local_provenance_rewrite_groups_select_local_array_base() {
     let map = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(i: usize) {
             let mut arr = [0_i32; 4];
@@ -1681,25 +1606,6 @@ fn array_local_provenance_complete_empty_summary_avoids_unknown_fallback() {
     );
 
     assert_unique_param(facts(&map, "f", "q"));
-}
-
-#[test]
-fn array_local_provenance_records_instantiated_arg_write_effects() {
-    let effects = run_call_effects(
-        r#"
-        pub unsafe fn copy_cursor(input: &mut *mut i32, output: &mut *mut i32) {
-            *output = *input;
-        }
-
-        pub unsafe fn f(mut p: *mut i32) {
-            let mut q = p.add(1);
-            copy_cursor(&mut p, &mut q);
-            let _ = (*p, *q);
-        }
-        "#,
-    );
-
-    assert_eq!(effects["f"], vec![(1, 1, true)]);
 }
 
 #[test]
@@ -2266,6 +2172,7 @@ fn array_local_provenance_cast_single_slot_slot0_preserves_param_provenance() {
 #[test]
 fn select_rewrite_groups_selects_cast_cursor_over_param_base() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         fn parse_bool(c: i8) -> bool {
             c == 89 || c == 121
@@ -2359,6 +2266,7 @@ fn array_local_provenance_struct_field_array_offset_pointers_share_base() {
 #[test]
 fn select_rewrite_groups_reject_struct_pointer_base_for_field_array_pointers() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct Info {
             pub steps: *mut u32,
@@ -2386,6 +2294,7 @@ fn select_rewrite_groups_reject_struct_pointer_base_for_field_array_pointers() {
 #[test]
 fn select_rewrite_groups_extern_call_with_struct_param_does_not_contaminate_param_field_slot() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct State {
             pub out: *mut i8,
@@ -2418,6 +2327,7 @@ fn select_rewrite_groups_extern_call_with_struct_param_does_not_contaminate_para
 #[test]
 fn select_rewrite_groups_cp_block_pattern_produces_index_tracked_group() {
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub struct State {
             pub out: *mut i8,
@@ -2452,6 +2362,7 @@ fn select_rewrite_groups_cp_block_pattern_produces_index_tracked_group() {
 fn liveness_gate_rejects_group_when_two_mut_locals_never_simultaneously_live() {
     // q is used and dead before r is created — no simultaneous borrow conflict.
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(p: *mut i32) {
             let q = p.add(1);
@@ -2476,6 +2387,7 @@ fn liveness_gate_rejects_group_when_two_mut_locals_never_simultaneously_live() {
 fn liveness_gate_accepts_group_when_two_mut_locals_simultaneously_live() {
     // q and r are both live at the tuple read — genuine borrow conflict.
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(p: *mut i32) {
             let q = p.add(1);
@@ -2499,6 +2411,7 @@ fn liveness_gate_accepts_group_when_two_mut_locals_simultaneously_live() {
 fn liveness_gate_rejects_group_when_mut_and_imm_locals_never_simultaneously_live() {
     // q (mut) is dead before r (const cast) is created.
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(p: *mut i32) {
             let q = p.add(1);
@@ -2523,6 +2436,7 @@ fn liveness_gate_rejects_group_when_mut_and_imm_locals_never_simultaneously_live
 fn liveness_gate_accepts_group_when_mut_and_imm_locals_simultaneously_live() {
     // q (*mut) and r (*const alias of q) are both alive at the tuple read.
     let groups = run_rewrite_groups_with_points_to(
+        RewriteGroupFactMode::ReadyOnly,
         r#"
         pub unsafe fn f(p: *mut i32) {
             let q = p.add(1);
@@ -2559,7 +2473,7 @@ fn group_has_rewritable_binding_for_field_base_group() {
         }
     "#;
 
-    let facts = run_rewrite_groups_with_points_to(code);
+    let facts = run_rewrite_groups_with_points_to(RewriteGroupFactMode::ReadyOnly, code);
     let process_groups = facts.get("process").expect("process not found");
     assert!(
         !process_groups.is_empty(),

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -161,6 +161,32 @@ fn run_interprocedural_analysis(code: &str) -> FxHashMap<(String, String), Local
     .unwrap()
 }
 
+fn run_call_effects(code: &str) -> FxHashMap<String, Vec<(usize, usize, bool)>> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let program = build_rust_program(tcx);
+        let results = array_local_provenance_analysis(&program, &FxHashSet::default());
+        program
+            .functions
+            .iter()
+            .map(|&did| {
+                let name = tcx.item_name(did.to_def_id()).to_string();
+                let mut effects = results[&did]
+                    .call_effects
+                    .values()
+                    .flat_map(|effect| {
+                        effect.writes.iter().map(|write| {
+                            (write.dst_arg_index, write.sources.len(), effect.complete)
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                effects.sort();
+                (name, effects)
+            })
+            .collect()
+    })
+    .unwrap()
+}
+
 #[derive(Clone, Debug)]
 struct RewriteGroupFacts {
     base: BaseId,
@@ -169,6 +195,16 @@ struct RewriteGroupFacts {
     member_root_names: FxHashSet<String>,
     index_tracked: bool,
     has_rewritable_binding: bool,
+}
+
+#[derive(Clone, Debug)]
+struct RewriteGroupStatusFacts {
+    base_name: Option<String>,
+    member_names: FxHashSet<String>,
+    kind: &'static str,
+    index_tracked: bool,
+    writes_base_binding: bool,
+    preserved_call_count: usize,
 }
 
 fn run_rewrite_groups_with_points_to(code: &str) -> FxHashMap<String, Vec<RewriteGroupFacts>> {
@@ -187,15 +223,16 @@ fn run_rewrite_groups_with_points_to(code: &str) -> FxHashMap<String, Vec<Rewrit
         let solutions = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
         let points_to =
             andersen::post_analyze(&andersen_config, pre_points_to, solutions, &tss, tcx);
+        let results = array_local_provenance_analysis(&rust_program, &alloc_fns);
 
         let mut facts = FxHashMap::default();
 
         for &did in &rust_program.functions {
             let fn_name = tcx.item_name(did.to_def_id()).to_string();
             let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
-            let result = analyze_body(tcx, did, &body, &alloc_fns);
+            let result = &results[&did];
             let groups = super::select_rewrite_groups(
-                &result,
+                result,
                 &body,
                 &mutability_result,
                 did,
@@ -254,6 +291,94 @@ fn run_rewrite_groups_with_points_to(code: &str) -> FxHashMap<String, Vec<Rewrit
                 })
                 .collect();
             facts.insert(fn_name, group_facts);
+        }
+
+        facts
+    })
+    .unwrap()
+}
+
+fn run_rewrite_group_statuses_with_points_to(
+    code: &str,
+) -> FxHashMap<String, Vec<RewriteGroupStatusFacts>> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        let rust_program = build_rust_program(tcx);
+        let mutability_result = mutability_analysis(&rust_program);
+
+        let arena = Arena::new();
+        let tss = ty_shape::get_ty_shapes(&arena, tcx, false);
+        let andersen_config = andersen::Config {
+            use_optimized_mir: false,
+            c_exposed_fns: FxHashSet::default(),
+        };
+        let pre_points_to = andersen::pre_analyze(&andersen_config, &tss, tcx);
+        let alloc_fns = pre_points_to.alloc_fns.clone();
+        let solutions = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
+        let points_to =
+            andersen::post_analyze(&andersen_config, pre_points_to, solutions, &tss, tcx);
+        let results = array_local_provenance_analysis(&rust_program, &alloc_fns);
+
+        let mut facts = FxHashMap::default();
+        for &did in &rust_program.functions {
+            let fn_name = tcx.item_name(did.to_def_id()).to_string();
+            let body = tcx.mir_drops_elaborated_and_const_checked(did).borrow();
+            let result = &results[&did];
+            let statuses = super::classify_rewrite_groups(
+                result,
+                &body,
+                &mutability_result,
+                did,
+                super::RewriteSelectionContext {
+                    tcx,
+                    points_to: &points_to,
+                },
+            );
+
+            let mut local_names: FxHashMap<rustc_middle::mir::Local, String> = FxHashMap::default();
+            for dbg in &body.var_debug_info {
+                if let rustc_middle::mir::VarDebugInfoContents::Place(place) = &dbg.value
+                    && let Some(local) = place.as_local()
+                {
+                    local_names.entry(local).or_insert(dbg.name.to_string());
+                }
+            }
+
+            let status_facts = statuses
+                .into_iter()
+                .map(|status| {
+                    let (group, kind, writes_base_binding, preserved_call_count) = match status {
+                        super::RewriteGroupStatus::Ready(group) => (group, "ready", false, 0),
+                        super::RewriteGroupStatus::PreservedAcrossCalls { group, calls } => (
+                            group,
+                            "preserved_across_calls",
+                            calls.iter().any(|call| call.writes_base_binding),
+                            calls.len(),
+                        ),
+                    };
+                    let member_names = group
+                        .members
+                        .iter()
+                        .filter_map(|slot| {
+                            let info = &result.slot_table.slot_infos[*slot];
+                            super::source_var_identity_for_slot(tcx, &body, &local_names, info)
+                        })
+                        .collect();
+                    let base_name = super::base_slot_info(result, &group)
+                        .and_then(|info| {
+                            super::source_var_identity_for_slot(tcx, &body, &local_names, info)
+                        })
+                        .or_else(|| local_names.get(&group.base_local).cloned());
+                    RewriteGroupStatusFacts {
+                        base_name,
+                        member_names,
+                        kind,
+                        index_tracked: group.index_tracked,
+                        writes_base_binding,
+                        preserved_call_count,
+                    }
+                })
+                .collect();
+            facts.insert(fn_name, status_facts);
         }
 
         facts
@@ -326,6 +451,202 @@ fn array_local_provenance_rewrite_groups_select_immutable_param_aliases() {
         }),
         "expected Param rewrite group containing q and r: {groups:#?}"
     );
+}
+
+#[test]
+fn classify_rewrite_groups_marks_cjson_calls_as_preserved() {
+    let statuses = run_rewrite_group_statuses_with_points_to(
+        r#"
+        pub unsafe fn advance(input: &mut *mut i8) {
+            *input = (*input).add(1);
+        }
+
+        pub unsafe fn minify(input: &mut *mut i8, output: &mut *mut i8) {
+            *input = (*input).add(1);
+            *output = (*output).add(1);
+        }
+
+        pub unsafe fn f(mut json: *mut i8) {
+            let mut into = json;
+            advance(&mut json);
+            minify(&mut json, &mut into);
+            let _ = (*json, *into);
+        }
+        "#,
+    );
+
+    let status = statuses["f"]
+        .iter()
+        .find(|status| {
+            status.base_name.as_deref() == Some("json") && status.member_names.contains("into")
+        })
+        .expect("expected json/into candidate");
+    assert_eq!(status.kind, "preserved_across_calls");
+    assert!(status.writes_base_binding);
+    assert_eq!(status.preserved_call_count, 2);
+}
+
+#[test]
+fn classify_rewrite_groups_marks_member_only_call_as_preserved() {
+    let statuses = run_rewrite_group_statuses_with_points_to(
+        r#"
+        pub unsafe fn advance(input: &mut *mut i32) {
+            *input = (*input).add(1);
+        }
+
+        pub unsafe fn f(p: *mut i32) {
+            let mut q = p;
+            let r = p.add(1);
+            advance(&mut q);
+            let _ = (*p, *q, *r);
+        }
+        "#,
+    );
+
+    let status = statuses["f"]
+        .iter()
+        .find(|status| {
+            status.base_name.as_deref() == Some("p")
+                && status.member_names.contains("q")
+                && status.member_names.contains("r")
+        })
+        .expect("expected p/q/r candidate");
+    assert_eq!(status.kind, "preserved_across_calls");
+    assert!(!status.writes_base_binding);
+    assert_eq!(status.preserved_call_count, 1);
+}
+
+#[test]
+fn classify_rewrite_groups_accepts_same_base_cross_argument_flow() {
+    let statuses = run_rewrite_group_statuses_with_points_to(
+        r#"
+        pub unsafe fn copy_cursor(input: &mut *mut i32, output: &mut *mut i32) {
+            *output = *input;
+        }
+
+        pub unsafe fn f(mut p: *mut i32) {
+            let mut q = p.add(1);
+            let r = p.add(2);
+            copy_cursor(&mut p, &mut q);
+            let _ = (*p, *q, *r);
+        }
+        "#,
+    );
+
+    let status = statuses["f"]
+        .iter()
+        .find(|status| {
+            status.base_name.as_deref() == Some("p")
+                && status.member_names.contains("q")
+                && status.member_names.contains("r")
+        })
+        .expect("expected same-base cross-argument candidate");
+    assert_eq!(status.kind, "preserved_across_calls");
+    assert!(!status.writes_base_binding);
+}
+
+#[test]
+fn classify_rewrite_groups_rejects_different_base_cross_argument_flow() {
+    let statuses = run_rewrite_group_statuses_with_points_to(
+        r#"
+        pub unsafe fn copy_cursor(input: &mut *mut i32, output: &mut *mut i32) {
+            *output = *input;
+        }
+
+        pub unsafe fn f(mut p: *mut i32, mut other: *mut i32) {
+            let q = p.add(1);
+            copy_cursor(&mut other, &mut p);
+            let r = q.add(1);
+            let _ = (*p, *q, *r);
+        }
+        "#,
+    );
+
+    assert!(
+        !statuses["f"].iter().any(|status| {
+            status.base_name.as_deref() == Some("p")
+                && status.member_names.contains("q")
+                && status.member_names.contains("r")
+        }),
+        "{:#?}",
+        statuses["f"]
+    );
+}
+
+#[test]
+fn classify_rewrite_groups_rejects_summarized_unknown_write() {
+    let statuses = run_rewrite_group_statuses_with_points_to(
+        r#"
+        unsafe extern "C" {
+            fn touch(input: *mut *mut i32);
+        }
+
+        pub unsafe fn helper(input: &mut *mut i32) {
+            touch(input);
+        }
+
+        pub unsafe fn f(mut p: *mut i32) {
+            let q = p.add(1);
+            helper(&mut p);
+            let r = q.add(1);
+            let _ = (*p, *q, *r);
+        }
+        "#,
+    );
+
+    assert!(
+        !statuses["f"].iter().any(|status| {
+            status.base_name.as_deref() == Some("p")
+                && status.member_names.contains("q")
+                && status.member_names.contains("r")
+        }),
+        "{:#?}",
+        statuses["f"]
+    );
+}
+
+#[test]
+fn classify_rewrite_groups_keeps_direct_assignment_ready() {
+    let statuses = run_rewrite_group_statuses_with_points_to(
+        r#"
+        pub unsafe fn f(mut p: *mut i32) {
+            let q = p.add(1);
+            p = p.add(2);
+            let r = q.add(1);
+            let _ = (*p, *q, *r);
+        }
+        "#,
+    );
+
+    let status = statuses["f"]
+        .iter()
+        .find(|status| {
+            status.base_name.as_deref() == Some("p")
+                && status.member_names.contains("q")
+                && status.member_names.contains("r")
+        })
+        .expect("expected direct-assignment candidate");
+    assert_eq!(status.kind, "ready");
+    assert!(status.index_tracked);
+}
+
+#[test]
+fn select_rewrite_groups_excludes_preserved_call_groups() {
+    let groups = run_rewrite_groups_with_points_to(
+        r#"
+        pub unsafe fn advance(input: &mut *mut i32) {
+            *input = (*input).add(1);
+        }
+
+        pub unsafe fn f(mut p: *mut i32) {
+            let q = p;
+            advance(&mut p);
+            let _ = (*p, *q);
+        }
+        "#,
+    );
+
+    assert!(groups["f"].is_empty(), "{:#?}", groups["f"]);
 }
 
 #[test]
@@ -1288,8 +1609,97 @@ fn array_local_provenance_direct_callee_arg_write_from_first_param_cjson_shape()
     let into = facts(&map, "cjson_minify", "into");
     let r = facts(&map, "cjson_minify", "r");
     assert_unique_param(q);
-    assert_eq!(into.unique, q.unique, "into should keep q/json base: {into:#?}");
+    assert_eq!(
+        into.unique, q.unique,
+        "into should keep q/json base: {into:#?}"
+    );
     assert_eq!(r.unique, q.unique, "r should keep q/json base: {r:#?}");
+}
+
+#[test]
+fn array_local_provenance_reference_self_write_preserves_base() {
+    let map = run_interprocedural_analysis(
+        r#"
+        pub unsafe fn advance(input: &mut *mut i32) {
+            *input = (*input).add(1);
+        }
+
+        pub unsafe fn f(mut p: *mut i32) {
+            let q = p;
+            advance(&mut p);
+            let r = q.add(1);
+            let _ = (*p, *q, *r);
+        }
+        "#,
+    );
+
+    let p = facts(&map, "f", "p");
+    let q = facts(&map, "f", "q");
+    let r = facts(&map, "f", "r");
+    assert_unique_param(p);
+    assert_eq!(q.unique, p.unique, "{q:#?}");
+    assert_eq!(r.unique, p.unique, "{r:#?}");
+}
+
+#[test]
+fn array_local_provenance_reference_cross_arg_same_base_preserves_base() {
+    let map = run_interprocedural_analysis(
+        r#"
+        pub unsafe fn copy_cursor(input: &mut *mut i32, output: &mut *mut i32) {
+            *output = *input;
+        }
+
+        pub unsafe fn f(mut p: *mut i32) {
+            let mut q = p.add(2);
+            copy_cursor(&mut p, &mut q);
+            let r = q.add(1);
+            let _ = (*p, *q, *r);
+        }
+        "#,
+    );
+
+    let p = facts(&map, "f", "p");
+    let q = facts(&map, "f", "q");
+    let r = facts(&map, "f", "r");
+    assert_unique_param(p);
+    assert_eq!(q.unique, p.unique, "{q:#?}");
+    assert_eq!(r.unique, p.unique, "{r:#?}");
+}
+
+#[test]
+fn array_local_provenance_complete_empty_summary_avoids_unknown_fallback() {
+    let map = run_interprocedural_analysis(
+        r#"
+        pub unsafe fn inspect(_input: &mut *mut i32) {}
+
+        pub unsafe fn f(mut p: *mut i32) {
+            inspect(&mut p);
+            let q = p.add(1);
+            let _ = *q;
+        }
+        "#,
+    );
+
+    assert_unique_param(facts(&map, "f", "q"));
+}
+
+#[test]
+fn array_local_provenance_records_instantiated_arg_write_effects() {
+    let effects = run_call_effects(
+        r#"
+        pub unsafe fn copy_cursor(input: &mut *mut i32, output: &mut *mut i32) {
+            *output = *input;
+        }
+
+        pub unsafe fn f(mut p: *mut i32) {
+            let mut q = p.add(1);
+            copy_cursor(&mut p, &mut q);
+            let _ = (*p, *q);
+        }
+        "#,
+    );
+
+    assert_eq!(effects["f"], vec![(1, 1, true)]);
 }
 
 #[test]
@@ -1446,20 +1856,20 @@ fn array_local_provenance_extern_call_stays_conservative() {
 
     let into = facts(&map, "f", "into");
     assert!(
-        !into.bases.iter().any(|base| matches!(base, BaseId::Param { .. })),
+        !into
+            .bases
+            .iter()
+            .any(|base| matches!(base, BaseId::Param { .. })),
         "unknown callee write should not introduce a param base: {into:#?}"
     );
     assert!(
-        into
-            .bases
-            .iter()
-            .any(|base| !matches!(
-                base,
-                BaseId::Unknown {
-                    reason: UnknownReason::NullLike,
-                    ..
-                }
-            )),
+        into.bases.iter().any(|base| !matches!(
+            base,
+            BaseId::Unknown {
+                reason: UnknownReason::NullLike,
+                ..
+            }
+        )),
         "unknown callee write should keep at least one non-null-like conservative base: {into:#?}"
     );
     assert!(
@@ -1518,7 +1928,9 @@ fn array_local_provenance_recursive_summary_does_not_panic() {
 
     let q = facts(&map, "f", "q");
     assert!(
-        q.bases.iter().any(|base| matches!(base, BaseId::Param { .. })),
+        q.bases
+            .iter()
+            .any(|base| matches!(base, BaseId::Param { .. })),
         "recursive summary should keep a Param base in the conservative result: {q:#?}"
     );
     assert!(

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -487,6 +487,21 @@ pub(crate) fn apply_array_local_index_rewrite<'tcx>(
     visitor.changed
 }
 
+/// Returns true when rewriting this group would suppress a store the caller
+/// can observe: the base is index-tracked (its direct stores become index
+/// updates that are never written back) and the base slot lives behind a
+/// `Pointee` path, i.e. in memory reachable through a parameter. Such groups
+/// stay classified by selection (future write-back support may restore them)
+/// but must not be planned for rewriting.
+pub(crate) fn group_suppresses_caller_visible_store(
+    provenance: &ArrayLocalProvenance,
+    group: &RewriteGroup,
+) -> bool {
+    group.index_tracked
+        && analyses::array_local_provenance::base_slot_info(provenance, group)
+            .is_some_and(|info| info.path.contains(&SlotPathElem::Pointee))
+}
+
 #[allow(dead_code)]
 pub(crate) fn group_has_rewritable_binding<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -786,6 +801,12 @@ struct GroupPlanContext<'a, 'tcx> {
 }
 
 fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGroup) {
+    // rewriting an index-tracked base behind a pointee path would turn its
+    // direct stores into local index updates and never write the advanced
+    // pointer back to caller-visible memory; keep such groups out of the plan.
+    if group_suppresses_caller_visible_store(context.provenance, group) {
+        return;
+    }
     let Some(&base_hir_id) = context.local_to_hir.get(&group.base_local) else {
         return;
     };

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -64,6 +64,9 @@ struct BindingRewrite {
     field_base: bool,
     base_proxy_hir_ids: FxHashSet<HirId>,
     group_member_hir_ids: FxHashSet<HirId>,
+    /// caller-visible index-tracked field base: the field write is kept live and
+    /// member materializations subtract `base_index_name` (approach D).
+    base_live: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -75,6 +78,8 @@ struct BaseCursorRewrite {
     base_is_raw_ptr: bool,
     ptr_ty: String,
     field_base: bool,
+    /// caller-visible field base whose write stays live (approach D).
+    base_live: bool,
 }
 
 type BaseCursorKey = (HirId, String);
@@ -969,6 +974,7 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                     base_is_raw_ptr,
                     ptr_ty,
                     field_base: group.base_slot_offset != 0,
+                    base_live: false,
                 },
             );
             Some(index_name)
@@ -1037,6 +1043,7 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                 field_base,
                 base_proxy_hir_ids: proxy_hir_ids.clone(),
                 group_member_hir_ids: group_member_hir_ids.clone(),
+                base_live: false,
             },
         );
     }
@@ -1405,6 +1412,7 @@ fn collect_binding_use_summaries_for_names_for_test(
                     field_base: false,
                     base_proxy_hir_ids: FxHashSet::default(),
                     group_member_hir_ids: FxHashSet::default(),
+                    base_live: false,
                 },
             )
         })

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -638,8 +638,7 @@ fn build_rewrite_plan<'tcx>(
                 points_to,
             },
         );
-        // record one Selection event per produced status before filtering
-        // (gated so no labels are built on the default, disabled path).
+        // gated so no labels are built on the default, disabled path.
         if trace.is_enabled() {
             for status in &all_statuses {
                 let (base_local, decision, reason): (
@@ -650,12 +649,11 @@ fn build_rewrite_plan<'tcx>(
                     RewriteGroupStatus::Ready(group) => {
                         (group.base_local, TraceDecision::Kept, "selected (ready)")
                     }
-                    // preserved-across-calls statuses are produced by selection but
-                    // discarded by the rewriter (not planned), so trace them as skipped.
+                    // preserved-across-calls statuses are discarded by the rewriter.
                     RewriteGroupStatus::PreservedAcrossCalls { group, .. } => (
                         group.base_local,
                         TraceDecision::Skipped,
-                        "selection produced a preserved-across-calls status (discarded, not planned)",
+                        "preserved across calls (discarded)",
                     ),
                 };
                 let label = format!("{base_local:?}");
@@ -1112,7 +1110,6 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
     };
     let non_null = context.nullity_result.non_null_locals.get(&context.def_id);
 
-    // record group kept (group made it past all early-returns and has members to process)
     context.trace.record(
         context.def_id,
         TraceSubject::Group(base_name.clone()),
@@ -1129,13 +1126,12 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
             continue;
         }
         let Some(&source_hir_id) = context.local_to_hir.get(&info.root) else {
-            // member not in HIR: skipped by the group_member_hir_ids filter
             context.trace.record(
                 context.def_id,
                 TraceSubject::Member(format!("{:?}", info.root)),
                 TraceStage::Plan,
                 TraceDecision::Skipped,
-                || "plan: member is not a raw-pointer local with a HIR binding".to_string(),
+                || "plan: member has no HIR binding".to_string(),
             );
             continue;
         };
@@ -1149,13 +1145,12 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
         let source_name = context.tcx.hir_name(source_hir_id).to_string();
         let ptr_ty = context.body.local_decls[info.root].ty;
         let ty::TyKind::RawPtr(pointee, mutability) = ptr_ty.kind() else {
-            // member not a raw-pointer type: skipped
             context.trace.record(
                 context.def_id,
                 TraceSubject::Member(source_name.clone()),
                 TraceStage::Plan,
                 TraceDecision::Skipped,
-                || "plan: member is not a raw-pointer local with a HIR binding".to_string(),
+                || "plan: member is not a raw-pointer local".to_string(),
             );
             continue;
         };
@@ -1199,7 +1194,6 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                 base_live,
             },
         );
-        // record member kept
         context.trace.record(
             context.def_id,
             TraceSubject::Member(source_name.clone()),
@@ -1576,7 +1570,7 @@ fn choose_binding_representations(
             rewrite.representation = BindingRepresentation::IndexOnly;
         }
     }
-    // record the chosen representation per member (only when tracing).
+    // gated: avoid building labels on the disabled path.
     if trace.is_enabled() {
         for (hir_id, rewrite) in &plan.by_hir_id {
             let representation = rewrite.representation.clone();

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2560,6 +2560,43 @@ fn base_assignment_index_expr(
     IndexExpr::Unsupported
 }
 
+/// For a live (caller-visible) field base, recognizes a base self-advance
+/// `(*s).out = (*s).out.offset(n)` / `.add(n)` and returns the counter update
+/// expression `out_idx + n`. Returns `None` for any other RHS (e.g. assignment
+/// from a member), which approach D does not support.
+fn live_base_self_advance_counter(
+    rhs: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    base_rewrite: &BaseCursorRewrite,
+) -> Option<Expr> {
+    let rhs = unwrap_cast_and_paren(rhs);
+    let ExprKind::MethodCall(call) = &rhs.kind else {
+        return None;
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return None;
+    }
+    let receiver = unwrap_cast_and_paren(&call.receiver);
+    let receiver_is_base = (!base_rewrite.field_base
+        && hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) == Some(base_rewrite.base_hir_id))
+        || receiver_is_base_as_ptr_for_context(
+            receiver,
+            ast_to_hir,
+            tcx,
+            base_rewrite.base_hir_id,
+            &base_rewrite.base_name,
+            base_rewrite.field_base,
+        )
+        || (base_rewrite.field_base && expr_matches_base_name(receiver, &base_rewrite.base_name));
+    if !receiver_is_base {
+        return None;
+    }
+    let offset = offset_index_arg_expr(name, &call.args[0]);
+    Some(add_index_expr(&base_rewrite.index_name, &offset))
+}
+
 fn index_init_expr(index: IndexExpr, nullable: bool) -> Option<Expr> {
     match (index, nullable) {
         (IndexExpr::Plain(expr), false) => Some(expr),
@@ -2838,6 +2875,38 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                 && let Some(index_stmt) = self.rewrite_materialized_local_stmt(local)
             {
                 new_stmts.push(index_stmt);
+                new_stmts.push(stmt);
+                continue;
+            }
+            if let StmtKind::Expr(expr) | StmtKind::Semi(expr) = &stmt.kind
+                && let ExprKind::Assign(lhs, rhs, _) = &expr.kind
+                && let Some(base_key) = direct_base_cursor_key(
+                    self.ast_to_hir,
+                    self.tcx,
+                    &self.plan.base_by_key,
+                    lhs,
+                )
+                && let Some(base_rewrite) = self.plan.base_by_key.get(&base_key)
+                && base_rewrite.base_live
+            {
+                if let Some(counter_rhs) =
+                    live_base_self_advance_counter(rhs, self.ast_to_hir, self.tcx, base_rewrite)
+                {
+                    let counter_stmt = utils::stmt!(
+                        "{} = {};",
+                        base_rewrite.index_name,
+                        pprust::expr_to_string(&counter_rhs)
+                    );
+                    // keep the field write verbatim (field stays caller-correct),
+                    // then advance the shadow counter.
+                    new_stmts.push(stmt);
+                    new_stmts.push(counter_stmt);
+                    self.changed = true;
+                    continue;
+                }
+                // not a recognized self-advance: leave the statement untouched.
+                // prune drops such groups, so members are not index-rewritten and
+                // the live field read stays correct.
                 new_stmts.push(stmt);
                 continue;
             }

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -27,11 +27,12 @@ use crate::{
     analyses::{
         self,
         array_local_provenance::{
-            ArrayLocalProvenance, PfgNode, RewriteGroup, RewriteSelectionContext, SlotInfo,
-            SlotPathElem, named_struct_field,
+            ArrayLocalProvenance, PfgNode, RewriteGroup, RewriteGroupStatus,
+            RewriteSelectionContext, SlotInfo, SlotPathElem, named_struct_field,
         },
         type_qualifier::foster::mutability::MutabilityResult,
     },
+    rewriter::array_local_trace::{RewriteTrace, TraceDecision, TraceStage, TraceSubject},
     utils::rustc::RustProgram,
 };
 
@@ -467,16 +468,43 @@ pub(crate) fn apply_array_local_index_rewrite<'tcx>(
     points_to: &andersen::AnalysisResult,
     ast_to_hir: &AstToHir,
 ) -> bool {
+    let mut trace = RewriteTrace::from_env();
+    let changed = apply_array_local_index_rewrite_inner(
+        krate,
+        input,
+        provenances,
+        mutability_result,
+        nullity_result,
+        points_to,
+        ast_to_hir,
+        &mut trace,
+    );
+    trace.emit(input.tcx);
+    changed
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_array_local_index_rewrite_inner<'tcx>(
+    krate: &mut Crate,
+    input: &RustProgram<'tcx>,
+    provenances: &FxHashMap<LocalDefId, ArrayLocalProvenance>,
+    mutability_result: &MutabilityResult,
+    nullity_result: &analyses::nullity::NullityResult,
+    points_to: &andersen::AnalysisResult,
+    ast_to_hir: &AstToHir,
+    trace: &mut RewriteTrace,
+) -> bool {
     let mut plan = build_rewrite_plan(
         input,
         provenances,
         mutability_result,
         nullity_result,
         points_to,
+        trace,
     );
     refine_base_pointer_kinds_from_ast(krate, ast_to_hir, input.tcx, &mut plan);
-    prune_unsupported_direct_place_uses(krate, ast_to_hir, input.tcx, &mut plan);
-    choose_binding_representations(krate, ast_to_hir, input.tcx, &mut plan);
+    prune_unsupported_direct_place_uses(krate, ast_to_hir, input.tcx, &mut plan, trace);
+    choose_binding_representations(krate, ast_to_hir, input.tcx, &mut plan, trace);
     if plan.by_hir_id.is_empty() {
         return false;
     }
@@ -487,9 +515,36 @@ pub(crate) fn apply_array_local_index_rewrite<'tcx>(
         plan,
         introduced_hir_ids: FxHashSet::default(),
         changed: false,
+        trace,
     };
     visitor.visit_crate(krate);
     visitor.changed
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn apply_array_local_index_rewrite_traced<'tcx>(
+    krate: &mut Crate,
+    input: &RustProgram<'tcx>,
+    provenances: &FxHashMap<LocalDefId, ArrayLocalProvenance>,
+    mutability_result: &MutabilityResult,
+    nullity_result: &analyses::nullity::NullityResult,
+    points_to: &andersen::AnalysisResult,
+    ast_to_hir: &AstToHir,
+    enabled: bool,
+) -> Vec<crate::rewriter::array_local_trace::TraceEvent> {
+    let mut trace = RewriteTrace::for_test(enabled);
+    let _ = apply_array_local_index_rewrite_inner(
+        krate,
+        input,
+        provenances,
+        mutability_result,
+        nullity_result,
+        points_to,
+        ast_to_hir,
+        &mut trace,
+    );
+    trace.into_events()
 }
 
 /// Returns true for an index-tracked base whose base slot lives behind a
@@ -562,6 +617,7 @@ fn build_rewrite_plan<'tcx>(
     mutability_result: &MutabilityResult,
     nullity_result: &analyses::nullity::NullityResult,
     points_to: &andersen::AnalysisResult,
+    trace: &mut RewriteTrace,
 ) -> RewritePlan {
     let mut plan = RewritePlan::default();
     for &def_id in &input.functions {
@@ -572,7 +628,7 @@ fn build_rewrite_plan<'tcx>(
             .tcx
             .mir_drops_elaborated_and_const_checked(def_id)
             .borrow();
-        let groups = analyses::array_local_provenance::select_rewrite_groups(
+        let all_statuses = analyses::array_local_provenance::classify_rewrite_groups(
             provenance,
             &body,
             mutability_result,
@@ -582,6 +638,43 @@ fn build_rewrite_plan<'tcx>(
                 points_to,
             },
         );
+        // record one Selection event per produced status before filtering
+        // (gated so no labels are built on the default, disabled path).
+        if trace.is_enabled() {
+            for status in &all_statuses {
+                let (base_local, decision, reason): (
+                    rustc_middle::mir::Local,
+                    TraceDecision,
+                    &str,
+                ) = match status {
+                    RewriteGroupStatus::Ready(group) => {
+                        (group.base_local, TraceDecision::Kept, "selected (ready)")
+                    }
+                    // preserved-across-calls statuses are produced by selection but
+                    // discarded by the rewriter (not planned), so trace them as skipped.
+                    RewriteGroupStatus::PreservedAcrossCalls { group, .. } => (
+                        group.base_local,
+                        TraceDecision::Skipped,
+                        "selection produced a preserved-across-calls status (discarded, not planned)",
+                    ),
+                };
+                let label = format!("{base_local:?}");
+                trace.record(
+                    def_id,
+                    TraceSubject::Group(label),
+                    TraceStage::Selection,
+                    decision,
+                    || reason.to_string(),
+                );
+            }
+        }
+        let groups: Vec<RewriteGroup> = all_statuses
+            .into_iter()
+            .filter_map(|status| match status {
+                RewriteGroupStatus::Ready(group) => Some(group),
+                RewriteGroupStatus::PreservedAcrossCalls { .. } => None,
+            })
+            .collect();
         if groups.is_empty() {
             continue;
         }
@@ -604,6 +697,7 @@ fn build_rewrite_plan<'tcx>(
                 local_to_hir: &local_to_hir,
                 existing_names: &mut existing_names,
                 plan: &mut plan,
+                trace: &mut *trace,
             };
             add_group_to_plan(&mut context, &group);
         }
@@ -797,11 +891,21 @@ struct GroupPlanContext<'a, 'tcx> {
     local_to_hir: &'a FxHashMap<Local, HirId>,
     existing_names: &'a mut FxHashSet<String>,
     plan: &'a mut RewritePlan,
+    trace: &'a mut RewriteTrace,
 }
 
 fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGroup) {
+    // cheap label for early-return sites where base_name is not yet computed
+    let base_local_label = || format!("{:?}", group.base_local);
     let base_live = group_needs_live_base_rewrite(context.provenance, group);
     let Some(&base_hir_id) = context.local_to_hir.get(&group.base_local) else {
+        context.trace.record(
+            context.def_id,
+            TraceSubject::Group(base_local_label()),
+            TraceStage::Plan,
+            TraceDecision::Dropped,
+            || "plan: base local has no HIR binding".to_string(),
+        );
         return;
     };
 
@@ -819,6 +923,13 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
             let Some(base_slot_info) =
                 analyses::array_local_provenance::base_slot_info(context.provenance, group)
             else {
+                context.trace.record(
+                    context.def_id,
+                    TraceSubject::Group(base_local_label()),
+                    TraceStage::Plan,
+                    TraceDecision::Dropped,
+                    || "plan: missing base slot info".to_string(),
+                );
                 return;
             };
             let local_name = context.tcx.hir_name(base_hir_id).to_string();
@@ -826,6 +937,13 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
             let Some(field_path_name) =
                 slot_path_to_expr_string(&local_name, &base_slot_info.path, base_ty, context.tcx)
             else {
+                context.trace.record(
+                    context.def_id,
+                    TraceSubject::Group(base_local_label()),
+                    TraceStage::Plan,
+                    TraceDecision::Dropped,
+                    || "plan: base field path not expressible".to_string(),
+                );
                 return;
             };
             // collect raw-pointer members that can serve as proxies for the field base
@@ -921,12 +1039,33 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
             let Some(base_info) =
                 analyses::array_local_provenance::base_slot_info(context.provenance, group)
             else {
+                context.trace.record(
+                    context.def_id,
+                    TraceSubject::Group(base_name.clone()),
+                    TraceStage::Plan,
+                    TraceDecision::Dropped,
+                    || "plan: index-tracked base slot info missing".to_string(),
+                );
                 return;
             };
             let Some(base_ptr_ty) = slot_ty(context.body, context.tcx, base_info) else {
+                context.trace.record(
+                    context.def_id,
+                    TraceSubject::Group(base_name.clone()),
+                    TraceStage::Plan,
+                    TraceDecision::Dropped,
+                    || "plan: base slot has no raw-pointer type".to_string(),
+                );
                 return;
             };
             let ty::TyKind::RawPtr(pointee, mutability) = base_ptr_ty.kind() else {
+                context.trace.record(
+                    context.def_id,
+                    TraceSubject::Group(base_name.clone()),
+                    TraceStage::Plan,
+                    TraceDecision::Dropped,
+                    || "plan: base slot has no raw-pointer type".to_string(),
+                );
                 return;
             };
             let index_stem = if group.base_slot_offset == 0 {
@@ -973,6 +1112,15 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
     };
     let non_null = context.nullity_result.non_null_locals.get(&context.def_id);
 
+    // record group kept (group made it past all early-returns and has members to process)
+    context.trace.record(
+        context.def_id,
+        TraceSubject::Group(base_name.clone()),
+        TraceStage::Plan,
+        TraceDecision::Kept,
+        || "plan: group will be planned".to_string(),
+    );
+
     for &slot_idx in &group.members {
         let Some(info) = context.provenance.slot_table.slot_infos.get(slot_idx) else {
             continue;
@@ -981,6 +1129,14 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
             continue;
         }
         let Some(&source_hir_id) = context.local_to_hir.get(&info.root) else {
+            // member not in HIR: skipped by the group_member_hir_ids filter
+            context.trace.record(
+                context.def_id,
+                TraceSubject::Member(format!("{:?}", info.root)),
+                TraceStage::Plan,
+                TraceDecision::Skipped,
+                || "plan: member is not a raw-pointer local with a HIR binding".to_string(),
+            );
             continue;
         };
         // skip proxy locals — they hold the base at offset 0 and stay as-is.
@@ -993,6 +1149,14 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
         let source_name = context.tcx.hir_name(source_hir_id).to_string();
         let ptr_ty = context.body.local_decls[info.root].ty;
         let ty::TyKind::RawPtr(pointee, mutability) = ptr_ty.kind() else {
+            // member not a raw-pointer type: skipped
+            context.trace.record(
+                context.def_id,
+                TraceSubject::Member(source_name.clone()),
+                TraceStage::Plan,
+                TraceDecision::Skipped,
+                || "plan: member is not a raw-pointer local with a HIR binding".to_string(),
+            );
             continue;
         };
         let index_name = fresh_index_name(&source_name, context.existing_names);
@@ -1034,6 +1198,14 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                 group_member_hir_ids: group_member_hir_ids.clone(),
                 base_live,
             },
+        );
+        // record member kept
+        context.trace.record(
+            context.def_id,
+            TraceSubject::Member(source_name.clone()),
+            TraceStage::Plan,
+            TraceDecision::Kept,
+            || "plan: member added to rewrite plan".to_string(),
         );
     }
 }
@@ -1280,6 +1452,7 @@ fn prune_unsupported_direct_place_uses(
     ast_to_hir: &AstToHir,
     tcx: TyCtxt<'_>,
     plan: &mut RewritePlan,
+    trace: &mut RewriteTrace,
 ) {
     if plan.by_hir_id.is_empty() {
         return;
@@ -1291,13 +1464,54 @@ fn prune_unsupported_direct_place_uses(
         planned_rewrites: plan.by_hir_id.clone(),
         base_rewrites: plan.base_by_key.clone(),
         unsupported_hir_ids: FxHashSet::default(),
+        trace_enabled: trace.is_enabled(),
+        dropped_reasons: Vec::new(),
     };
     visitor.visit_crate(krate);
+    // record one prune drop per member still in the plan (a member can be flagged
+    // by more than one site; only the first reason is traced).
+    let mut traced_drops: FxHashSet<HirId> = FxHashSet::default();
+    for (hir_id, reason) in &visitor.dropped_reasons {
+        if !traced_drops.insert(*hir_id) {
+            continue;
+        }
+        if let Some(rewrite) = plan.by_hir_id.get(hir_id) {
+            let source_name = rewrite.source_name.clone();
+            let reason = reason.clone();
+            trace.record(
+                hir_id.owner.def_id,
+                TraceSubject::Member(source_name),
+                TraceStage::Prune,
+                TraceDecision::Dropped,
+                || reason,
+            );
+        }
+    }
     if !visitor.unsupported_hir_ids.is_empty() {
         plan.by_hir_id
             .retain(|hir_id, _| !visitor.unsupported_hir_ids.contains(hir_id));
     }
+    // snapshot base cursors before orphan pruning so removed ones can be traced.
+    let base_cursors_before: Vec<(BaseCursorKey, String, LocalDefId)> = if trace.is_enabled() {
+        plan.base_by_key
+            .iter()
+            .map(|(key, rewrite)| (key.clone(), rewrite.base_name.clone(), rewrite.fn_def_id))
+            .collect()
+    } else {
+        Vec::new()
+    };
     prune_orphan_base_cursors(plan);
+    for (key, base_name, fn_def_id) in base_cursors_before {
+        if !plan.base_by_key.contains_key(&key) {
+            trace.record(
+                fn_def_id,
+                TraceSubject::Base(base_name),
+                TraceStage::Prune,
+                TraceDecision::Dropped,
+                || "prune: orphan base cursor (no live members)".to_string(),
+            );
+        }
+    }
 }
 
 fn prune_orphan_base_cursors(plan: &mut RewritePlan) {
@@ -1316,6 +1530,7 @@ fn choose_binding_representations(
     ast_to_hir: &AstToHir,
     tcx: TyCtxt<'_>,
     plan: &mut RewritePlan,
+    trace: &mut RewriteTrace,
 ) {
     if plan.by_hir_id.is_empty() {
         return;
@@ -1359,6 +1574,20 @@ fn choose_binding_representations(
             rewrite.representation = BindingRepresentation::Materialized(kind);
         } else if !summary.has_index_benefit() {
             rewrite.representation = BindingRepresentation::IndexOnly;
+        }
+    }
+    // record the chosen representation per member (only when tracing).
+    if trace.is_enabled() {
+        for (hir_id, rewrite) in &plan.by_hir_id {
+            let representation = rewrite.representation.clone();
+            let index_benefit = rewrite.has_index_benefit;
+            trace.record(
+                hir_id.owner.def_id,
+                TraceSubject::Member(rewrite.source_name.clone()),
+                TraceStage::Representation,
+                TraceDecision::Kept,
+                || format!("representation={representation:?} index_benefit={index_benefit}"),
+            );
         }
     }
 }
@@ -1807,6 +2036,10 @@ struct UnsupportedDirectPlaceUseVisitor<'a, 'tcx> {
     planned_rewrites: FxHashMap<HirId, BindingRewrite>,
     base_rewrites: FxHashMap<BaseCursorKey, BaseCursorRewrite>,
     unsupported_hir_ids: FxHashSet<HirId>,
+    // reasons for each prune drop, collected only when the trace is enabled
+    // (so the offending assignment text is not pretty-printed otherwise).
+    trace_enabled: bool,
+    dropped_reasons: Vec<(HirId, String)>,
 }
 
 impl AstVisitor<'_> for UnsupportedDirectPlaceUseVisitor<'_, '_> {
@@ -1910,15 +2143,34 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
                 rewrite,
             )
         {
+            if self.trace_enabled {
+                self.dropped_reasons.push((
+                    hir_id,
+                    format!(
+                        "prune: unsupported assignment `{}`",
+                        pprust::expr_to_string(rhs)
+                    ),
+                ));
+            }
             self.unsupported_hir_ids.insert(hir_id);
         }
     }
 
     fn mark_rewrites_for_base_unsupported(&mut self, base_key: &BaseCursorKey) {
-        for rewrite in self.planned_rewrites.values() {
-            if base_cursor_key(rewrite.base_hir_id, &rewrite.base_name) == *base_key {
-                self.unsupported_hir_ids.insert(rewrite.source_hir_id);
+        let matched: Vec<HirId> = self
+            .planned_rewrites
+            .values()
+            .filter(|rewrite| base_cursor_key(rewrite.base_hir_id, &rewrite.base_name) == *base_key)
+            .map(|rewrite| rewrite.source_hir_id)
+            .collect();
+        for source_hir_id in matched {
+            if self.trace_enabled {
+                self.dropped_reasons.push((
+                    source_hir_id,
+                    "prune: base cursor used in an unsupported place".to_string(),
+                ));
             }
+            self.unsupported_hir_ids.insert(source_hir_id);
         }
     }
 
@@ -1937,6 +2189,15 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
         let hir_id =
             direct_planned_local_hir_id(self.ast_to_hir, self.tcx, &self.planned_rewrites, expr)?;
         if self.planned_rewrites.contains_key(&hir_id) {
+            if self.trace_enabled {
+                self.dropped_reasons.push((
+                    hir_id,
+                    format!(
+                        "prune: direct unsupported place use `{}`",
+                        pprust::expr_to_string(expr)
+                    ),
+                ));
+            }
             self.unsupported_hir_ids.insert(hir_id);
             Some(hir_id)
         } else {
@@ -2838,6 +3099,7 @@ struct ArrayLocalIndexRewriteVisitor<'a, 'tcx> {
     plan: RewritePlan,
     introduced_hir_ids: FxHashSet<HirId>,
     changed: bool,
+    trace: &'a mut RewriteTrace,
 }
 
 impl ArrayLocalIndexRewriteVisitor<'_, '_> {
@@ -2896,7 +3158,19 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
                 &rewrite,
             );
         }
-        let new_index_init = index_init_expr(index, rewrite.nullable)?;
+        let Some(new_index_init) = index_init_expr(index, rewrite.nullable) else {
+            self.trace.record(
+                hir_id.owner.def_id,
+                TraceSubject::Member(rewrite.source_name.clone()),
+                TraceStage::Apply,
+                TraceDecision::Skipped,
+                || {
+                    "apply: index derivation failed at visit time (prune/visitor divergence)"
+                        .to_string()
+                },
+            );
+            return None;
+        };
         let index_name = rewrite.index_name.clone();
         let index_stmt = utils::stmt!(
             "let mut {}: isize = {};",
@@ -2911,6 +3185,13 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
         local.ty = Some(materialized_ty(&rewrite));
         *init = P(materialized_init);
         self.introduced_hir_ids.insert(hir_id);
+        self.trace.record(
+            hir_id.owner.def_id,
+            TraceSubject::Member(rewrite.source_name.clone()),
+            TraceStage::Apply,
+            TraceDecision::Rewritten,
+            || "apply: materialized binding introduced".to_string(),
+        );
         self.changed = true;
         Some(index_stmt)
     }
@@ -3074,6 +3355,16 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             );
         }
         let Some(new_init) = index_init_expr(index, rewrite.nullable) else {
+            self.trace.record(
+                hir_id.owner.def_id,
+                TraceSubject::Member(rewrite.source_name.clone()),
+                TraceStage::Apply,
+                TraceDecision::Skipped,
+                || {
+                    "apply: index derivation failed at visit time (prune/visitor divergence)"
+                        .to_string()
+                },
+            );
             mut_visit::walk_local(self, local);
             return;
         };
@@ -3084,6 +3375,13 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
         local.ty = Some(index_ty(rewrite.nullable));
         *init = P(new_init);
         self.introduced_hir_ids.insert(hir_id);
+        self.trace.record(
+            hir_id.owner.def_id,
+            TraceSubject::Member(rewrite.source_name.clone()),
+            TraceStage::Apply,
+            TraceDecision::Rewritten,
+            || "apply: index-only binding introduced".to_string(),
+        );
         self.changed = true;
     }
 

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -1853,6 +1853,24 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
             direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.base_rewrites, lhs)
         {
             if let Some(base_rewrite) = self.base_rewrites.get(&base_key) {
+                if base_rewrite.base_live {
+                    // approach D only supports base self-advance; any other base
+                    // mutation (or an offset arg referencing a planned member)
+                    // drops the group so the field is left untouched.
+                    if live_base_self_advance_counter(rhs, self.ast_to_hir, self.tcx, base_rewrite)
+                        .is_none()
+                        || base_assignment_index_arg_contains_planned_local(
+                            rhs,
+                            self.ast_to_hir,
+                            self.tcx,
+                            &self.planned_rewrites,
+                            base_rewrite,
+                        )
+                    {
+                        self.mark_rewrites_for_base_unsupported(&base_key);
+                    }
+                    return;
+                }
                 let index = base_assignment_index_expr(
                     rhs,
                     self.ast_to_hir,

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2159,6 +2159,53 @@ fn is_null_expr(expr: &Expr) -> bool {
     }
 }
 
+/// returns whether unwrapping a cast on an `offset`/`add`/`offset_from`
+/// receiver preserves the pointee size, so the derived index stays in base
+/// element units; alignment is also required to match as extra conservatism for
+/// the rare same-size/different-align case. a receiver with no enclosing cast is
+/// trivially layout-preserving. for multi-level casts the outermost cast type is
+/// compared against the fully-unwrapped (all casts stripped) inner type, so any
+/// size change anywhere in the chain causes rejection. fails closed: if either
+/// side's type is unresolvable, is not a raw pointer, or has no computable
+/// layout, returns false.
+fn receiver_cast_preserves_pointee_layout(
+    receiver: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+) -> bool {
+    let outer = unwrap_paren(receiver);
+    // no cast applied directly to the receiver: the unwrap cannot change units.
+    if !matches!(outer.kind, ExprKind::Cast(..)) {
+        return true;
+    }
+    let inner = unwrap_cast_and_paren(outer);
+    let (Some(outer_layout), Some(inner_layout)) = (
+        ast_expr_pointee_size_align(outer, ast_to_hir, tcx),
+        ast_expr_pointee_size_align(inner, ast_to_hir, tcx),
+    ) else {
+        return false;
+    };
+    outer_layout == inner_layout
+}
+
+/// resolves the `(size, align)` in bytes of the pointee of an AST expression
+/// whose type is a raw pointer. returns `None` if the type is unresolvable, not
+/// a raw pointer, or has no computable layout.
+fn ast_expr_pointee_size_align(
+    expr: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+) -> Option<(u64, u64)> {
+    let hir_expr = ast_to_hir.get_expr(expr.id, tcx)?;
+    let typeck = tcx.typeck(hir_expr.hir_id.owner);
+    let ty::TyKind::RawPtr(pointee, _) = typeck.expr_ty(hir_expr).kind() else {
+        return None;
+    };
+    let typing_env = ty::TypingEnv::post_analysis(tcx, hir_expr.hir_id.owner.to_def_id());
+    let layout = tcx.layout_of(typing_env.as_query_input(*pointee)).ok()?;
+    Some((layout.size.bytes(), layout.align.abi.bytes()))
+}
+
 fn unwrap_pointer_producing_expr(expr: &Expr) -> &Expr {
     let expr = unwrap_cast_and_paren(expr);
     match &expr.kind {
@@ -2303,6 +2350,9 @@ fn projected_as_ptr_receiver_base_name(
     if !matches!(name, "offset" | "add") || offset_call.args.len() != 1 {
         return None;
     }
+    if !receiver_cast_preserves_pointee_layout(&offset_call.receiver, ast_to_hir, tcx) {
+        return None;
+    }
     let receiver = unwrap_cast_and_paren(&offset_call.receiver);
     let ExprKind::MethodCall(as_ptr_call) = &receiver.kind else {
         return None;
@@ -2371,6 +2421,9 @@ fn pointer_index_from_base_expr(
     if !matches!(name, "offset" | "add") || call.args.len() != 1 {
         return IndexExpr::Unsupported;
     }
+    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
+        return IndexExpr::Unsupported;
+    }
     let receiver = unwrap_cast_and_paren(&call.receiver);
     let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
     let receiver_is_base = (!field_base && receiver_hir_id == Some(base_hir_id))
@@ -2408,6 +2461,9 @@ fn group_member_pointer_assignment_index_expr(
     if !matches!(name, "offset" | "add") || call.args.len() != 1 {
         return IndexExpr::Unsupported;
     }
+    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
+        return IndexExpr::Unsupported;
+    }
     let receiver = unwrap_pointer_producing_expr(&call.receiver);
     let Some(receiver_hir_id) = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) else {
         return IndexExpr::Unsupported;
@@ -2440,6 +2496,9 @@ fn introduced_group_member_assignment_index_expr(
     };
     let name = call.seg.ident.name.as_str();
     if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return IndexExpr::Unsupported;
+    }
+    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
         return IndexExpr::Unsupported;
     }
     let receiver = unwrap_pointer_producing_expr(&call.receiver);
@@ -2485,6 +2544,9 @@ fn assignment_index_expr(
     };
     let name = call.seg.ident.name.as_str();
     if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return IndexExpr::Unsupported;
+    }
+    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
         return IndexExpr::Unsupported;
     }
     let receiver = unwrap_pointer_producing_expr(&call.receiver);
@@ -2538,6 +2600,9 @@ fn base_assignment_index_expr(
     if !matches!(name, "offset" | "add") || call.args.len() != 1 {
         return IndexExpr::Unsupported;
     }
+    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
+        return IndexExpr::Unsupported;
+    }
     let receiver = unwrap_cast_and_paren(&call.receiver);
     let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
     let receiver_is_base = (!base_rewrite.field_base
@@ -2583,6 +2648,9 @@ fn live_base_self_advance_counter(
     };
     let name = call.seg.ident.name.as_str();
     if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return None;
+    }
+    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
         return None;
     }
     let receiver = unwrap_cast_and_paren(&call.receiver);

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -492,13 +492,11 @@ pub(crate) fn apply_array_local_index_rewrite<'tcx>(
     visitor.changed
 }
 
-/// Returns true when rewriting this group would suppress a store the caller
-/// can observe: the base is index-tracked (its direct stores become index
-/// updates that are never written back) and the base slot lives behind a
-/// `Pointee` path, i.e. in memory reachable through a parameter. Such groups
-/// stay classified by selection (future write-back support may restore them)
-/// but must not be planned for rewriting.
-pub(crate) fn group_suppresses_caller_visible_store(
+/// Returns true for an index-tracked base whose base slot lives behind a
+/// `Pointee` path — a caller-visible field base. These are rewritten with the
+/// live-field / shadow-counter scheme (approach D): the field write is kept and
+/// member materializations subtract the base counter.
+pub(crate) fn group_needs_live_base_rewrite(
     provenance: &ArrayLocalProvenance,
     group: &RewriteGroup,
 ) -> bool {
@@ -806,12 +804,7 @@ struct GroupPlanContext<'a, 'tcx> {
 }
 
 fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGroup) {
-    // rewriting an index-tracked base behind a pointee path would turn its
-    // direct stores into local index updates and never write the advanced
-    // pointer back to caller-visible memory; keep such groups out of the plan.
-    if group_suppresses_caller_visible_store(context.provenance, group) {
-        return;
-    }
+    let base_live = group_needs_live_base_rewrite(context.provenance, group);
     let Some(&base_hir_id) = context.local_to_hir.get(&group.base_local) else {
         return;
     };
@@ -974,7 +967,7 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                     base_is_raw_ptr,
                     ptr_ty,
                     field_base: group.base_slot_offset != 0,
-                    base_live: false,
+                    base_live,
                 },
             );
             Some(index_name)
@@ -1043,7 +1036,7 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                 field_base,
                 base_proxy_hir_ids: proxy_hir_ids.clone(),
                 group_member_hir_ids: group_member_hir_ids.clone(),
-                base_live: false,
+                base_live,
             },
         );
     }

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -3022,6 +3022,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                 if let Some(base_key) =
                     direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, lhs)
                     && let Some(rewrite) = self.plan.base_by_key.get(&base_key)
+                    && !rewrite.base_live
                 {
                     let index = base_assignment_index_expr(
                         rhs,
@@ -3176,6 +3177,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             && let Some(base_key) =
                 direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, inner)
             && let Some(rewrite) = self.plan.base_by_key.get(&base_key)
+            && !rewrite.base_live
         {
             let ptr = base_cursor_pointer_expr(rewrite);
             *expr = utils::expr!("*({})", pprust::expr_to_string(&ptr));
@@ -3228,6 +3230,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
         if let Some(base_key) =
             direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, expr)
             && let Some(rewrite) = self.plan.base_by_key.get(&base_key)
+            && !rewrite.base_live
         {
             *expr = base_cursor_pointer_expr(rewrite);
             self.changed = true;

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2887,12 +2887,8 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             }
             if let StmtKind::Expr(expr) | StmtKind::Semi(expr) = &stmt.kind
                 && let ExprKind::Assign(lhs, rhs, _) = &expr.kind
-                && let Some(base_key) = direct_base_cursor_key(
-                    self.ast_to_hir,
-                    self.tcx,
-                    &self.plan.base_by_key,
-                    lhs,
-                )
+                && let Some(base_key) =
+                    direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, lhs)
                 && let Some(base_rewrite) = self.plan.base_by_key.get(&base_key)
                 && base_rewrite.base_live
             {
@@ -3282,7 +3278,10 @@ mod member_offset_tests {
 
     #[test]
     fn non_live_base_is_unchanged() {
-        assert_eq!(member_offset_expr(false, Some("out_idx"), "src_idx"), "src_idx");
+        assert_eq!(
+            member_offset_expr(false, Some("out_idx"), "src_idx"),
+            "src_idx"
+        );
     }
 
     #[test]

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2583,6 +2583,16 @@ fn idx_read_expr(rewrite: &BindingRewrite) -> String {
     }
 }
 
+/// computes the offset expression for a member materialization. for a live
+/// (caller-visible) field base the member index is corrected by the base
+/// counter (`index - base_index`); otherwise the member index is used as-is.
+fn member_offset_expr(base_live: bool, base_index_name: Option<&str>, index_expr: &str) -> String {
+    match (base_live, base_index_name) {
+        (true, Some(base_idx)) => format!("({index_expr}) - ({base_idx})"),
+        _ => index_expr.to_string(),
+    }
+}
+
 fn base_offset_expr_for_parts(base_name: &str, base_is_raw_ptr: bool, index_expr: &str) -> String {
     if base_is_raw_ptr {
         format!("({base_name}).offset({index_expr})")
@@ -2592,7 +2602,12 @@ fn base_offset_expr_for_parts(base_name: &str, base_is_raw_ptr: bool, index_expr
 }
 
 fn base_offset_expr_for_index(rewrite: &BindingRewrite, index_expr: &str) -> String {
-    base_offset_expr_for_parts(&rewrite.base_name, rewrite.base_is_raw_ptr, index_expr)
+    let offset = member_offset_expr(
+        rewrite.base_live,
+        rewrite.base_index_name.as_deref(),
+        index_expr,
+    );
+    base_offset_expr_for_parts(&rewrite.base_name, rewrite.base_is_raw_ptr, &offset)
 }
 
 fn pointer_expr_for_index(rewrite: &BindingRewrite) -> Expr {
@@ -3171,5 +3186,28 @@ impl LocalKindInitMut for LocalKind {
             LocalKind::Init(init) | LocalKind::InitElse(init, _) => Some(init),
             LocalKind::Decl => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod member_offset_tests {
+    use super::member_offset_expr;
+
+    #[test]
+    fn live_base_subtracts_base_index() {
+        assert_eq!(
+            member_offset_expr(true, Some("out_idx"), "src_idx"),
+            "(src_idx) - (out_idx)"
+        );
+    }
+
+    #[test]
+    fn non_live_base_is_unchanged() {
+        assert_eq!(member_offset_expr(false, Some("out_idx"), "src_idx"), "src_idx");
+    }
+
+    #[test]
+    fn live_base_without_index_is_unchanged() {
+        assert_eq!(member_offset_expr(true, None, "src_idx"), "src_idx");
     }
 }

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -513,10 +513,6 @@ pub(crate) fn group_has_rewritable_binding<'tcx>(
     provenance: &ArrayLocalProvenance,
     group: &RewriteGroup,
 ) -> bool {
-    // index_tracked with a field base is unsupported.
-    if group.base_slot_offset != 0 && group.index_tracked {
-        return false;
-    }
     let hir_to_mir = utils::ir::map_thir_to_mir(def_id, false, tcx);
     let local_to_hir: FxHashMap<Local, HirId> = hir_to_mir
         .binding_to_local

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2417,12 +2417,7 @@ fn is_null_expr(expr: &Expr) -> bool {
 /// returns whether unwrapping a cast on an `offset`/`add`/`offset_from`
 /// receiver preserves the pointee size, so the derived index stays in base
 /// element units; alignment is also required to match as extra conservatism for
-/// the rare same-size/different-align case. a receiver with no enclosing cast is
-/// trivially layout-preserving. for multi-level casts the outermost cast type is
-/// compared against the fully-unwrapped (all casts stripped) inner type, so any
-/// size change anywhere in the chain causes rejection. fails closed: if either
-/// side's type is unresolvable, is not a raw pointer, or has no computable
-/// layout, returns false.
+/// the rare same-size/different-align case.
 fn receiver_cast_preserves_pointee_layout(
     receiver: &Expr,
     ast_to_hir: &AstToHir,

--- a/crates/pointer_replacer/src/rewriter/array_local_trace.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_trace.rs
@@ -1,0 +1,204 @@
+//! opt-in decision trace for the array-local index rewrite pass. deliberately
+//! separate from `diagnostics::DecisionDiagnostics` (the main pass's
+//! framework); see the rewrite-decision-trace design spec. disabled by default
+//! and a no-op when disabled.
+
+use rustc_hir::def_id::LocalDefId;
+
+/// the subject of a decision: a whole group (labelled by its base), a member
+/// cursor (by source name), or a base cursor (by name).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TraceSubject {
+    Group(String),
+    Member(String),
+    Base(String),
+}
+
+/// the pass stage at which a decision was made.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TraceStage {
+    Selection,
+    Plan,
+    AstRefine,
+    Prune,
+    Representation,
+    Apply,
+}
+
+/// the outcome recorded for a subject at a stage.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TraceDecision {
+    Kept,
+    Dropped,
+    Rewritten,
+    Skipped,
+}
+
+/// one recorded decision.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TraceEvent {
+    pub fn_def_id: LocalDefId,
+    pub subject: TraceSubject,
+    pub stage: TraceStage,
+    pub decision: TraceDecision,
+    pub reason: String,
+}
+
+/// collects decision events for the array-local index rewrite. when disabled
+/// (the default), `record` is a no-op and no reason strings are built.
+#[derive(Clone, Debug)]
+pub(crate) struct RewriteTrace {
+    enabled: bool,
+    events: Vec<TraceEvent>,
+}
+
+/// the environment variable that enables the trace.
+const ENV_VAR: &str = "CRAT_ARRAY_LOCAL_TRACE";
+
+impl RewriteTrace {
+    /// enabled iff `CRAT_ARRAY_LOCAL_TRACE` is set to a non-empty, non-"0",
+    /// non-"false" value.
+    pub(crate) fn from_env() -> Self {
+        let enabled = std::env::var(ENV_VAR).is_ok_and(|v| {
+            let v = v.trim();
+            !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+        });
+        Self {
+            enabled,
+            events: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(enabled: bool) -> Self {
+        Self {
+            enabled,
+            events: Vec::new(),
+        }
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// records an event. no-op when disabled; the `reason` closure is invoked
+    /// only when enabled, so reason strings cost nothing in the default path.
+    pub(crate) fn record(
+        &mut self,
+        fn_def_id: LocalDefId,
+        subject: TraceSubject,
+        stage: TraceStage,
+        decision: TraceDecision,
+        reason: impl FnOnce() -> String,
+    ) {
+        if !self.enabled {
+            return;
+        }
+        self.events.push(TraceEvent {
+            fn_def_id,
+            subject,
+            stage,
+            decision,
+            reason: reason(),
+        });
+    }
+
+    pub(crate) fn events(&self) -> &[TraceEvent] {
+        &self.events
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_events(self) -> Vec<TraceEvent> {
+        self.events
+    }
+
+    /// dumps the events to stderr, grouped by function. no-op when disabled.
+    pub(crate) fn emit(&self, tcx: rustc_middle::ty::TyCtxt<'_>) {
+        if !self.enabled {
+            return;
+        }
+        let mut by_fn: rustc_hash::FxHashMap<LocalDefId, Vec<&TraceEvent>> =
+            rustc_hash::FxHashMap::default();
+        for event in &self.events {
+            by_fn.entry(event.fn_def_id).or_default().push(event);
+        }
+        let mut fns: Vec<_> = by_fn.keys().copied().collect();
+        fns.sort_by_key(|did| did.local_def_index.as_u32());
+        for did in fns {
+            eprintln!(
+                "[array-local-trace] fn {}",
+                tcx.def_path_str(did.to_def_id())
+            );
+            for event in &by_fn[&did] {
+                eprintln!(
+                    "[array-local-trace]   {:?} {:?} {:?} {} :: {}",
+                    event.stage,
+                    event.decision,
+                    subject_kind(&event.subject),
+                    subject_label(&event.subject),
+                    event.reason,
+                );
+            }
+        }
+    }
+}
+
+fn subject_kind(subject: &TraceSubject) -> &'static str {
+    match subject {
+        TraceSubject::Group(_) => "group",
+        TraceSubject::Member(_) => "member",
+        TraceSubject::Base(_) => "base",
+    }
+}
+
+fn subject_label(subject: &TraceSubject) -> &str {
+    match subject {
+        TraceSubject::Group(s) | TraceSubject::Member(s) | TraceSubject::Base(s) => s,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn did() -> LocalDefId {
+        rustc_hir::def_id::CRATE_DEF_ID
+    }
+
+    #[test]
+    fn disabled_trace_records_nothing_and_builds_no_reason() {
+        let mut trace = RewriteTrace::for_test(false);
+        let mut built = false;
+        trace.record(
+            did(),
+            TraceSubject::Member("q".into()),
+            TraceStage::Prune,
+            TraceDecision::Dropped,
+            || {
+                built = true;
+                "should not run".into()
+            },
+        );
+        assert!(!trace.is_enabled());
+        assert!(trace.events().is_empty());
+        assert!(!built, "reason closure must not run when disabled");
+    }
+
+    #[test]
+    fn enabled_trace_records_event_with_reason() {
+        let mut trace = RewriteTrace::for_test(true);
+        trace.record(
+            did(),
+            TraceSubject::Member("q".into()),
+            TraceStage::Prune,
+            TraceDecision::Dropped,
+            || "q = b\"x\\0\"".into(),
+        );
+        assert_eq!(trace.events().len(), 1);
+        let e = &trace.events()[0];
+        assert_eq!(e.subject, TraceSubject::Member("q".into()));
+        assert_eq!(e.stage, TraceStage::Prune);
+        assert_eq!(e.decision, TraceDecision::Dropped);
+        assert_eq!(e.reason, "q = b\"x\\0\"");
+    }
+}

--- a/crates/pointer_replacer/src/rewriter/array_local_trace.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_trace.rs
@@ -19,7 +19,6 @@ pub(crate) enum TraceSubject {
 pub(crate) enum TraceStage {
     Selection,
     Plan,
-    AstRefine,
     Prune,
     Representation,
     Apply,
@@ -103,6 +102,7 @@ impl RewriteTrace {
         });
     }
 
+    #[cfg(test)]
     pub(crate) fn events(&self) -> &[TraceEvent] {
         &self.events
     }

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -34,7 +34,7 @@ use crate::{
 };
 
 pub(crate) mod array_local_index_rewriter;
-mod array_local_trace;
+pub(crate) mod array_local_trace;
 pub(crate) mod collector;
 pub(crate) mod decision;
 pub(crate) mod diagnostics;
@@ -263,6 +263,60 @@ pub fn rewrite_array_local_provenance(config: &Config, tcx: TyCtxt<'_>) -> (Stri
     );
 
     (pprust::crate_to_string_for_macros(&krate), changed)
+}
+
+/// Test-only entry point that runs the array-local pass with the decision trace
+/// forced on (`enabled = true`) or off (`enabled = false`) and returns both the
+/// rewritten source and the collected events. Mirrors
+/// `rewrite_array_local_provenance`'s setup. Returning the source lets tests
+/// assert the trace is behavior-neutral (enabled vs disabled output is equal).
+#[cfg(test)]
+pub(crate) fn rewrite_array_local_provenance_trace(
+    config: &Config,
+    tcx: TyCtxt<'_>,
+    enabled: bool,
+) -> (String, Vec<array_local_trace::TraceEvent>) {
+    let mut krate = utils::ast::expanded_ast(tcx);
+    let ast_to_hir = utils::ast::make_ast_to_hir(&mut krate, tcx);
+    utils::ast::remove_unnecessary_items_from_ast(&mut krate);
+
+    let input = collect_input(tcx);
+    let arena = typed_arena::Arena::new();
+    let tss = utils::ty_shape::get_ty_shapes(&arena, tcx, false);
+    let andersen_config = andersen::Config {
+        use_optimized_mir: false,
+        c_exposed_fns: config.c_exposed_fns.clone(),
+    };
+    let pre_points_to = andersen::pre_analyze(&andersen_config, &tss, tcx);
+    let alloc_fns = pre_points_to.alloc_fns.clone();
+    let points_to_solutions = andersen::analyze(&andersen_config, &pre_points_to, &tss, tcx);
+    let points_to = andersen::post_analyze(
+        &andersen_config,
+        pre_points_to,
+        points_to_solutions,
+        &tss,
+        tcx,
+    );
+    let mutability_result =
+        analyses::type_qualifier::foster::mutability::mutability_analysis(&input);
+    let source_var_groups = analyses::mir_variable_grouping::SourceVarGroups::new(&input);
+    let mut nullity_result = analyses::nullity::analyze(&input, &points_to);
+    nullity_result.non_null_locals =
+        source_var_groups.postprocess_non_null_locals(nullity_result.non_null_locals);
+    let provenances =
+        analyses::array_local_provenance::array_local_provenance_analysis(&input, &alloc_fns);
+
+    let events = array_local_index_rewriter::apply_array_local_index_rewrite_traced(
+        &mut krate,
+        &input,
+        &provenances,
+        &mutability_result,
+        &nullity_result,
+        &points_to,
+        &ast_to_hir,
+        enabled,
+    );
+    (pprust::crate_to_string_for_macros(&krate), events)
 }
 
 pub(crate) fn collect_input(tcx: TyCtxt<'_>) -> RustProgram<'_> {

--- a/crates/pointer_replacer/src/rewriter/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/mod.rs
@@ -34,6 +34,7 @@ use crate::{
 };
 
 pub(crate) mod array_local_index_rewriter;
+mod array_local_trace;
 pub(crate) mod collector;
 pub(crate) mod decision;
 pub(crate) mod diagnostics;

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9616,3 +9616,96 @@ pub unsafe fn process_buffer(mut state: *mut ProcessState, mut target: i8, mut r
         "{s}"
     );
 }
+
+#[test]
+fn test_array_local_rewriter_rejects_size_changing_receiver_cast() {
+    // `(p as *mut i8).offset(12)` advances 12 *bytes* past an *mut i32 base;
+    // recording index 12 and re-materializing in i32 units would be 48 bytes.
+    // the rewriter must leave q untouched.
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = (p as *mut i8).offset(12) as *mut i32;
+    *p = 1;
+    *q = 3;
+    *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(
+        !changed,
+        "size-changing receiver cast must not be rewritten:\n{s}"
+    );
+    assert!(
+        s.contains("let mut q: *mut i32"),
+        "q must stay a raw pointer:\n{s}"
+    );
+    assert!(!s.contains("q_idx"), "no index must be derived for q:\n{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_keeps_offset_then_cast() {
+    // offset-then-cast: the index is computed in base (i32) units, the cast is
+    // applied to the result, so this stays rewritten (control).
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = p.offset(3) as *mut i32;
+    *p = 1;
+    *q = 3;
+    *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut q_idx: isize = (3) as isize"), "{s}");
+    assert!(!s.contains("let mut q: *mut i32"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_keeps_equal_size_receiver_cast() {
+    // `(p as *const u8).offset(3)` over an *mut i8 base: pointee size is
+    // unchanged (1 == 1), so the index unit is correct and the rewrite stands.
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i8) -> i8 {
+    let mut q: *mut i8 = (p as *const u8).offset(3) as *mut i8;
+    *p = 1;
+    *q = 3;
+    *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut q_idx: isize = (3) as isize"), "{s}");
+    assert!(!s.contains("let mut q: *mut i8"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_offset_from_not_folded_across_size_cast() {
+    // q is a size-changing cast cursor; its offset_from(r) must NOT be folded
+    // into an index subtraction, because q has no valid base-unit index.
+    let code = r#"
+pub unsafe fn foo(mut base: *mut i32) -> isize {
+    let mut q: *mut i32 = (base as *mut i8).offset(12) as *mut i32;
+    let mut r: *mut i32 = base.offset(1);
+    *base = 0;
+    *q = 0;
+    *r = 0;
+    q.offset_from(r)
+}
+"#;
+    let (s, _changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    // r may be independently rewritten to r_idx (no size-changing cast on r's
+    // receiver), so we check only that q is the (unrewritten) receiver of
+    // offset_from, not that r specifically appears as the argument.
+    assert!(
+        s.contains("q.offset_from("),
+        "offset_from must be preserved:\n{s}"
+    );
+    assert!(
+        !s.contains("q_idx"),
+        "no index must be derived for the cast cursor q:\n{s}"
+    );
+}

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9554,7 +9554,7 @@ pub unsafe fn dual(mut p: *mut Pair, mut da: isize, mut db: isize) -> i32 {
 
 #[test]
 fn test_array_local_rewriter_skips_live_field_base_with_non_self_advance() {
-    // the base field is reassigned from a member, not a self-advance, so D
+    // the base field is reassigned from a member, not a self-advance,
     // cannot track the counter; the group is dropped and left unrewritten.
     let code = r#"
 #[repr(C)]

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -17,6 +17,13 @@ fn rewrite_array_local_provenance_with_config(code: &str, config: &Config) -> (S
     .unwrap()
 }
 
+fn array_local_trace_events(code: &str) -> Vec<crate::rewriter::array_local_trace::TraceEvent> {
+    ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        crate::rewriter::rewrite_array_local_provenance_trace(&Config::default(), tcx, true).1
+    })
+    .unwrap()
+}
+
 fn rewrite_struct_arrays_then_pointer(code: &str, config: &Config) -> (String, BytemuckDependency) {
     let (pre, changed) = rewrite_struct_arrays_with_config(code, config);
     let input = if changed { pre.as_str() } else { code };
@@ -9707,5 +9714,82 @@ pub unsafe fn foo(mut base: *mut i32) -> isize {
     assert!(
         !s.contains("q_idx"),
         "no index must be derived for the cast cursor q:\n{s}"
+    );
+}
+
+#[test]
+fn test_array_local_trace_records_selection_and_apply_for_rewritten_group() {
+    use crate::rewriter::array_local_trace::{TraceStage, TraceSubject};
+    // a simple selectable + rewritten group (mirrors
+    // test_array_local_rewriter_rewrites_simple_non_null_derived_local).
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = p.offset(3);
+    *p = 1;
+    *q = 3;
+    *q
+}
+"#;
+    let events = array_local_trace_events(code);
+    assert!(
+        events.iter().any(|e| e.stage == TraceStage::Selection),
+        "expected at least one Selection event: {events:#?}"
+    );
+    assert!(
+        events.iter().any(|e| e.stage == TraceStage::Apply
+            && matches!(&e.subject, TraceSubject::Member(name) if name == "q")),
+        "expected an Apply event for member q: {events:#?}"
+    );
+}
+
+#[test]
+fn test_array_local_trace_disabled_is_neutral() {
+    // enabling the trace must not change the rewritten output, and the disabled
+    // trace must record nothing.
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = p.offset(3);
+    *p = 1;
+    *q = 3;
+    *q
+}
+"#;
+    let (src_enabled, _events) = ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        crate::rewriter::rewrite_array_local_provenance_trace(&Config::default(), tcx, true)
+    })
+    .unwrap();
+    let (src_disabled, events_disabled) = ::utils::compilation::run_compiler_on_str(code, |tcx| {
+        crate::rewriter::rewrite_array_local_provenance_trace(&Config::default(), tcx, false)
+    })
+    .unwrap();
+    assert!(
+        events_disabled.is_empty(),
+        "disabled trace must record nothing: {events_disabled:#?}"
+    );
+    assert_eq!(
+        src_enabled, src_disabled,
+        "enabling the trace must not change pass output"
+    );
+}
+
+#[test]
+fn test_array_local_trace_records_prune_drop_with_assignment_text() {
+    use crate::rewriter::array_local_trace::{TraceDecision, TraceStage};
+    // q is reassigned via an expression the index rewrite cannot handle, so the
+    // prune pass drops it; the trace records a Prune/Dropped event whose reason
+    // includes the offending assignment text.
+    let code = r#"
+pub unsafe fn foo(mut p: *mut i32) -> i32 {
+    let mut q: *mut i32 = std::ptr::null_mut();
+    q = p.offset(if q.is_null() { 0 } else { 1 });
+    *q
+}
+"#;
+    let events = array_local_trace_events(code);
+    assert!(
+        events.iter().any(|e| e.stage == TraceStage::Prune
+            && e.decision == TraceDecision::Dropped
+            && e.reason.contains("q.is_null()")),
+        "expected a Prune/Dropped event mentioning the offending assignment: {events:#?}"
     );
 }

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9436,11 +9436,10 @@ pub unsafe fn expose(mut h: *mut Holder, mut i: isize) {
 }
 
 #[test]
-fn test_array_local_rewriter_preserves_reassigned_pointee_field_base_store() {
-    // (*s).out lives behind the parameter pointer, so the caller observes it
-    // after return; index-tracking the reassignment would suppress that store.
-    // the group stays classified but must not be rewritten (see
-    // group_suppresses_caller_visible_store).
+fn test_array_local_rewriter_rewrites_reassigned_pointee_field_base_live() {
+    // (*s).out is caller-visible: the field write is KEPT live, a shadow
+    // counter tracks the advance, and members materialize off the live field
+    // with the counter subtracted (approach D).
     let code = r#"
 #[repr(C)]
 pub struct State {
@@ -9459,22 +9458,23 @@ pub unsafe fn copy_from_back(mut s: *mut State, mut length: isize, mut distance:
 }
 "#;
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
-    assert!(
-        !changed,
-        "caller-visible field base reassignment must not be index-tracked:\n{s}"
-    );
+    assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("(*s).out ="), "{s}");
-    assert!(!s.contains("out_idx"), "{s}");
-    assert!(!s.contains("src_idx"), "{s}");
-    assert!(!s.contains("dst_idx"), "{s}");
+    // field write kept live
+    assert!(s.contains("(*s).out = (*s).out.offset(length)"), "{s}");
+    // shadow counter declared and advanced
+    assert!(s.contains("let mut out_idx: isize = 0isize"), "{s}");
+    assert!(s.contains("out_idx = (out_idx) + (length)"), "{s}");
+    // members are indexes, materialized with - out_idx
+    assert!(s.contains("src_idx"), "{s}");
+    assert!(s.contains("dst_idx"), "{s}");
+    assert!(s.contains("- (out_idx)"), "{s}");
 }
 
 #[test]
-fn test_array_local_rewriter_skips_memory_copy_cursors_of_reassigned_pointee_field_base() {
-    // same caller-visibility constraint as
-    // test_array_local_rewriter_preserves_reassigned_pointee_field_base_store:
-    // (*s).out is reassigned, so the whole group must stay unrewritten.
+fn test_array_local_rewriter_rewrites_memory_copy_cursors_of_reassigned_pointee_field_base() {
+    // (*s).out is caller-visible: the field write is KEPT live (approach D),
+    // a shadow counter tracks the advance, and members are index-rewritten.
     let code = r#"
 #[repr(C)]
 pub struct State {
@@ -9503,22 +9503,20 @@ pub unsafe fn copy_from_back(mut s: *mut State, mut length: i32, mut distance: i
 }
 "#;
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
-    assert!(
-        !changed,
-        "cursors of a reassigned caller-visible field base must not be rewritten:\n{s}"
-    );
+    assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    // field write kept live
     assert!(s.contains("(*s).out ="), "{s}");
-    assert!(!s.contains("src_idx"), "{s}");
-    assert!(!s.contains("dst_idx"), "{s}");
-    assert!(s.contains("let mut src: *mut i8"), "{s}");
-    assert!(s.contains("let mut dst: *mut i8"), "{s}");
+    // member index vars present
+    assert!(s.contains("src_idx") || s.contains("dst_idx"), "{s}");
+    // shadow counter for out declared
+    assert!(s.contains("out_idx"), "{s}");
 }
 
 #[test]
-fn test_array_local_rewriter_skips_two_reassigned_pointee_field_bases() {
-    // both (*p).a and (*p).b are reassigned caller-visible field bases, so
-    // neither group may be index-tracked.
+fn test_array_local_rewriter_rewrites_two_reassigned_pointee_field_bases() {
+    // both (*p).a and (*p).b are caller-visible field bases; both are rewritten
+    // with the live-field / shadow-counter scheme (approach D).
     let code = r#"
 #[repr(C)]
 pub struct Pair {
@@ -9537,15 +9535,37 @@ pub unsafe fn dual(mut p: *mut Pair, mut da: isize, mut db: isize) -> i32 {
 }
 "#;
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
-    assert!(
-        !changed,
-        "reassigned caller-visible field bases must not be rewritten:\n{s}"
-    );
+    assert!(changed, "{s}");
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    // field writes kept live
     assert!(s.contains("(*p).a ="), "{s}");
     assert!(s.contains("(*p).b ="), "{s}");
-    assert!(!s.contains("a_idx"), "{s}");
-    assert!(!s.contains("b_idx"), "{s}");
+    // member index vars present
+    assert!(s.contains("ax_idx") || s.contains("a_idx"), "{s}");
+    assert!(s.contains("bx_idx") || s.contains("b_idx"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_skips_live_field_base_with_non_self_advance() {
+    // the base field is reassigned from a member, not a self-advance, so D
+    // cannot track the counter; the group is dropped and left unrewritten.
+    let code = r#"
+#[repr(C)]
+pub struct State {
+    pub out: *mut i8,
+}
+
+pub unsafe fn f(mut s: *mut State, mut n: isize) -> i32 {
+    let mut cur: *mut i8 = (*s).out.offset(n);
+    (*s).out = cur;
+    cur = cur.offset(1);
+    *cur as i32
+}
+"#;
+    let (s, _changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("(*s).out = cur"), "{s}");
+    assert!(!s.contains("out_idx"), "{s}");
 }
 
 #[test]

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9436,7 +9436,11 @@ pub unsafe fn expose(mut h: *mut Holder, mut i: isize) {
 }
 
 #[test]
-fn test_array_local_rewriter_tracks_index_for_reassigned_field_base() {
+fn test_array_local_rewriter_preserves_reassigned_pointee_field_base_store() {
+    // (*s).out lives behind the parameter pointer, so the caller observes it
+    // after return; index-tracking the reassignment would suppress that store.
+    // the group stays classified but must not be rewritten (see
+    // group_suppresses_caller_visible_store).
     let code = r#"
 #[repr(C)]
 pub struct State {
@@ -9456,20 +9460,21 @@ pub unsafe fn copy_from_back(mut s: *mut State, mut length: isize, mut distance:
 "#;
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     assert!(
-        changed,
-        "expected field-base index tracking to rewrite:\n{s}"
+        !changed,
+        "caller-visible field base reassignment must not be index-tracked:\n{s}"
     );
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("out_idx") || s.contains("s_out_idx"), "{s}");
-    assert!(s.contains("src_idx"), "{s}");
-    assert!(s.contains("dst_idx"), "{s}");
-    assert!(s.contains("let mut src: *mut i8"), "{s}");
-    assert!(s.contains("let mut dst: *mut i8"), "{s}");
-    assert!(!s.contains("(*s).out = (*s).out.offset(length)"), "{s}");
+    assert!(s.contains("(*s).out ="), "{s}");
+    assert!(!s.contains("out_idx"), "{s}");
+    assert!(!s.contains("src_idx"), "{s}");
+    assert!(!s.contains("dst_idx"), "{s}");
 }
 
 #[test]
-fn test_array_local_rewriter_keeps_field_base_memory_copy_cursors_index_only() {
+fn test_array_local_rewriter_skips_memory_copy_cursors_of_reassigned_pointee_field_base() {
+    // same caller-visibility constraint as
+    // test_array_local_rewriter_preserves_reassigned_pointee_field_base_store:
+    // (*s).out is reassigned, so the whole group must stay unrewritten.
     let code = r#"
 #[repr(C)]
 pub struct State {
@@ -9499,31 +9504,21 @@ pub unsafe fn copy_from_back(mut s: *mut State, mut length: i32, mut distance: i
 "#;
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     assert!(
-        changed,
-        "expected field-base memory copy cursors to be rewritten:\n{s}"
+        !changed,
+        "cursors of a reassigned caller-visible field base must not be rewritten:\n{s}"
     );
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("src_idx"), "{s}");
-    assert!(s.contains("dst_idx"), "{s}");
-    assert!(!s.contains("let mut src: *mut i8"), "{s}");
-    assert!(!s.contains("let mut dst: *mut i8"), "{s}");
-    assert!(
-        s.contains("memset(((*s).out).offset(dst_idx)")
-            || s.contains("memset((*s).out.offset(dst_idx)"),
-        "expected memset destination to inline dst_idx from the field base:\n{s}"
-    );
-    assert!(
-        s.contains("*(((*s).out).offset(src_idx)") || s.contains("*((*s).out.offset(src_idx)"),
-        "expected src deref to inline src_idx from the field base:\n{s}"
-    );
-    assert!(
-        s.contains("*(((*s).out).offset(dst_idx)") || s.contains("*((*s).out.offset(dst_idx)"),
-        "expected dst deref to inline dst_idx from the field base:\n{s}"
-    );
+    assert!(s.contains("(*s).out ="), "{s}");
+    assert!(!s.contains("src_idx"), "{s}");
+    assert!(!s.contains("dst_idx"), "{s}");
+    assert!(s.contains("let mut src: *mut i8"), "{s}");
+    assert!(s.contains("let mut dst: *mut i8"), "{s}");
 }
 
 #[test]
-fn test_array_local_rewriter_keeps_distinct_indexes_for_two_reassigned_field_bases() {
+fn test_array_local_rewriter_skips_two_reassigned_pointee_field_bases() {
+    // both (*p).a and (*p).b are reassigned caller-visible field bases, so
+    // neither group may be index-tracked.
     let code = r#"
 #[repr(C)]
 pub struct Pair {
@@ -9543,16 +9538,14 @@ pub unsafe fn dual(mut p: *mut Pair, mut da: isize, mut db: isize) -> i32 {
 "#;
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     assert!(
-        changed,
-        "expected both reassigned field bases to be rewritten:\n{s}"
+        !changed,
+        "reassigned caller-visible field bases must not be rewritten:\n{s}"
     );
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("let mut a_idx: isize"), "{s}");
-    assert!(s.contains("let mut b_idx: isize"), "{s}");
-    assert!(s.contains("ax_idx"), "{s}");
-    assert!(s.contains("bx_idx"), "{s}");
-    assert!(s.contains("let mut ax: *mut i8"), "{s}");
-    assert!(s.contains("let mut bx: *mut i16"), "{s}");
+    assert!(s.contains("(*p).a ="), "{s}");
+    assert!(s.contains("(*p).b ="), "{s}");
+    assert!(!s.contains("a_idx"), "{s}");
+    assert!(!s.contains("b_idx"), "{s}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds interprocedural base-pointer provenance to the array-local index rewrite pass, so the pass can see through function calls instead of conservatively bailing whenever a cursor or its base flows through a call. 
- Fix rewrite of caller-visible field bases, several soundness guards
- Add an decision-trace facility.

### Interprocedural provenance via function summaries
The analysis now computes per-function FunctionSummary records and uses them to resolve base provenance across call boundaries
- Fixed-point over the call graph — summaries are solved per SCC in call-graph post-order (bounded at 32 iterations)
- Preserved-across-calls groups —mark a group when its base is provably preserved across the intervening calls (recording which calls and whether each writes the base binding), rather than rejecting it. Rewriter for this is not implemented yet.

### Caller-visible field bases
Index-tracked groups whose base slot lives behind a caller-visible field are now rewritten correctly.

```Rust
// before, field (*s).out itself is not updated
unsafe fn cp_block<'a, 'b>(mut s: *mut cp_state_t<'a, 'b>) -> i32 {
    let __crat_borrowed_s = s.as_mut().unwrap();
    let mut out_idx: isize = 0isize;
    let mut current_block: u64;
    loop {
        ...
        if symbol < 256 {
            if !((__crat_borrowed_s.out.offset(out_idx) as *mut i8).offset(1)
                            <= __crat_borrowed_s.out_end) {
                cp_error_reason.set(b"Attempted to overwrite out buffer while outputting a symbol.\0"
                            as *const u8 as *const i8);
                current_block = 10862015606883543423;
                break;
            } else {
                *(__crat_borrowed_s.out.offset(out_idx) as *mut i8) =
                    symbol as i8;
                out_idx = out_idx + 1;
            }
        } else {
            if !(symbol > 256) {
                current_block = 17788412896529399552;
                break;
            
// after, field is also updated 
unsafe fn cp_block<'a, 'b>(mut s: *mut cp_state_t<'a, 'b>) -> i32 {
    let __crat_borrowed_s = s.as_mut().unwrap();
    let mut out_idx: isize = 0isize;
    let mut current_block: u64;
    loop {
        ...
        if symbol < 256 {
            if !(__crat_borrowed_s.out.offset(1) <= __crat_borrowed_s.out_end)
                {
                cp_error_reason.set(b"Attempted to overwrite out buffer while outputting a symbol.\0"
                            as *const u8 as *const i8);
                current_block = 10862015606883543423;
                break;           } else {
                *__crat_borrowed_s.out = symbol as i8;
                __crat_borrowed_s.out = __crat_borrowed_s.out.offset(1);
                out_idx = out_idx + 1;
            }

```

### Soundness guards
- Size-changing receiver casts: a cast that changes pointee size now yields Unsupported/None so the index isn't materialized in the wrong element unit.
- Size-mismatched cast cursors in selection: replaced the old pointer-cast escape with a size-and-alignment equality check, so e.g. an *mut i8 cursor over an *mut i32 base is no longer selected.
- Constant pointers: only the integer-zero sentinel stays transparent NullLike; string/byte-literal, static, and other non-zero pointer constants are now opaque ConstantPointer, so a cursor reassigned to such a constant is correctly excluded at selection time.
- Allocator / pointer-arithmetic matching restricted to core/std and foreign items, and caller-visible field-base stores are guarded from index tracking.

### Decision trace
RewriteTrace collector (subject / stage / decision / reason) enabled via the CRAT_ARRAY_LOCAL_TRACE env var. 

---

## Test

Compared to master branch

Unsafe counts
master: 22,881
current: 22,877
Delta: −4, entirely from offset

Changed cases:
Public-Tests/B02_organic/load_png_mem_lib: 145 → 143 (offset −2); src/lib.rs differs
Public-Tests/B02_organic/pinflate_lib: 51 → 49 (offset −2); src/lib.rs differs

