### PR TITLE
Improve array local provenance analysis (rewriter)

### DIFF
--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -2220,6 +2220,16 @@ impl<'tcx> Collector<'_, 'tcx> {
             return false;
         }
 
+        self.apply_summary(&summary, args, destination, location)
+    }
+
+    fn apply_summary(
+        &mut self,
+        summary: &FunctionSummary,
+        args: &[Spanned<Operand<'tcx>>],
+        destination: Place<'tcx>,
+        location: Location,
+    ) -> bool {
         let mut return_edges = Vec::new();
         let mut arg_write_edges: FxHashMap<(usize, SlotIdx), Vec<PfgNode>> = FxHashMap::default();
         let mut unknown_returns = Vec::new();

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -2358,6 +2358,14 @@ impl<'tcx> Collector<'_, 'tcx> {
             return;
         }
 
+        if let Some((def_id, name)) = call.as_ref()
+            && let Some(summary) =
+                builtin_summary(self.tcx, *def_id, name, args, *destination, self.body)
+            && self.apply_summary(&summary, args, *destination, location)
+        {
+            return;
+        }
+
         if !call
             .as_ref()
             .is_some_and(|(def_id, name)| call_no_writes(self.tcx, *def_id, name))
@@ -3108,6 +3116,59 @@ fn constant_pointer_reason<'tcx>(operand: &Operand<'tcx>, tcx: TyCtxt<'tcx>) -> 
     }
 }
 
+fn builtin_summary<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+    name: &str,
+    args: &[Spanned<Operand<'tcx>>],
+    destination: Place<'tcx>,
+    body: &Body<'tcx>,
+) -> Option<FunctionSummary> {
+    if !tcx.is_foreign_item(def_id) {
+        return None;
+    }
+    let last = name.rsplit("::").next()?;
+    let arg0_is_ptr = args
+        .first()
+        .is_some_and(|arg| arg.node.ty(body, tcx).is_raw_ptr());
+    let dst_is_ptr = destination.ty(body, tcx).ty.is_raw_ptr();
+    let base_preserving = || FunctionSummary {
+        completeness: SummaryCompleteness::Complete,
+        return_flows: vec![
+            SummaryFlow {
+                dst_return_path: vec![],
+                src: SummarySource::ParamSlot {
+                    arg_index: 0,
+                    path: vec![],
+                },
+            },
+            SummaryFlow {
+                dst_return_path: vec![],
+                src: SummarySource::Unknown(UnknownReason::NullLike),
+            },
+        ],
+        ..FunctionSummary::default()
+    };
+    let empty_complete = || FunctionSummary {
+        completeness: SummaryCompleteness::Complete,
+        ..FunctionSummary::default()
+    };
+    match last {
+        // base-preserving, null-on-miss: returns a cursor into arg0 or null.
+        "strstr" | "strchr" | "strrchr" | "strpbrk"
+            if args.len() == 2 && arg0_is_ptr && dst_is_ptr =>
+        {
+            Some(base_preserving())
+        }
+        "memchr" if args.len() == 3 && arg0_is_ptr && dst_is_ptr => Some(base_preserving()),
+        // read-only: no pointer return, no pointer-changing arg writes.
+        "strlen" if args.len() == 1 && arg0_is_ptr => Some(empty_complete()),
+        "strcmp" if args.len() == 2 && arg0_is_ptr => Some(empty_complete()),
+        "strncmp" | "memcmp" if args.len() == 3 && arg0_is_ptr => Some(empty_complete()),
+        _ => None,
+    }
+}
+
 fn call_propagates_first_arg<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
@@ -3116,26 +3177,8 @@ fn call_propagates_first_arg<'tcx>(
     destination: Place<'tcx>,
     body: &Body<'tcx>,
 ) -> bool {
-    is_memchr_call(tcx, def_id, name, args, destination, body)
-        || is_from_raw_parts_mut_call(tcx, def_id, name, args, destination, body)
+    is_from_raw_parts_mut_call(tcx, def_id, name, args, destination, body)
         || is_slice_index_mut_call(tcx, def_id, name, args, destination, body)
-}
-
-fn is_memchr_call<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    def_id: DefId,
-    name: &str,
-    args: &[Spanned<Operand<'tcx>>],
-    destination: Place<'tcx>,
-    body: &Body<'tcx>,
-) -> bool {
-    matches!(name.rsplit("::").next(), Some("memchr"))
-        && tcx.is_foreign_item(def_id)
-        && args.len() == 3
-        && args
-            .first()
-            .is_some_and(|arg| arg.node.ty(body, tcx).is_raw_ptr())
-        && destination.ty(body, tcx).ty.is_raw_ptr()
 }
 
 fn is_from_raw_parts_mut_call<'tcx>(

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/mod.rs
@@ -1690,6 +1690,20 @@ pub(crate) fn base_slot_info<'a>(
     provenance.slot_table.slot_infos.get(base_slot)
 }
 
+/// last-segment names of external calls whose arg 0 is a base-preserving
+/// pointer cursor that can be inline-materialised at the call site.
+pub(crate) fn is_inlineable_pointer_arg(name: &str, arg_index: usize) -> bool {
+    matches!(
+        name,
+        "memchr" | "memset" | "strstr" | "strchr" | "strrchr" | "strpbrk"
+    ) && arg_index == 0
+}
+
+pub(crate) fn is_inlineable_call(name: &str) -> bool {
+    // every inlineable call's pointer arg is arg 0, so reuse the single list.
+    is_inlineable_pointer_arg(name, 0)
+}
+
 #[allow(dead_code)]
 pub fn debug_rewrite_groups<'tcx>(
     groups: &[RewriteGroup],

--- a/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
+++ b/crates/pointer_replacer/src/analyses/array_local_provenance/tests.rs
@@ -2816,3 +2816,158 @@ fn null_sentinel_reassignment_stays_transparent() {
         "null sentinel must keep a unique non-null Param base: {q:#?}"
     );
 }
+
+// --- builtin_summary tests ---
+
+#[test]
+fn builtin_summary_strstr_foreign_gives_param_and_null_bases() {
+    // strstr returns a cursor into arg0 or null; the result must have
+    // Param(uname) as the unique non-null base and a NullLike base too.
+    let map = run_analysis(
+        r#"
+        unsafe extern "C" {
+            fn strstr(
+                haystack: *const core::ffi::c_char,
+                needle: *const core::ffi::c_char,
+            ) -> *mut core::ffi::c_char;
+        }
+
+        pub unsafe fn f(uname: *const core::ffi::c_char, pat: *const core::ffi::c_char) {
+            let str_tmp: *mut core::ffi::c_char = strstr(uname, pat);
+            let _ = str_tmp;
+        }
+        "#,
+    );
+
+    let str_tmp = facts(&map, "f", "str_tmp");
+    // must carry a Param base (from arg0=uname)
+    assert!(
+        str_tmp
+            .bases
+            .iter()
+            .any(|b| matches!(b, BaseId::Param { .. })),
+        "strstr result must have a Param base: {str_tmp:#?}"
+    );
+    // must carry a NullLike base (null-on-miss)
+    assert!(
+        str_tmp.bases.iter().any(|b| matches!(
+            b,
+            BaseId::Unknown {
+                reason: UnknownReason::NullLike,
+                ..
+            }
+        )),
+        "strstr result must have a NullLike base: {str_tmp:#?}"
+    );
+    // unique non-null base must be the Param
+    assert!(
+        matches!(str_tmp.unique_non_null, Some(BaseId::Param { .. })),
+        "strstr unique non-null base must be Param(uname): {str_tmp:#?}"
+    );
+}
+
+#[test]
+fn builtin_summary_strstr_foreign_is_selected_and_nullable() {
+    // strstr result must be selected into a rewrite group together with `cur`
+    // (both derive from `uname`) and the group is nullable.
+    let code = r#"
+        unsafe extern "C" {
+            fn strstr(
+                haystack: *const core::ffi::c_char,
+                needle: *const core::ffi::c_char,
+            ) -> *mut core::ffi::c_char;
+        }
+
+        pub unsafe fn f(mut uname: *const core::ffi::c_char, pat: *const core::ffi::c_char) {
+            let str_tmp: *mut core::ffi::c_char = strstr(uname, pat);
+            let cur: *mut core::ffi::c_char = str_tmp.offset(1);
+            let _ = (*cur, *str_tmp);
+        }
+        "#;
+
+    // selection check
+    let groups = run_rewrite_groups_with_points_to(RewriteGroupFactMode::ReadyOnly, code);
+    let f_groups = groups.get("f").expect("missing facts for f");
+    assert!(
+        f_groups
+            .iter()
+            .any(|group| group.member_names.contains("str_tmp")),
+        "strstr result must be selected into a rewrite group: {f_groups:#?}"
+    );
+
+    // nullability check: str_tmp must carry a NullLike base so the rewriter
+    // emits Option<isize>; dropping the NullLike flow from base_preserving()
+    // would leave the selection assertion above green but break this one.
+    let map = run_analysis(code);
+    let str_tmp = facts(&map, "f", "str_tmp");
+    assert!(
+        str_tmp.bases.iter().any(|b| matches!(
+            b,
+            BaseId::Unknown {
+                reason: UnknownReason::NullLike,
+                ..
+            }
+        )),
+        "str_tmp must carry a NullLike base (null-on-miss makes it nullable): {str_tmp:#?}"
+    );
+}
+
+#[test]
+fn builtin_summary_local_strstr_not_treated_as_base_preserving() {
+    // a LOCAL Rust function named strstr must not be treated as base-preserving
+    // by the builtin table; its return gets OpaqueReturn provenance.
+    let map = run_analysis(
+        r#"
+        pub unsafe fn strstr(
+            haystack: *const core::ffi::c_char,
+            needle: *const core::ffi::c_char,
+        ) -> *mut core::ffi::c_char {
+            let _ = (haystack, needle);
+            core::ptr::null_mut()
+        }
+
+        pub unsafe fn f(uname: *const core::ffi::c_char, pat: *const core::ffi::c_char) {
+            let str_tmp: *mut core::ffi::c_char = strstr(uname, pat);
+            let _ = str_tmp;
+        }
+        "#,
+    );
+
+    let str_tmp = facts(&map, "f", "str_tmp");
+    // the local strstr returns null_mut(), so no Param base should flow to str_tmp
+    assert!(
+        !str_tmp
+            .bases
+            .iter()
+            .any(|b| matches!(b, BaseId::Param { .. })),
+        "local strstr must not receive Param base from the builtin table: {str_tmp:#?}"
+    );
+}
+
+#[test]
+fn builtin_summary_mismatched_foreign_strstr_not_base_preserving() {
+    // a foreign strstr whose first two args are non-pointer integers does not
+    // match the builtin signature guard and falls through to unknown-call handling.
+    let map = run_analysis(
+        r#"
+        unsafe extern "C" {
+            fn strstr(a: i32, b: i32) -> *mut core::ffi::c_char;
+        }
+
+        pub unsafe fn f(n: i32, m: i32) {
+            let str_tmp: *mut core::ffi::c_char = strstr(n, m);
+            let _ = str_tmp;
+        }
+        "#,
+    );
+
+    let str_tmp = facts(&map, "f", "str_tmp");
+    // mismatched signature must not produce {Param, NullLike} base set
+    assert!(
+        !str_tmp
+            .bases
+            .iter()
+            .any(|b| matches!(b, BaseId::Param { .. })),
+        "signature-mismatched foreign strstr must not receive a Param base: {str_tmp:#?}"
+    );
+}

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -1568,6 +1568,13 @@ fn choose_binding_representations(
                 rewrite.representation = BindingRepresentation::IndexOnly;
                 continue;
             }
+            // a moving cursor whose only materialization reason is shared value
+            // uses (derefs) stays index-only; its uses are inline-materialized
+            // rather than kept as a `&T` binding.
+            if !matches!(kind, MaterializationKind::RawPtr) && summary.has_index_benefit() {
+                rewrite.representation = BindingRepresentation::IndexOnly;
+                continue;
+            }
             rewrite.representation = BindingRepresentation::Materialized(kind);
         } else if !summary.has_index_benefit() {
             rewrite.representation = BindingRepresentation::IndexOnly;

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2105,7 +2105,6 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
                         &self.plan.by_hir_id,
                         base_rewrite,
                     );
-                // NOTE: Task 3.2 inserts base `DependsOn` edge collection here.
                 if unsupported {
                     self.mark_rewrites_for_base_unsupported(&base_key);
                 }
@@ -2144,9 +2143,6 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
             &self.plan.by_hir_id,
             rewrite,
         );
-        // NOTE: Task 2.1 inserts `decisions.insert(rhs.id, index)` and Task 3.2
-        // inserts `DependsOn` edge collection at this same derivation. Task 1.2
-        // uses only the supported/unsupported distinction.
         if unsupported {
             if self.trace_enabled {
                 self.dropped_reasons.push((
@@ -2407,21 +2403,26 @@ struct DerivationCtx<'a, 'tcx> {
 }
 
 /// the single result of deriving an index from an assignment/init RHS.
+// the `DependsOn` member list and the `Unsupported` reason string are not read
+// today (every caller treats `Index` and `DependsOn` alike and ignores the
+// reason); they are retained as the natural carriers for the deferred
+// dependency-cascade / base-cursor work continuing on this branch.
 #[allow(dead_code)]
 enum Derivation {
     /// fully derivable from the anchor (and possibly the base cursor).
     Index(IndexExpr),
-    /// derivable, but only if these planned members are also rewritten.
-    /// (the edge vec is collected in Task 3.2; the reason str in Task 2.1.)
+    /// derivable; the `Vec<HirId>` lists the other planned members it derives
+    /// from (reserved for the deferred dependency-cascade analysis).
     DependsOn(IndexExpr, Vec<HirId>),
-    /// not derivable; the &str is the trace reason.
+    /// not derivable; the &str is the (reserved) trace reason.
     Unsupported(&'static str),
 }
 
-/// the one derivation entry point. validation and emission both call this with
-/// the same arguments, so they cannot disagree. every planned member is treated
-/// as available; a dependency on another member is recorded via `DependsOn`
-/// rather than gated on an `introduced` set.
+/// the one derivation entry point, shared by validation and emission so they
+/// cannot disagree on whether an RHS is derivable. the supported/unsupported
+/// decision is independent of `ctx.introduced`; that set only selects, at
+/// emission, between the index form and the runtime `offset_from` pointer form
+/// for a cross-reference to a member that is not (yet) introduced.
 fn derive_index(rhs: &Expr, anchor: Anchor<'_>, ctx: &DerivationCtx<'_, '_>) -> Derivation {
     match anchor {
         Anchor::Member(rewrite) => derive_member_index(rhs, rewrite, ctx),

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -1857,10 +1857,20 @@ impl AstVisitor<'_> for BindingUseClassifier<'_, '_> {
             }
             ExprKind::Assign(lhs, rhs, _) => {
                 self.record_multi_cursor_deref_expr([&**lhs, &**rhs]);
-                if let Some(hir_id) = self.direct_planned_local_hir_id(lhs) {
+                let lhs_hir = self.direct_planned_local_hir_id(lhs);
+                if let Some(hir_id) = lhs_hir {
                     self.summaries.entry(hir_id).or_default().movement_count += 1;
                 }
                 self.record_write_through_pointer(lhs);
+                // a member copy `q = p` (both same-group planned members) is an
+                // index operation, not a pointer-value use of `p`.
+                if let Some(lhs_hir) = lhs_hir
+                    && let Some(rhs_hir) = self.direct_planned_local_hir_id(rhs)
+                    && self.same_group_members(lhs_hir, rhs_hir)
+                {
+                    self.summaries.entry(rhs_hir).or_default().movement_count += 1;
+                    return;
+                }
                 self.visit_expr(rhs);
                 return;
             }
@@ -1948,9 +1958,34 @@ impl AstVisitor<'_> for BindingUseClassifier<'_, '_> {
         }
         visit::walk_expr(self, expr);
     }
+
+    fn visit_local(&mut self, local: &rustc_ast::Local) {
+        // a member-copy initializer `let q = p` (both same-group planned members)
+        // is an index operation, not a pointer-value use of `p`.
+        if let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx)
+            && let hir::PatKind::Binding(_, q_hir, _, _) = let_stmt.pat.kind
+            && self.planned_rewrites.contains_key(&q_hir)
+            && let LocalKind::Init(init) | LocalKind::InitElse(init, _) = &local.kind
+            && let Some(p_hir) = self.direct_planned_local_hir_id(init)
+            && self.same_group_members(q_hir, p_hir)
+        {
+            self.summaries.entry(p_hir).or_default().movement_count += 1;
+            return;
+        }
+        visit::walk_local(self, local);
+    }
 }
 
 impl BindingUseClassifier<'_, '_> {
+    /// true when both hir ids are planned members of the same group (same base).
+    fn same_group_members(&self, a: HirId, b: HirId) -> bool {
+        let (Some(ra), Some(rb)) = (self.planned_rewrites.get(&a), self.planned_rewrites.get(&b))
+        else {
+            return false;
+        };
+        ra.base_hir_id == rb.base_hir_id && ra.base_name == rb.base_name
+    }
+
     fn direct_planned_local_hir_id(&self, expr: &Expr) -> Option<HirId> {
         direct_planned_local_hir_id(
             self.ast_to_hir,

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2614,6 +2614,9 @@ fn derive_member_call(
     let base_index = base_current_index_expr(rewrite).unwrap_or("0isize");
     let base_ptr = base_offset_expr_for_index(rewrite, base_index);
     let call_str = pprust::expr_to_string(rhs);
+    // every base-preserving call recognized here returns the cursor or null, so
+    // its member is nullable; the non-nullable branch holds only if a future
+    // base-preserving entry guarantees a non-null return.
     let block = if rewrite.nullable {
         utils::expr!(
             "{{ let __crat_call_cursor = {}; if __crat_call_cursor.is_null() {{ None }} else {{ Some((__crat_call_cursor).offset_from({})) }} }}",

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -121,9 +121,8 @@ impl BindingUseSummary {
         if self.unsupported_escape || self.address_taken_count > 0 {
             return None;
         }
-        if self.call_arg_count > 0 {
-            return Some(MaterializationKind::RawPtr);
-        }
+        // a call argument is inline-materialized at the call site (via the
+        // pointer_value_expr fallback), so it does not force a kept raw pointer.
         if self.pointer_value_count > 0 {
             return Some(MaterializationKind::RawPtr);
         }
@@ -169,16 +168,15 @@ mod binding_use_summary_tests {
     }
 
     #[test]
-    fn call_argument_use_materializes_as_raw_pointer() {
+    fn call_argument_use_does_not_force_materialization() {
+        // a call argument is inline-materialized at the call site, so it does not
+        // force a kept raw-pointer binding.
         let summary = BindingUseSummary {
             call_arg_count: 1,
             ..BindingUseSummary::default()
         };
 
-        assert_eq!(
-            summary.materialization_kind(false),
-            Some(MaterializationKind::RawPtr)
-        );
+        assert_eq!(summary.materialization_kind(false), None);
     }
 
     #[test]

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2369,6 +2369,9 @@ fn direct_local_hir_id(ast_to_hir: &AstToHir, tcx: TyCtxt<'_>, expr: &Expr) -> O
 #[derive(Clone)]
 enum IndexExpr {
     Plain(Expr),
+    /// an index expression already in the target representation (`isize` or
+    /// `Option<isize>`); emitted verbatim, never wrapped. used for member copies.
+    Verbatim(Expr),
     Null,
     Unsupported,
 }
@@ -2417,6 +2420,62 @@ fn derive_index(rhs: &Expr, anchor: Anchor<'_>, ctx: &DerivationCtx<'_, '_>) -> 
     }
 }
 
+/// derives `q = other` where `other` is a direct path to another planned member
+/// of the same group. returns `None` if `rhs` is not a path to a group member
+/// (so derivation falls through to the method-call forms); returns
+/// `Some(Unsupported)` if it is a member copy but not expressible.
+fn derive_member_copy(
+    rhs: &Expr,
+    rewrite: &BindingRewrite,
+    ctx: &DerivationCtx<'_, '_>,
+) -> Option<Derivation> {
+    let other_hir_id = hir_id_of_ast_expr(ctx.ast_to_hir, ctx.tcx, rhs.id)?;
+    if !rewrite.group_member_hir_ids.contains(&other_hir_id) {
+        return None;
+    }
+    let other = ctx.plan.by_hir_id.get(&other_hir_id)?;
+    if other.base_hir_id != rewrite.base_hir_id || other.base_name != rewrite.base_name {
+        return None;
+    }
+    if other.nullable != rewrite.nullable {
+        return Some(Derivation::Unsupported(
+            "member copy with mismatched nullability",
+        ));
+    }
+    // introduced (or, during validation, treated as available): copy the index
+    // value verbatim (q_idx = other_idx), preserving the null state for nullable
+    // members.
+    if ctx
+        .introduced
+        .is_none_or(|introduced| introduced.contains(&other_hir_id))
+    {
+        return Some(Derivation::DependsOn(
+            IndexExpr::Verbatim(utils::expr!("{}", other.index_name)),
+            vec![other_hir_id],
+        ));
+    }
+    // not introduced: `other` is still a raw pointer at runtime, so compute the
+    // index via `offset_from` (a non-null index, so `Plain` wraps correctly for
+    // a nullable destination). only at assignment sites, matching item 6.
+    if ctx.allow_member_pointer_form {
+        let base_index = base_current_index_expr(rewrite).unwrap_or("0isize");
+        let base_ptr = base_offset_expr_for_index(rewrite, base_index);
+        let relative = utils::expr!(
+            "({}).offset_from({})",
+            pprust::expr_to_string(rhs),
+            base_ptr
+        );
+        let index = match base_current_index_expr(rewrite) {
+            Some(name) => add_index_expr(name, &relative),
+            None => relative,
+        };
+        return Some(Derivation::Index(IndexExpr::Plain(index)));
+    }
+    Some(Derivation::Unsupported(
+        "member copy from a not-introduced member at an initializer site",
+    ))
+}
+
 fn derive_member_index(
     rhs: &Expr,
     rewrite: &BindingRewrite,
@@ -2428,6 +2487,10 @@ fn derive_member_index(
         index => return Derivation::Index(index),
     }
     let rhs = unwrap_pointer_producing_expr(rhs);
+    // direct member copy: q = p where p is another planned member of the same group.
+    if let Some(derivation) = derive_member_copy(rhs, rewrite, ctx) {
+        return derivation;
+    }
     let ExprKind::MethodCall(call) = &rhs.kind else {
         return Derivation::Unsupported("member RHS is not base-derived or a method call");
     };
@@ -2940,6 +3003,7 @@ fn index_init_expr(index: IndexExpr, nullable: bool) -> Option<Expr> {
         (IndexExpr::Plain(expr), true) => {
             Some(utils::expr!("Some({})", pprust::expr_to_string(&expr)))
         }
+        (IndexExpr::Verbatim(expr), _) => Some(expr),
         (IndexExpr::Null, true) => Some(utils::expr!("None")),
         (IndexExpr::Null, false) | (IndexExpr::Unsupported, _) => None,
     }
@@ -3124,7 +3188,9 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
             return Some(idx_read_expr(rewrite));
         }
         match pointer_index_from_base_expr(expr, self.ast_to_hir, self.tcx, anchor) {
-            IndexExpr::Plain(index) => Some(pprust::expr_to_string(&index)),
+            IndexExpr::Plain(index) | IndexExpr::Verbatim(index) => {
+                Some(pprust::expr_to_string(&index))
+            }
             IndexExpr::Null | IndexExpr::Unsupported => None,
         }
     }

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2385,28 +2385,18 @@ struct DerivationCtx<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     plan: &'a RewritePlan,
     /// the set of members already introduced (index-rewritten) at this point.
-    /// `None` during validation (every planned member is treated as available
-    /// so the `DependsOn` edge is recorded). `Some(set)` during emission, so a
+    /// `None` during validation, `Some(set)` during emission
     /// cross-reference to a member that is planned but not yet introduced —
     /// e.g. one whose initializer was not index-derivable and stays raw — falls
     /// back to the runtime `offset_from` form against the member's raw pointer
-    /// (preserving the pre-consolidation behavior).
     introduced: Option<&'a FxHashSet<HirId>>,
     /// whether the runtime `offset_from` pointer-form fallback for a
-    /// not-introduced / pruned group member is permitted. the pre-consolidation
-    /// code reached that form only from the *assignment* path
-    /// (`group_member_pointer_assignment_index_expr`), never from the binding
-    /// *initializer* path (`visit_local`/`rewrite_materialized_local_stmt`), so
-    /// this is `true` at assignment sites and `false` at initializer sites to
-    /// stay diff-neutral.
+    /// not-introduced / pruned group member is permitted. this is `true` at
+    /// assignment sites and `false` at initializer sites to stay diff-neutral.
     allow_member_pointer_form: bool,
 }
 
 /// the single result of deriving an index from an assignment/init RHS.
-// the `DependsOn` member list and the `Unsupported` reason string are not read
-// today (every caller treats `Index` and `DependsOn` alike and ignores the
-// reason); they are retained as the natural carriers for the deferred
-// dependency-cascade / base-cursor work continuing on this branch.
 #[allow(dead_code)]
 enum Derivation {
     /// fully derivable from the anchor (and possibly the base cursor).
@@ -2414,15 +2404,12 @@ enum Derivation {
     /// derivable; the `Vec<HirId>` lists the other planned members it derives
     /// from (reserved for the deferred dependency-cascade analysis).
     DependsOn(IndexExpr, Vec<HirId>),
-    /// not derivable; the &str is the (reserved) trace reason.
+    /// not derivable; the &str is the trace reason.
     Unsupported(&'static str),
 }
 
 /// the one derivation entry point, shared by validation and emission so they
-/// cannot disagree on whether an RHS is derivable. the supported/unsupported
-/// decision is independent of `ctx.introduced`; that set only selects, at
-/// emission, between the index form and the runtime `offset_from` pointer form
-/// for a cross-reference to a member that is not (yet) introduced.
+/// cannot disagree on whether an RHS is derivable.
 fn derive_index(rhs: &Expr, anchor: Anchor<'_>, ctx: &DerivationCtx<'_, '_>) -> Derivation {
     match anchor {
         Anchor::Member(rewrite) => derive_member_index(rhs, rewrite, ctx),
@@ -2463,8 +2450,7 @@ fn derive_member_index(
     }
     // 3. from another planned member of the same group that is (or, during
     //    validation, is treated as) introduced: q = other.offset(n) ->
-    //    other_idx + n. gate on group_member_hir_ids (the frozen group set) AND
-    //    same base, matching the original introduced_group_member path.
+    //    other_idx + n.
     if let Some(other_hir_id) = receiver_hir_id
         && rewrite.group_member_hir_ids.contains(&other_hir_id)
         && ctx
@@ -2487,10 +2473,6 @@ fn derive_member_index(
     //    from the plan, or planned but not (yet) introduced (e.g. its init was
     //    undecidable so it stays raw). the member is a raw pointer at runtime,
     //    so compute the index via runtime `offset_from` against the base
-    //    pointer — the emitted form of the old
-    //    group_member_pointer_assignment_index_expr. this keeps groups alive
-    //    when only a subset of members is index-derivable. only reachable from
-    //    assignment sites (not initializer sites), matching the old code.
     if ctx.allow_member_pointer_form
         && let Some(other_hir_id) = receiver_hir_id
         && rewrite.group_member_hir_ids.contains(&other_hir_id)
@@ -2915,7 +2897,7 @@ fn pointer_index_from_base_expr(
 /// For a live (caller-visible) field base, recognizes a base self-advance
 /// `(*s).out = (*s).out.offset(n)` / `.add(n)` and returns the counter update
 /// expression `out_idx + n`. Returns `None` for any other RHS (e.g. assignment
-/// from a member), which approach D does not support.
+/// from a member)
 fn live_base_self_advance_counter(
     rhs: &Expr,
     ast_to_hir: &AstToHir,
@@ -3171,8 +3153,7 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
             tcx: self.tcx,
             plan: &self.plan,
             introduced: Some(&self.introduced_hir_ids),
-            // initializer site: no pointer-form fallback (diff-neutral with the
-            // old visit_local path, which never reached the pointer form).
+            // initializer site: no pointer-form fallback
             allow_member_pointer_form: false,
         };
         let index = match derive_index(init, Anchor::Member(&rewrite), &ctx) {

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2365,6 +2365,161 @@ enum IndexExpr {
     Unsupported,
 }
 
+/// what an index derivation is anchored to: a group member or a base cursor.
+#[allow(dead_code)]
+enum Anchor<'a> {
+    Member(&'a BindingRewrite),
+    Base(&'a BaseCursorRewrite),
+}
+
+/// read-only context for derivation, shared by validation and emission.
+#[allow(dead_code)]
+struct DerivationCtx<'a, 'tcx> {
+    ast_to_hir: &'a AstToHir,
+    tcx: TyCtxt<'tcx>,
+    plan: &'a RewritePlan,
+}
+
+/// the single result of deriving an index from an assignment/init RHS.
+#[allow(dead_code)]
+enum Derivation {
+    /// fully derivable from the anchor (and possibly the base cursor).
+    Index(IndexExpr),
+    /// derivable, but only if these planned members are also rewritten.
+    DependsOn(IndexExpr, Vec<HirId>),
+    /// not derivable; the &str is the trace reason.
+    Unsupported(&'static str),
+}
+
+/// the one derivation entry point. validation and emission both call this with
+/// the same arguments, so they cannot disagree. every planned member is treated
+/// as available; a dependency on another member is recorded via `DependsOn`
+/// rather than gated on an `introduced` set.
+#[allow(dead_code)]
+fn derive_index(rhs: &Expr, anchor: Anchor<'_>, ctx: &DerivationCtx<'_, '_>) -> Derivation {
+    match anchor {
+        Anchor::Member(rewrite) => derive_member_index(rhs, rewrite, ctx),
+        Anchor::Base(base_rewrite) => derive_base_index(rhs, base_rewrite, ctx),
+    }
+}
+
+#[allow(dead_code)]
+fn derive_member_index(
+    rhs: &Expr,
+    rewrite: &BindingRewrite,
+    ctx: &DerivationCtx<'_, '_>,
+) -> Derivation {
+    // 1. derive-from-base (RHS is base, base.offset(n), proxy, base.as_ptr...).
+    match pointer_index_from_base_expr(rhs, ctx.ast_to_hir, ctx.tcx, rewrite) {
+        IndexExpr::Unsupported => {}
+        index => return Derivation::Index(index),
+    }
+    let rhs = unwrap_pointer_producing_expr(rhs);
+    let ExprKind::MethodCall(call) = &rhs.kind else {
+        return Derivation::Unsupported("member RHS is not base-derived or a method call");
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return Derivation::Unsupported("member RHS method is not offset/add");
+    }
+    if !receiver_cast_preserves_pointee_layout(&call.receiver, ctx.ast_to_hir, ctx.tcx) {
+        return Derivation::Unsupported("member RHS receiver cast changes pointee size");
+    }
+    let receiver = unwrap_pointer_producing_expr(&call.receiver);
+    let receiver_hir_id = hir_id_of_ast_expr(ctx.ast_to_hir, ctx.tcx, receiver.id);
+    // 2. self-advance: q = q.offset(n) -> idx_read(self) + n. no dependency.
+    if receiver_hir_id == Some(rewrite.source_hir_id) {
+        return Derivation::Index(IndexExpr::Plain(relative_index_expr(
+            &idx_read_expr(rewrite),
+            name,
+            &call.args[0],
+        )));
+    }
+    // 3. from another planned member of the same group: q = other.offset(n).
+    //    gate on group_member_hir_ids (the frozen group set) AND same base, to
+    //    match the original introduced_group_member_assignment_index_expr.
+    if let Some(other_hir_id) = receiver_hir_id
+        && rewrite.group_member_hir_ids.contains(&other_hir_id)
+        && let Some(other) = ctx.plan.by_hir_id.get(&other_hir_id)
+        && other.base_hir_id == rewrite.base_hir_id
+        && other.base_name == rewrite.base_name
+    {
+        return Derivation::DependsOn(
+            IndexExpr::Plain(relative_index_expr(&idx_read_expr(other), name, &call.args[0])),
+            vec![other_hir_id],
+        );
+    }
+    Derivation::Unsupported("member RHS receiver is not the base, self, or a planned member")
+}
+
+#[allow(dead_code)]
+fn derive_base_index(
+    rhs: &Expr,
+    base_rewrite: &BaseCursorRewrite,
+    ctx: &DerivationCtx<'_, '_>,
+) -> Derivation {
+    if is_null_expr(rhs) {
+        return Derivation::Unsupported("base assignment from null");
+    }
+    let rhs_u = unwrap_cast_and_paren(rhs);
+    // base = base / base.as_ptr -> index 0 (the base cursor's own index).
+    if (!base_rewrite.field_base
+        && hir_id_of_ast_expr(ctx.ast_to_hir, ctx.tcx, rhs_u.id) == Some(base_rewrite.base_hir_id))
+        || (base_rewrite.field_base && expr_matches_base_name(rhs_u, &base_rewrite.base_name))
+    {
+        return Derivation::Index(IndexExpr::Plain(utils::expr!("{}", base_rewrite.index_name)));
+    }
+    // base = member (same base) -> DependsOn(member_idx, [member]).
+    if let Some(hir_id) =
+        direct_planned_local_hir_id(ctx.ast_to_hir, ctx.tcx, &ctx.plan.by_hir_id, rhs_u)
+        && let Some(member) = ctx.plan.by_hir_id.get(&hir_id)
+        && same_rewrite_base(member, base_rewrite)
+    {
+        return Derivation::DependsOn(
+            IndexExpr::Plain(utils::expr!("{}", idx_read_expr(member))),
+            vec![hir_id],
+        );
+    }
+    let ExprKind::MethodCall(call) = &rhs_u.kind else {
+        return Derivation::Unsupported("base RHS is not base/member or a method call");
+    };
+    let name = call.seg.ident.name.as_str();
+    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+        return Derivation::Unsupported("base RHS method is not offset/add");
+    }
+    if !receiver_cast_preserves_pointee_layout(&call.receiver, ctx.ast_to_hir, ctx.tcx) {
+        return Derivation::Unsupported("base RHS receiver cast changes pointee size");
+    }
+    let receiver = unwrap_cast_and_paren(&call.receiver);
+    let receiver_hir_id = hir_id_of_ast_expr(ctx.ast_to_hir, ctx.tcx, receiver.id);
+    let receiver_is_base = (!base_rewrite.field_base
+        && receiver_hir_id == Some(base_rewrite.base_hir_id))
+        || receiver_is_base_as_ptr_for_context(
+            receiver,
+            ctx.ast_to_hir,
+            ctx.tcx,
+            base_rewrite.base_hir_id,
+            &base_rewrite.base_name,
+            base_rewrite.field_base,
+        )
+        || (base_rewrite.field_base && expr_matches_base_name(receiver, &base_rewrite.base_name));
+    if receiver_is_base {
+        let offset = offset_index_arg_expr(name, &call.args[0]);
+        return Derivation::Index(IndexExpr::Plain(add_index_expr(&base_rewrite.index_name, &offset)));
+    }
+    // base = member.offset(n) (same base) -> DependsOn(member_idx + n, [member]).
+    if let Some(hir_id) = receiver_hir_id
+        && let Some(member) = ctx.plan.by_hir_id.get(&hir_id)
+        && same_rewrite_base(member, base_rewrite)
+    {
+        return Derivation::DependsOn(
+            IndexExpr::Plain(relative_index_expr(&idx_read_expr(member), name, &call.args[0])),
+            vec![hir_id],
+        );
+    }
+    Derivation::Unsupported("base RHS receiver is not the base or a planned member")
+}
+
 fn hir_id_of_ast_expr(ast_to_hir: &AstToHir, tcx: TyCtxt<'_>, node_id: NodeId) -> Option<HirId> {
     let hir_expr = ast_to_hir.get_expr(node_id, tcx)?;
     let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = hir_expr.kind else {
@@ -3642,5 +3797,22 @@ mod member_offset_tests {
     #[test]
     fn live_base_without_index_is_unchanged() {
         assert_eq!(member_offset_expr(true, None, "src_idx"), "src_idx");
+    }
+}
+
+#[cfg(test)]
+mod derivation_tests {
+    // these run the whole pass and assert the emitted index forms, which
+    // exercise derive_index end to end (a direct unit harness would need a
+    // built RewritePlan). kept here so the module name documents intent.
+    use super::*;
+
+    // marker test: derive_index exists and the enum variants are constructible.
+    #[test]
+    fn derivation_enum_is_constructible() {
+        let d = Derivation::Unsupported("x");
+        assert!(matches!(d, Derivation::Unsupported("x")));
+        let d2 = Derivation::DependsOn(IndexExpr::Null, vec![]);
+        assert!(matches!(d2, Derivation::DependsOn(IndexExpr::Null, _)));
     }
 }

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2136,6 +2136,7 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
             Derivation::Index(index) | Derivation::DependsOn(index, _) => {
                 index_init_expr(index.clone(), rewrite.nullable).is_none()
             }
+            Derivation::Conditional { .. } => false,
         } || assignment_index_arg_contains_planned_local(
             rhs,
             self.ast_to_hir,
@@ -2407,6 +2408,14 @@ enum Derivation {
     /// derivable; the `Vec<HirId>` lists the other planned members it derives
     /// from (reserved for the deferred dependency-cascade analysis).
     DependsOn(IndexExpr, Vec<HirId>),
+    /// a pointer-valued `if`/`else` whose branches each derive to an index
+    /// relative to the same group base.
+    Conditional {
+        then_index: IndexExpr,
+        else_index: IndexExpr,
+        #[allow(dead_code)]
+        deps: Vec<HirId>,
+    },
     /// not derivable; the &str is the trace reason.
     Unsupported(&'static str),
 }
@@ -2476,6 +2485,71 @@ fn derive_member_copy(
     ))
 }
 
+/// the trailing expression of a block of the form `{ <expr> }` (a single
+/// expression statement and nothing else). returns `None` otherwise.
+fn block_tail_expr(block: &Block) -> Option<&Expr> {
+    let [stmt] = block.stmts.as_slice() else {
+        return None;
+    };
+    match &stmt.kind {
+        StmtKind::Expr(expr) => Some(expr),
+        _ => None,
+    }
+}
+
+/// derives a pointer-valued `if cond { a } else { b }` assigned to a member,
+/// where both branch tails derive to an index against the same anchor.
+fn derive_member_conditional(
+    rhs: &Expr,
+    rewrite: &BindingRewrite,
+    ctx: &DerivationCtx<'_, '_>,
+) -> Derivation {
+    let ExprKind::If(_cond, then_block, Some(else_expr)) = &rhs.kind else {
+        return Derivation::Unsupported("conditional cursor update without an else branch");
+    };
+    let (Some(then_tail), ExprKind::Block(else_block, _)) =
+        (block_tail_expr(then_block), &else_expr.kind)
+    else {
+        return Derivation::Unsupported("conditional branch is not a simple block");
+    };
+    let Some(else_tail) = block_tail_expr(else_block) else {
+        return Derivation::Unsupported("conditional else branch is not a simple block");
+    };
+    let mut deps = Vec::new();
+    let then_index = match derive_member_index(then_tail, rewrite, ctx) {
+        Derivation::Index(index) => index,
+        Derivation::DependsOn(index, d) => {
+            deps.extend(d);
+            index
+        }
+        _ => return Derivation::Unsupported("conditional then branch is not index-derivable"),
+    };
+    let else_index = match derive_member_index(else_tail, rewrite, ctx) {
+        Derivation::Index(index) => index,
+        Derivation::DependsOn(index, d) => {
+            deps.extend(d);
+            index
+        }
+        _ => return Derivation::Unsupported("conditional else branch is not index-derivable"),
+    };
+    // both branches must be expressible for the destination's nullability. a
+    // `Null` branch is only expressible for a nullable destination, so this also
+    // enforces the spec's null-branch rule. (`IndexExpr` already derives `Clone`
+    // — the validation site at ~2136 calls `index.clone()`.)
+    if index_init_expr(then_index.clone(), rewrite.nullable).is_none()
+        || index_init_expr(else_index.clone(), rewrite.nullable).is_none()
+    {
+        return Derivation::Unsupported(
+            "conditional branch is null for a non-nullable destination",
+        );
+    }
+    Derivation::Conditional {
+        then_index,
+        else_index,
+        deps,
+    }
+}
+
 fn derive_member_index(
     rhs: &Expr,
     rewrite: &BindingRewrite,
@@ -2490,6 +2564,9 @@ fn derive_member_index(
     // direct member copy: q = p where p is another planned member of the same group.
     if let Some(derivation) = derive_member_copy(rhs, rewrite, ctx) {
         return derivation;
+    }
+    if let ExprKind::If(..) = &rhs.kind {
+        return derive_member_conditional(rhs, rewrite, ctx);
     }
     let ExprKind::MethodCall(call) = &rhs.kind else {
         return Derivation::Unsupported("member RHS is not base-derived or a method call");
@@ -3195,6 +3272,30 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
         }
     }
 
+    /// builds the index RHS for a conditional cursor update: visits the original
+    /// condition (rewriting pointer uses such as `*q`) and assembles
+    /// `if <cond'> { then } else { else }`. `rhs` is the original `if` expression.
+    fn conditional_index_rhs(
+        &mut self,
+        rhs: &mut Expr,
+        then_index: IndexExpr,
+        else_index: IndexExpr,
+        nullable: bool,
+    ) -> Option<Expr> {
+        let then_rhs = index_assignment_rhs_expr(then_index, nullable)?;
+        let else_rhs = index_assignment_rhs_expr(else_index, nullable)?;
+        let ExprKind::If(cond, _, _) = &mut rhs.kind else {
+            return None;
+        };
+        self.visit_expr(cond);
+        Some(utils::expr!(
+            "if {} {{ {} }} else {{ {} }}",
+            pprust::expr_to_string(cond),
+            pprust::expr_to_string(&then_rhs),
+            pprust::expr_to_string(&else_rhs)
+        ))
+    }
+
     fn rewrite_materialized_local_stmt(&mut self, local: &mut rustc_ast::Local) -> Option<Stmt> {
         let let_stmt = self.ast_to_hir.get_let_stmt(local.id, self.tcx)?;
         let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind else {
@@ -3224,6 +3325,7 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
         };
         let index = match derive_index(init, Anchor::Member(&rewrite), &ctx) {
             Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
+            Derivation::Conditional { .. } => IndexExpr::Unsupported,
             Derivation::Unsupported(_) => IndexExpr::Unsupported,
         };
         let Some(new_index_init) = index_init_expr(index, rewrite.nullable) else {
@@ -3348,11 +3450,19 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                     introduced: Some(&self.introduced_hir_ids),
                     allow_member_pointer_form: true,
                 };
-                let index = match derive_index(rhs, Anchor::Member(&rewrite), &ctx) {
-                    Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
-                    Derivation::Unsupported(_) => IndexExpr::Unsupported,
+                let derivation = derive_index(rhs, Anchor::Member(&rewrite), &ctx);
+                let new_rhs = match derivation {
+                    Derivation::Index(index) | Derivation::DependsOn(index, _) => {
+                        index_assignment_rhs_expr(index, rewrite.nullable)
+                    }
+                    Derivation::Conditional {
+                        then_index,
+                        else_index,
+                        ..
+                    } => self.conditional_index_rhs(rhs, then_index, else_index, rewrite.nullable),
+                    Derivation::Unsupported(_) => None,
                 };
-                if let Some(new_rhs) = index_assignment_rhs_expr(index, rewrite.nullable) {
+                if let Some(new_rhs) = new_rhs {
                     let idx_stmt = utils::stmt!(
                         "{} = {};",
                         rewrite.index_name,
@@ -3415,6 +3525,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
         };
         let index = match derive_index(init, Anchor::Member(&rewrite), &ctx) {
             Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
+            Derivation::Conditional { .. } => IndexExpr::Unsupported,
             Derivation::Unsupported(_) => IndexExpr::Unsupported,
         };
         let Some(new_init) = index_init_expr(index, rewrite.nullable) else {
@@ -3465,6 +3576,7 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                     };
                     let index = match derive_index(rhs, Anchor::Base(rewrite), &ctx) {
                         Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
+                        Derivation::Conditional { .. } => IndexExpr::Unsupported,
                         Derivation::Unsupported(_) => IndexExpr::Unsupported,
                     };
                     if let IndexExpr::Plain(new_rhs) = index {
@@ -3491,12 +3603,22 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                         introduced: Some(&self.introduced_hir_ids),
                         allow_member_pointer_form: true,
                     };
-                    let index = match derive_index(rhs, Anchor::Member(rewrite), &ctx) {
-                        Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
-                        Derivation::Unsupported(_) => IndexExpr::Unsupported,
+                    let derivation = derive_index(rhs, Anchor::Member(rewrite), &ctx);
+                    let index_name = rewrite.index_name.clone();
+                    let nullable = rewrite.nullable;
+                    let new_rhs = match derivation {
+                        Derivation::Index(index) | Derivation::DependsOn(index, _) => {
+                            index_assignment_rhs_expr(index, nullable)
+                        }
+                        Derivation::Conditional {
+                            then_index,
+                            else_index,
+                            ..
+                        } => self.conditional_index_rhs(rhs, then_index, else_index, nullable),
+                        Derivation::Unsupported(_) => None,
                     };
-                    if let Some(new_rhs) = index_assignment_rhs_expr(index, rewrite.nullable) {
-                        *lhs = P(utils::expr!("{}", rewrite.index_name));
+                    if let Some(new_rhs) = new_rhs {
+                        *lhs = P(utils::expr!("{}", index_name));
                         *rhs = P(new_rhs);
                         self.changed = true;
                     } else {

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -48,6 +48,24 @@ enum MaterializationKind {
     RawPtr,
 }
 
+/// one structural step of a base projection, used to match a base expression by
+/// resolution instead of pretty-printed text.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum BaseStep {
+    Deref,
+    Field(String),
+}
+
+/// structural form of a group's base: the root binding plus its projection steps.
+/// matching resolves the root via `HirId` and compares steps, so it is
+/// shadowing-safe and formatting-insensitive (unlike `base_name`, which is for
+/// emitting code only).
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct BasePath {
+    root: HirId,
+    steps: Vec<BaseStep>,
+}
+
 #[derive(Clone, Debug)]
 struct BindingRewrite {
     source_hir_id: HirId,
@@ -60,6 +78,7 @@ struct BindingRewrite {
     moves: bool,
     base_hir_id: HirId,
     base_name: String,
+    base_path: BasePath,
     base_index_name: Option<String>,
     base_is_raw_ptr: bool,
     nullable: bool,
@@ -78,6 +97,7 @@ struct BaseCursorRewrite {
     fn_def_id: LocalDefId,
     base_hir_id: HirId,
     base_name: String,
+    base_path: BasePath,
     index_name: String,
     base_is_raw_ptr: bool,
     ptr_ty: String,
@@ -907,106 +927,128 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
         return;
     };
 
-    // Compute (base_name, proxy_hir_ids) depending on whether the base is a
-    // direct local (offset 0) or a field path (offset > 0).
-    // (base_name, proxy_hir_ids, field_base)
-    let (base_name, proxy_hir_ids, field_base): (String, FxHashSet<HirId>, bool) =
-        if group.base_slot_offset == 0 {
-            (
-                context.tcx.hir_name(base_hir_id).to_string(),
-                FxHashSet::default(),
-                false,
-            )
-        } else {
-            let Some(base_slot_info) =
-                analyses::array_local_provenance::base_slot_info(context.provenance, group)
-            else {
-                context.trace.record(
-                    context.def_id,
-                    TraceSubject::Group(base_local_label()),
-                    TraceStage::Plan,
-                    TraceDecision::Dropped,
-                    || "plan: missing base slot info".to_string(),
-                );
-                return;
-            };
-            let local_name = context.tcx.hir_name(base_hir_id).to_string();
-            let base_ty = context.body.local_decls[group.base_local].ty;
-            let Some(field_path_name) =
-                slot_path_to_expr_string(&local_name, &base_slot_info.path, base_ty, context.tcx)
-            else {
-                context.trace.record(
-                    context.def_id,
-                    TraceSubject::Group(base_local_label()),
-                    TraceStage::Plan,
-                    TraceDecision::Dropped,
-                    || "plan: base field path not expressible".to_string(),
-                );
-                return;
-            };
-            // collect raw-pointer members that can serve as proxies for the field base
-            let proxies: FxHashSet<HirId> = group
-                .members
-                .iter()
-                .filter_map(|&slot_idx| {
-                    let info = context.provenance.slot_table.slot_infos.get(slot_idx)?;
-                    if !info.path.is_empty() || info.root == group.base_local {
-                        return None;
-                    }
-                    if !matches!(
-                        context.body.local_decls[info.root].ty.kind(),
-                        ty::TyKind::RawPtr(..)
-                    ) {
-                        return None;
-                    }
-                    let &hir_id = context.local_to_hir.get(&info.root)?;
-                    (!group.index_tracked
-                        && (local_is_pure_field_base_proxy(context.body, info.root)
-                            || (local_is_never_mutated(context.body, info.root)
-                                && local_is_simple_copy_from_local(
-                                    context.body,
-                                    info.root,
-                                    group.base_local,
-                                ))))
-                    .then_some(hir_id)
-                })
-                .collect();
-            // a never-mutated member that holds the base pointer at offset 0 can be used as
-            // the effective base name, avoiding rewriting it to an index and allowing members
-            // to use IndexOnly representation (field_base = false).
-            let immutable_copy_name = if !group.index_tracked {
-                group.members.iter().find_map(|&slot_idx| {
-                    let info = context.provenance.slot_table.slot_infos.get(slot_idx)?;
-                    if !info.path.is_empty() || info.root == group.base_local {
-                        return None;
-                    }
-                    if !matches!(
-                        context.body.local_decls[info.root].ty.kind(),
-                        ty::TyKind::RawPtr(..)
-                    ) {
-                        return None;
-                    }
-                    if local_is_pure_field_base_proxy(context.body, info.root) {
-                        return None;
-                    }
-                    if !local_is_never_mutated(context.body, info.root) {
-                        return None;
-                    }
-                    // confirm the single init directly copies the field base (not a call result)
-                    if !local_is_simple_copy_from_local(context.body, info.root, group.base_local) {
-                        return None;
-                    }
-                    let &hir_id = context.local_to_hir.get(&info.root)?;
-                    Some(context.tcx.hir_name(hir_id).to_string())
-                })
-            } else {
-                None
-            };
-            match immutable_copy_name {
-                Some(name) => (name, proxies, false),
-                None => (field_path_name, proxies, true),
-            }
+    // Compute (base_name, proxy_hir_ids, field_base, base_steps) depending on
+    // whether the base is a direct local (offset 0) or a field path (offset > 0).
+    // base_steps is the structural projection used for resolution-based matching;
+    // it is empty for a direct-local base (matching keys on the root HirId).
+    let (base_name, proxy_hir_ids, field_base, base_steps): (
+        String,
+        FxHashSet<HirId>,
+        bool,
+        Vec<BaseStep>,
+    ) = if group.base_slot_offset == 0 {
+        (
+            context.tcx.hir_name(base_hir_id).to_string(),
+            FxHashSet::default(),
+            false,
+            Vec::new(),
+        )
+    } else {
+        let Some(base_slot_info) =
+            analyses::array_local_provenance::base_slot_info(context.provenance, group)
+        else {
+            context.trace.record(
+                context.def_id,
+                TraceSubject::Group(base_local_label()),
+                TraceStage::Plan,
+                TraceDecision::Dropped,
+                || "plan: missing base slot info".to_string(),
+            );
+            return;
         };
+        let local_name = context.tcx.hir_name(base_hir_id).to_string();
+        let base_ty = context.body.local_decls[group.base_local].ty;
+        let Some(field_path_name) =
+            slot_path_to_expr_string(&local_name, &base_slot_info.path, base_ty, context.tcx)
+        else {
+            context.trace.record(
+                context.def_id,
+                TraceSubject::Group(base_local_label()),
+                TraceStage::Plan,
+                TraceDecision::Dropped,
+                || "plan: base field path not expressible".to_string(),
+            );
+            return;
+        };
+        let Some(field_base_steps) =
+            slot_path_to_base_steps(&base_slot_info.path, base_ty, context.tcx)
+        else {
+            context.trace.record(
+                context.def_id,
+                TraceSubject::Group(base_local_label()),
+                TraceStage::Plan,
+                TraceDecision::Dropped,
+                || "plan: base field path not structurally resolvable".to_string(),
+            );
+            return;
+        };
+        // collect raw-pointer members that can serve as proxies for the field base
+        let proxies: FxHashSet<HirId> = group
+            .members
+            .iter()
+            .filter_map(|&slot_idx| {
+                let info = context.provenance.slot_table.slot_infos.get(slot_idx)?;
+                if !info.path.is_empty() || info.root == group.base_local {
+                    return None;
+                }
+                if !matches!(
+                    context.body.local_decls[info.root].ty.kind(),
+                    ty::TyKind::RawPtr(..)
+                ) {
+                    return None;
+                }
+                let &hir_id = context.local_to_hir.get(&info.root)?;
+                (!group.index_tracked
+                    && (local_is_pure_field_base_proxy(context.body, info.root)
+                        || (local_is_never_mutated(context.body, info.root)
+                            && local_is_simple_copy_from_local(
+                                context.body,
+                                info.root,
+                                group.base_local,
+                            ))))
+                .then_some(hir_id)
+            })
+            .collect();
+        // a never-mutated member that holds the base pointer at offset 0 can be used as
+        // the effective base name, avoiding rewriting it to an index and allowing members
+        // to use IndexOnly representation (field_base = false).
+        let immutable_copy_name = if !group.index_tracked {
+            group.members.iter().find_map(|&slot_idx| {
+                let info = context.provenance.slot_table.slot_infos.get(slot_idx)?;
+                if !info.path.is_empty() || info.root == group.base_local {
+                    return None;
+                }
+                if !matches!(
+                    context.body.local_decls[info.root].ty.kind(),
+                    ty::TyKind::RawPtr(..)
+                ) {
+                    return None;
+                }
+                if local_is_pure_field_base_proxy(context.body, info.root) {
+                    return None;
+                }
+                if !local_is_never_mutated(context.body, info.root) {
+                    return None;
+                }
+                // confirm the single init directly copies the field base (not a call result)
+                if !local_is_simple_copy_from_local(context.body, info.root, group.base_local) {
+                    return None;
+                }
+                let &hir_id = context.local_to_hir.get(&info.root)?;
+                Some(context.tcx.hir_name(hir_id).to_string())
+            })
+        } else {
+            None
+        };
+        match immutable_copy_name {
+            Some(name) => (name, proxies, false, Vec::new()),
+            None => (field_path_name, proxies, true, field_base_steps),
+        }
+    };
+    let base_path = BasePath {
+        root: base_hir_id,
+        steps: base_steps,
+    };
 
     let base_is_raw_ptr = matches!(
         context.body.local_decls[group.base_local].ty.kind(),
@@ -1096,6 +1138,7 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                     fn_def_id: context.def_id,
                     base_hir_id,
                     base_name: base_name.clone(),
+                    base_path: base_path.clone(),
                     index_name: index_name.clone(),
                     base_is_raw_ptr,
                     ptr_ty,
@@ -1184,6 +1227,7 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                 moves: false,
                 base_hir_id,
                 base_name: base_name.clone(),
+                base_path: base_path.clone(),
                 base_index_name: base_index_name.clone(),
                 base_is_raw_ptr,
                 nullable,
@@ -1298,6 +1342,32 @@ fn slot_path_to_expr_string<'tcx>(
         }
     }
     Some(expr)
+}
+
+/// structural counterpart of `slot_path_to_expr_string`: resolves the same field
+/// names but emits `BaseStep`s for resolution-based matching. shares the failure
+/// conditions (unresolvable deref/field, `Element`).
+fn slot_path_to_base_steps<'tcx>(
+    path: &[SlotPathElem],
+    mut ty: ty::Ty<'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> Option<Vec<BaseStep>> {
+    let mut steps = Vec::with_capacity(path.len());
+    for elem in path {
+        match elem {
+            SlotPathElem::Pointee => {
+                ty = ty.builtin_deref(true)?;
+                steps.push(BaseStep::Deref);
+            }
+            SlotPathElem::Field(field) => {
+                let (field_name, field_ty) = named_struct_field(tcx, ty, *field)?;
+                steps.push(BaseStep::Field(field_name));
+                ty = field_ty;
+            }
+            SlotPathElem::Element => return None,
+        }
+    }
+    Some(steps)
 }
 
 fn local_is_pure_field_base_proxy(body: &rustc_middle::mir::Body<'_>, local: Local) -> bool {
@@ -1629,6 +1699,10 @@ fn collect_binding_use_summaries_for_names_for_test(
                     moves: false,
                     base_hir_id: hir_id,
                     base_name: "base".to_string(),
+                    base_path: BasePath {
+                        root: hir_id,
+                        steps: Vec::new(),
+                    },
                     base_index_name: None,
                     base_is_raw_ptr: true,
                     nullable: false,
@@ -2344,11 +2418,11 @@ fn base_assignment_index_arg_contains_planned_local(
             receiver,
             ast_to_hir,
             tcx,
-            base_rewrite.base_hir_id,
-            &base_rewrite.base_name,
+            &base_rewrite.base_path,
             base_rewrite.field_base,
         )
-        || (base_rewrite.field_base && expr_matches_base_name(receiver, &base_rewrite.base_name));
+        || (base_rewrite.field_base
+            && expr_matches_base_path(receiver, ast_to_hir, tcx, &base_rewrite.base_path));
     if !receiver_is_base
         && !receiver_hir_id.is_some_and(|hir_id| {
             planned_rewrites
@@ -2401,10 +2475,8 @@ fn direct_base_cursor_key(
         return Some(base_key);
     }
     base_rewrites.iter().find_map(|(key, rewrite)| {
-        (rewrite.field_base
-            && expr_matches_base_name(expr, &rewrite.base_name)
-            && expr_is_projection_from_base_hir(expr, ast_to_hir, tcx, rewrite.base_hir_id))
-        .then_some(key.clone())
+        (rewrite.field_base && expr_matches_base_path(expr, ast_to_hir, tcx, &rewrite.base_path))
+            .then_some(key.clone())
     })
 }
 
@@ -2613,7 +2685,8 @@ fn derive_member_call(
     let arg0 = call_args.first()?;
     let arg0_is_base = hir_id_of_ast_expr(ctx.ast_to_hir, ctx.tcx, unwrap_cast_and_paren(arg0).id)
         == Some(rewrite.base_hir_id)
-        || (rewrite.field_base && expr_matches_base_name(arg0, &rewrite.base_name));
+        || (rewrite.field_base
+            && expr_matches_base_path(arg0, ctx.ast_to_hir, ctx.tcx, &rewrite.base_path));
     if !arg0_is_base {
         return Some(Derivation::Unsupported("call arg0 is not the group base"));
     }
@@ -2745,7 +2818,8 @@ fn derive_base_index(
     // base = base / base.as_ptr -> index 0 (the base cursor's own index).
     if (!base_rewrite.field_base
         && hir_id_of_ast_expr(ctx.ast_to_hir, ctx.tcx, rhs_u.id) == Some(base_rewrite.base_hir_id))
-        || (base_rewrite.field_base && expr_matches_base_name(rhs_u, &base_rewrite.base_name))
+        || (base_rewrite.field_base
+            && expr_matches_base_path(rhs_u, ctx.ast_to_hir, ctx.tcx, &base_rewrite.base_path))
     {
         return Derivation::Index(IndexExpr::Plain(utils::expr!(
             "{}",
@@ -2781,11 +2855,11 @@ fn derive_base_index(
             receiver,
             ctx.ast_to_hir,
             ctx.tcx,
-            base_rewrite.base_hir_id,
-            &base_rewrite.base_name,
+            &base_rewrite.base_path,
             base_rewrite.field_base,
         )
-        || (base_rewrite.field_base && expr_matches_base_name(receiver, &base_rewrite.base_name));
+        || (base_rewrite.field_base
+            && expr_matches_base_path(receiver, ctx.ast_to_hir, ctx.tcx, &base_rewrite.base_path));
     if receiver_is_base {
         let offset = offset_index_arg_expr(name, &call.args[0]);
         return Derivation::Index(IndexExpr::Plain(add_index_expr(
@@ -2915,9 +2989,50 @@ fn unwrap_pointer_producing_expr(expr: &Expr) -> &Expr {
     }
 }
 
-fn expr_matches_base_name(expr: &Expr, base_name: &str) -> bool {
-    pprust::expr_to_string(unwrap_cast_and_paren(expr)).replace(' ', "")
-        == base_name.replace(' ', "")
+/// resolution-based field-base match: the projection steps must match
+/// structurally and the root must resolve to `base.root`. matches the same
+/// expression shapes a canonical pretty-printed comparison would — the outer
+/// cast/paren layer is stripped and inner parens are transparent, but `AddrOf`
+/// and inner casts are not peeled (they print differently and must not match) —
+/// while resolving the root by `HirId`, which a string comparison cannot do, so
+/// it is shadowing-safe.
+fn expr_matches_base_path(
+    expr: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    base: &BasePath,
+) -> bool {
+    expr_matches_base_steps(
+        unwrap_cast_and_paren(expr),
+        ast_to_hir,
+        tcx,
+        base.root,
+        &base.steps,
+    )
+}
+
+fn expr_matches_base_steps(
+    expr: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    root: HirId,
+    steps: &[BaseStep],
+) -> bool {
+    let expr = unwrap_paren(expr);
+    let Some((last, rest)) = steps.split_last() else {
+        return hir_id_of_ast_expr(ast_to_hir, tcx, expr.id) == Some(root);
+    };
+    match (last, &expr.kind) {
+        (BaseStep::Field(name), ExprKind::Field(inner, ident))
+            if ident.name.as_str() == name.as_str() =>
+        {
+            expr_matches_base_steps(inner, ast_to_hir, tcx, root, rest)
+        }
+        (BaseStep::Deref, ExprKind::Unary(UnOp::Deref, inner)) => {
+            expr_matches_base_steps(inner, ast_to_hir, tcx, root, rest)
+        }
+        _ => false,
+    }
 }
 
 fn offset_index_arg_expr(name: &str, arg: &Expr) -> Expr {
@@ -2977,7 +3092,12 @@ fn receiver_is_base_as_ptr_hir(
     expr_is_projection_from_base_hir(&call.receiver, ast_to_hir, tcx, base_hir_id)
 }
 
-fn receiver_is_field_base_as_ptr(receiver: &Expr, base_name: &str) -> bool {
+fn receiver_is_field_base_as_ptr(
+    receiver: &Expr,
+    ast_to_hir: &AstToHir,
+    tcx: TyCtxt<'_>,
+    base: &BasePath,
+) -> bool {
     let ExprKind::MethodCall(call) = &receiver.kind else {
         return false;
     };
@@ -2985,21 +3105,20 @@ fn receiver_is_field_base_as_ptr(receiver: &Expr, base_name: &str) -> bool {
     if !matches!(name, "as_ptr" | "as_mut_ptr") || !call.args.is_empty() {
         return false;
     }
-    expr_matches_base_name(&call.receiver, base_name)
+    expr_matches_base_path(&call.receiver, ast_to_hir, tcx, base)
 }
 
 fn receiver_is_base_as_ptr_for_context(
     receiver: &Expr,
     ast_to_hir: &AstToHir,
     tcx: TyCtxt<'_>,
-    base_hir_id: HirId,
-    base_name: &str,
+    base_path: &BasePath,
     field_base: bool,
 ) -> bool {
     if field_base {
-        receiver_is_field_base_as_ptr(receiver, base_name)
+        receiver_is_field_base_as_ptr(receiver, ast_to_hir, tcx, base_path)
     } else {
-        receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, base_hir_id)
+        receiver_is_base_as_ptr_hir(receiver, ast_to_hir, tcx, base_path.root)
     }
 }
 
@@ -3013,8 +3132,7 @@ fn receiver_is_base_as_ptr(
         receiver,
         ast_to_hir,
         tcx,
-        rewrite.base_hir_id,
-        &rewrite.base_name,
+        &rewrite.base_path,
         rewrite.field_base,
     )
 }
@@ -3071,7 +3189,7 @@ fn pointer_index_from_base_expr(
     rewrite: &BindingRewrite,
 ) -> IndexExpr {
     let base_hir_id = rewrite.base_hir_id;
-    let base_name = rewrite.base_name.as_str();
+    let base_path = &rewrite.base_path;
     let field_base = rewrite.field_base;
     let base_proxy_hir_ids = &rewrite.base_proxy_hir_ids;
     let base_index_name = base_current_index_expr(rewrite);
@@ -3084,15 +3202,8 @@ fn pointer_index_from_base_expr(
     let expr_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, expr.id);
     if (!field_base && expr_hir_id == Some(base_hir_id))
         || expr_hir_id.is_some_and(|id| base_proxy_hir_ids.contains(&id))
-        || (field_base && expr_matches_base_name(expr, base_name))
-        || receiver_is_base_as_ptr_for_context(
-            expr,
-            ast_to_hir,
-            tcx,
-            base_hir_id,
-            base_name,
-            field_base,
-        )
+        || (field_base && expr_matches_base_path(expr, ast_to_hir, tcx, base_path))
+        || receiver_is_base_as_ptr_for_context(expr, ast_to_hir, tcx, base_path, field_base)
     {
         return IndexExpr::Plain(match base_index_name {
             Some(index_name) => utils::expr!("{}", index_name),
@@ -3113,15 +3224,8 @@ fn pointer_index_from_base_expr(
     let receiver = unwrap_cast_and_paren(&call.receiver);
     let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
     let receiver_is_base = (!field_base && receiver_hir_id == Some(base_hir_id))
-        || receiver_is_base_as_ptr_for_context(
-            receiver,
-            ast_to_hir,
-            tcx,
-            base_hir_id,
-            base_name,
-            field_base,
-        )
-        || (field_base && expr_matches_base_name(receiver, base_name))
+        || receiver_is_base_as_ptr_for_context(receiver, ast_to_hir, tcx, base_path, field_base)
+        || (field_base && expr_matches_base_path(receiver, ast_to_hir, tcx, base_path))
         || receiver_hir_id.is_some_and(|id| base_proxy_hir_ids.contains(&id));
     if !receiver_is_base {
         return IndexExpr::Unsupported;
@@ -3161,11 +3265,11 @@ fn live_base_self_advance_counter(
             receiver,
             ast_to_hir,
             tcx,
-            base_rewrite.base_hir_id,
-            &base_rewrite.base_name,
+            &base_rewrite.base_path,
             base_rewrite.field_base,
         )
-        || (base_rewrite.field_base && expr_matches_base_name(receiver, &base_rewrite.base_name));
+        || (base_rewrite.field_base
+            && expr_matches_base_path(receiver, ast_to_hir, tcx, &base_rewrite.base_path));
     if !receiver_is_base {
         return None;
     }

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -3371,6 +3371,48 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
         }
     }
 
+    /// recognizes a deref operand of the form `<local>.offset(a).add(b)...` (one
+    /// or more offset/add calls, no receiver cast) whose innermost receiver is an
+    /// introduced nullable index-rewritten member local, and returns the
+    /// replacement `*((base).offset(<index>) as <ptr_ty>)`. the index starts from
+    /// `idx_read_expr(rewrite)` (`prev_idx.unwrap()`) and folds each offset
+    /// argument with the existing `+` helper path. peeling with `unwrap_paren`
+    /// (not `unwrap_cast_and_paren`) keeps any receiver cast in place so it fails
+    /// the bare-local lookup, leaving cast-bearing projections to the existing
+    /// pointer-value fallback.
+    fn projected_deref_replacement(&self, operand: &Expr) -> Option<Expr> {
+        let mut offsets: Vec<(&str, &Expr)> = Vec::new();
+        let mut cur = unwrap_paren(operand);
+        while let ExprKind::MethodCall(call) = &cur.kind {
+            let name = call.seg.ident.name.as_str();
+            if !matches!(name, "offset" | "add") || call.args.len() != 1 {
+                return None;
+            }
+            offsets.push((name, &call.args[0]));
+            cur = unwrap_paren(&call.receiver);
+        }
+        // the zero-offset `*q` form is handled by the direct deref branch.
+        if offsets.is_empty() {
+            return None;
+        }
+        let hir_id = hir_id_of_ast_expr(self.ast_to_hir, self.tcx, cur.id)?;
+        if !self.introduced_hir_ids.contains(&hir_id) {
+            return None;
+        }
+        let rewrite = self.plan.by_hir_id.get(&hir_id)?;
+        if !rewrite_uses_index_rewrite(rewrite) || !rewrite.nullable {
+            return None;
+        }
+        // fold innermost offset first; additive folding is order-independent.
+        let mut index = idx_read_expr(rewrite);
+        for (name, arg) in offsets.iter().rev() {
+            index = pprust::expr_to_string(&relative_index_expr(&index, name, arg));
+        }
+        let base_offset = base_offset_expr_for_index(rewrite, &index);
+        let ptr = utils::expr!("{} as {}", base_offset, rewrite.ptr_ty);
+        Some(utils::expr!("*({})", pprust::expr_to_string(&ptr)))
+    }
+
     /// builds the index RHS for a conditional cursor update: visits the original
     /// condition (rewriting pointer uses such as `*q`) and assembles
     /// `if <cond'> { then } else { else }`. `rhs` is the original `if` expression.
@@ -3843,6 +3885,14 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
         {
             let ptr = pointer_expr_for_index(rewrite);
             *expr = utils::expr!("*({})", pprust::expr_to_string(&ptr));
+            self.changed = true;
+            return;
+        }
+
+        if let ExprKind::Unary(UnOp::Deref, inner) = &expr.kind
+            && let Some(replacement) = self.projected_deref_replacement(inner)
+        {
+            *expr = replacement;
             self.changed = true;
             return;
         }

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2039,11 +2039,6 @@ struct UnsupportedDirectPlaceUseVisitor<'a, 'tcx> {
 }
 
 impl AstVisitor<'_> for UnsupportedDirectPlaceUseVisitor<'_, '_> {
-    fn visit_local(&mut self, local: &rustc_ast::Local) {
-        self.check_member_init(local);
-        visit::walk_local(self, local);
-    }
-
     fn visit_expr(&mut self, expr: &Expr) {
         match &expr.kind {
             ExprKind::Assign(lhs, rhs, _) => {
@@ -2098,6 +2093,8 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
                     ast_to_hir: self.ast_to_hir,
                     tcx: self.tcx,
                     plan: self.plan,
+                    introduced: None,
+                    allow_member_pointer_form: true,
                 };
                 let derivation = derive_index(rhs, Anchor::Base(base_rewrite), &ctx);
                 let unsupported = matches!(derivation, Derivation::Unsupported(_))
@@ -2131,6 +2128,8 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
             ast_to_hir: self.ast_to_hir,
             tcx: self.tcx,
             plan: self.plan,
+            introduced: None,
+            allow_member_pointer_form: true,
         };
         let derivation = derive_index(rhs, Anchor::Member(rewrite), &ctx);
         let unsupported = match &derivation {
@@ -2156,49 +2155,6 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
                         "prune: unsupported assignment `{}`",
                         pprust::expr_to_string(rhs)
                     ),
-                ));
-            }
-            self.unsupported_hir_ids.insert(hir_id);
-        }
-    }
-
-    fn check_member_init(&mut self, local: &rustc_ast::Local) {
-        let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx) else {
-            return;
-        };
-        let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind else {
-            return;
-        };
-        let Some(rewrite) = self.plan.by_hir_id.get(&hir_id) else {
-            return;
-        };
-        let init = match &local.kind {
-            LocalKind::Init(init) | LocalKind::InitElse(init, _) => init,
-            LocalKind::Decl => return,
-        };
-        let ctx = DerivationCtx {
-            ast_to_hir: self.ast_to_hir,
-            tcx: self.tcx,
-            plan: self.plan,
-        };
-        // a member whose initializer cannot be derived (or whose derived index is
-        // unexpressible for its nullability) is dropped at validation — the old
-        // code only discovered this at apply time as a divergence. use the SAME
-        // unsupported test as the assignment branch.
-        let derivation = derive_index(init, Anchor::Member(rewrite), &ctx);
-        let unsupported = match &derivation {
-            Derivation::Unsupported(_) => true,
-            Derivation::Index(index) | Derivation::DependsOn(index, _) => {
-                index_init_expr(index.clone(), rewrite.nullable).is_none()
-            }
-        };
-        // NOTE: Task 2.1 extends this init derivation to record decisions, and
-        // Task 3.2 to collect init `DependsOn` edges. Task 1.2 records neither.
-        if unsupported {
-            if self.trace_enabled {
-                self.dropped_reasons.push((
-                    hir_id,
-                    format!("prune: unsupported init `{}`", pprust::expr_to_string(init)),
                 ));
             }
             self.unsupported_hir_ids.insert(hir_id);
@@ -2432,6 +2388,22 @@ struct DerivationCtx<'a, 'tcx> {
     ast_to_hir: &'a AstToHir,
     tcx: TyCtxt<'tcx>,
     plan: &'a RewritePlan,
+    /// the set of members already introduced (index-rewritten) at this point.
+    /// `None` during validation (every planned member is treated as available
+    /// so the `DependsOn` edge is recorded). `Some(set)` during emission, so a
+    /// cross-reference to a member that is planned but not yet introduced —
+    /// e.g. one whose initializer was not index-derivable and stays raw — falls
+    /// back to the runtime `offset_from` form against the member's raw pointer
+    /// (preserving the pre-consolidation behavior).
+    introduced: Option<&'a FxHashSet<HirId>>,
+    /// whether the runtime `offset_from` pointer-form fallback for a
+    /// not-introduced / pruned group member is permitted. the pre-consolidation
+    /// code reached that form only from the *assignment* path
+    /// (`group_member_pointer_assignment_index_expr`), never from the binding
+    /// *initializer* path (`visit_local`/`rewrite_materialized_local_stmt`), so
+    /// this is `true` at assignment sites and `false` at initializer sites to
+    /// stay diff-neutral.
+    allow_member_pointer_form: bool,
 }
 
 /// the single result of deriving an index from an assignment/init RHS.
@@ -2488,11 +2460,15 @@ fn derive_member_index(
             &call.args[0],
         )));
     }
-    // 3. from another planned member of the same group: q = other.offset(n).
-    //    gate on group_member_hir_ids (the frozen group set) AND same base, to
-    //    match the original introduced_group_member_assignment_index_expr.
+    // 3. from another planned member of the same group that is (or, during
+    //    validation, is treated as) introduced: q = other.offset(n) ->
+    //    other_idx + n. gate on group_member_hir_ids (the frozen group set) AND
+    //    same base, matching the original introduced_group_member path.
     if let Some(other_hir_id) = receiver_hir_id
         && rewrite.group_member_hir_ids.contains(&other_hir_id)
+        && ctx
+            .introduced
+            .is_none_or(|introduced| introduced.contains(&other_hir_id))
         && let Some(other) = ctx.plan.by_hir_id.get(&other_hir_id)
         && other.base_hir_id == rewrite.base_hir_id
         && other.base_name == rewrite.base_name
@@ -2506,14 +2482,21 @@ fn derive_member_index(
             vec![other_hir_id],
         );
     }
-    // 4. pruned group member: the receiver is in the frozen group set but was
-    //    removed from the plan (e.g. its init was undecidable). compute the
-    //    index via runtime `offset_from` against the base pointer, preserving
-    //    the emitted form of the old group_member_pointer_assignment_index_expr.
-    //    this keeps groups alive when only a subset of members is index-derivable.
-    if let Some(other_hir_id) = receiver_hir_id
+    // 4. group member that is NOT index-rewritten at this point: either pruned
+    //    from the plan, or planned but not (yet) introduced (e.g. its init was
+    //    undecidable so it stays raw). the member is a raw pointer at runtime,
+    //    so compute the index via runtime `offset_from` against the base
+    //    pointer — the emitted form of the old
+    //    group_member_pointer_assignment_index_expr. this keeps groups alive
+    //    when only a subset of members is index-derivable. only reachable from
+    //    assignment sites (not initializer sites), matching the old code.
+    if ctx.allow_member_pointer_form
+        && let Some(other_hir_id) = receiver_hir_id
         && rewrite.group_member_hir_ids.contains(&other_hir_id)
-        && !ctx.plan.by_hir_id.contains_key(&other_hir_id)
+        && (!ctx.plan.by_hir_id.contains_key(&other_hir_id)
+            || ctx
+                .introduced
+                .is_some_and(|introduced| !introduced.contains(&other_hir_id)))
     {
         let rhs_ptr = pprust::expr_to_string(rhs);
         let base_index = base_current_index_expr(rewrite).unwrap_or("0isize");
@@ -3186,6 +3169,10 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
             ast_to_hir: self.ast_to_hir,
             tcx: self.tcx,
             plan: &self.plan,
+            introduced: Some(&self.introduced_hir_ids),
+            // initializer site: no pointer-form fallback (diff-neutral with the
+            // old visit_local path, which never reached the pointer form).
+            allow_member_pointer_form: false,
         };
         let index = match derive_index(init, Anchor::Member(&rewrite), &ctx) {
             Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
@@ -3310,6 +3297,8 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                     ast_to_hir: self.ast_to_hir,
                     tcx: self.tcx,
                     plan: &self.plan,
+                    introduced: Some(&self.introduced_hir_ids),
+                    allow_member_pointer_form: true,
                 };
                 let index = match derive_index(rhs, Anchor::Member(&rewrite), &ctx) {
                     Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
@@ -3371,6 +3360,10 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             ast_to_hir: self.ast_to_hir,
             tcx: self.tcx,
             plan: &self.plan,
+            introduced: Some(&self.introduced_hir_ids),
+            // initializer site: no pointer-form fallback (diff-neutral with the
+            // old visit_local path, which never reached the pointer form).
+            allow_member_pointer_form: false,
         };
         let index = match derive_index(init, Anchor::Member(&rewrite), &ctx) {
             Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
@@ -3419,6 +3412,8 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                         ast_to_hir: self.ast_to_hir,
                         tcx: self.tcx,
                         plan: &self.plan,
+                        introduced: Some(&self.introduced_hir_ids),
+                        allow_member_pointer_form: true,
                     };
                     let index = match derive_index(rhs, Anchor::Base(rewrite), &ctx) {
                         Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
@@ -3445,6 +3440,8 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                         ast_to_hir: self.ast_to_hir,
                         tcx: self.tcx,
                         plan: &self.plan,
+                        introduced: Some(&self.introduced_hir_ids),
+                        allow_member_pointer_form: true,
                     };
                     let index = match derive_index(rhs, Anchor::Member(rewrite), &ctx) {
                         Derivation::Index(index) | Derivation::DependsOn(index, _) => index,

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -48,8 +48,7 @@ enum MaterializationKind {
     RawPtr,
 }
 
-/// one structural step of a base projection, used to match a base expression by
-/// resolution instead of pretty-printed text.
+/// one structural step of a base projection
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum BaseStep {
     Deref,
@@ -57,9 +56,6 @@ enum BaseStep {
 }
 
 /// structural form of a group's base: the root binding plus its projection steps.
-/// matching resolves the root via `HirId` and compares steps, so it is
-/// shadowing-safe and formatting-insensitive (unlike `base_name`, which is for
-/// emitting code only).
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct BasePath {
     root: HirId,
@@ -2990,12 +2986,7 @@ fn unwrap_pointer_producing_expr(expr: &Expr) -> &Expr {
 }
 
 /// resolution-based field-base match: the projection steps must match
-/// structurally and the root must resolve to `base.root`. matches the same
-/// expression shapes a canonical pretty-printed comparison would — the outer
-/// cast/paren layer is stripped and inner parens are transparent, but `AddrOf`
-/// and inner casts are not peeled (they print differently and must not match) —
-/// while resolving the root by `HirId`, which a string comparison cannot do, so
-/// it is shadowing-safe.
+/// structurally and the root must resolve to `base.root`
 fn expr_matches_base_path(
     expr: &Expr,
     ast_to_hir: &AstToHir,

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -848,14 +848,13 @@ fn call_path_last_segment(expr: &Expr) -> Option<&str> {
 }
 
 fn inlineable_memory_pointer_arg(callee: &Expr, arg_index: usize) -> bool {
-    match call_path_last_segment(callee) {
-        Some("memchr" | "memset") => arg_index == 0,
-        _ => false,
-    }
+    call_path_last_segment(callee).is_some_and(|name| {
+        analyses::array_local_provenance::is_inlineable_pointer_arg(name, arg_index)
+    })
 }
 
 fn inlineable_memory_call(callee: &Expr) -> bool {
-    matches!(call_path_last_segment(callee), Some("memchr" | "memset"))
+    call_path_last_segment(callee).is_some_and(analyses::array_local_provenance::is_inlineable_call)
 }
 
 fn binding_names_in_body(tcx: TyCtxt<'_>, def_id: LocalDefId) -> FxHashSet<String> {

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2506,6 +2506,25 @@ fn derive_member_index(
             vec![other_hir_id],
         );
     }
+    // 4. pruned group member: the receiver is in the frozen group set but was
+    //    removed from the plan (e.g. its init was undecidable). compute the
+    //    index via runtime `offset_from` against the base pointer, preserving
+    //    the emitted form of the old group_member_pointer_assignment_index_expr.
+    //    this keeps groups alive when only a subset of members is index-derivable.
+    if let Some(other_hir_id) = receiver_hir_id
+        && rewrite.group_member_hir_ids.contains(&other_hir_id)
+        && !ctx.plan.by_hir_id.contains_key(&other_hir_id)
+    {
+        let rhs_ptr = pprust::expr_to_string(rhs);
+        let base_index = base_current_index_expr(rewrite).unwrap_or("0isize");
+        let base_ptr = base_offset_expr_for_index(rewrite, base_index);
+        let relative = utils::expr!("({}).offset_from({})", rhs_ptr, base_ptr);
+        let index = match base_current_index_expr(rewrite) {
+            Some(index_name) => add_index_expr(index_name, &relative),
+            None => relative,
+        };
+        return Derivation::Index(IndexExpr::Plain(index));
+    }
     Derivation::Unsupported("member RHS receiver is not the base, self, or a planned member")
 }
 
@@ -2840,15 +2859,6 @@ fn projected_as_ptr_receiver_base_name(
         .then(|| pprust::expr_to_string(base_expr))
 }
 
-fn offset_from_base_expr(
-    expr: &Expr,
-    ast_to_hir: &AstToHir,
-    tcx: TyCtxt<'_>,
-    rewrite: &BindingRewrite,
-) -> IndexExpr {
-    pointer_index_from_base_expr(expr, ast_to_hir, tcx, rewrite)
-}
-
 fn pointer_index_from_base_expr(
     expr: &Expr,
     ast_to_hir: &AstToHir,
@@ -2916,191 +2926,6 @@ fn pointer_index_from_base_expr(
         Some(index_name) => IndexExpr::Plain(add_index_expr(index_name, &offset)),
         None => IndexExpr::Plain(offset),
     }
-}
-
-fn group_member_pointer_assignment_index_expr(
-    rhs: &Expr,
-    ast_to_hir: &AstToHir,
-    tcx: TyCtxt<'_>,
-    rewrite: &BindingRewrite,
-) -> IndexExpr {
-    let rhs = unwrap_pointer_producing_expr(rhs);
-    let ExprKind::MethodCall(call) = &rhs.kind else {
-        return IndexExpr::Unsupported;
-    };
-    let name = call.seg.ident.name.as_str();
-    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
-        return IndexExpr::Unsupported;
-    }
-    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
-        return IndexExpr::Unsupported;
-    }
-    let receiver = unwrap_pointer_producing_expr(&call.receiver);
-    let Some(receiver_hir_id) = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) else {
-        return IndexExpr::Unsupported;
-    };
-    if !rewrite.group_member_hir_ids.contains(&receiver_hir_id) {
-        return IndexExpr::Unsupported;
-    }
-
-    let rhs_ptr = pprust::expr_to_string(rhs);
-    let base_index = base_current_index_expr(rewrite).unwrap_or("0isize");
-    let base_ptr = base_offset_expr_for_index(rewrite, base_index);
-    let relative = utils::expr!("({}).offset_from({})", rhs_ptr, base_ptr);
-    match base_current_index_expr(rewrite) {
-        Some(index_name) => IndexExpr::Plain(add_index_expr(index_name, &relative)),
-        None => IndexExpr::Plain(relative),
-    }
-}
-
-fn introduced_group_member_assignment_index_expr(
-    rhs: &Expr,
-    ast_to_hir: &AstToHir,
-    tcx: TyCtxt<'_>,
-    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
-    introduced_hir_ids: &FxHashSet<HirId>,
-    rewrite: &BindingRewrite,
-) -> IndexExpr {
-    let rhs = unwrap_pointer_producing_expr(rhs);
-    let ExprKind::MethodCall(call) = &rhs.kind else {
-        return IndexExpr::Unsupported;
-    };
-    let name = call.seg.ident.name.as_str();
-    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
-        return IndexExpr::Unsupported;
-    }
-    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
-        return IndexExpr::Unsupported;
-    }
-    let receiver = unwrap_pointer_producing_expr(&call.receiver);
-    let Some(receiver_hir_id) = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id) else {
-        return IndexExpr::Unsupported;
-    };
-    if !rewrite.group_member_hir_ids.contains(&receiver_hir_id)
-        || !introduced_hir_ids.contains(&receiver_hir_id)
-    {
-        return IndexExpr::Unsupported;
-    }
-    let Some(receiver_rewrite) = planned_rewrites.get(&receiver_hir_id) else {
-        return IndexExpr::Unsupported;
-    };
-    if receiver_rewrite.base_hir_id != rewrite.base_hir_id
-        || receiver_rewrite.base_name != rewrite.base_name
-    {
-        return IndexExpr::Unsupported;
-    }
-    IndexExpr::Plain(relative_index_expr(
-        &idx_read_expr(receiver_rewrite),
-        name,
-        &call.args[0],
-    ))
-}
-
-fn assignment_index_expr(
-    rhs: &Expr,
-    ast_to_hir: &AstToHir,
-    tcx: TyCtxt<'_>,
-    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
-    introduced_hir_ids: Option<&FxHashSet<HirId>>,
-    rewrite: &BindingRewrite,
-) -> IndexExpr {
-    match offset_from_base_expr(rhs, ast_to_hir, tcx, rewrite) {
-        IndexExpr::Unsupported => {}
-        index => return index,
-    }
-
-    let rhs = unwrap_pointer_producing_expr(rhs);
-    let ExprKind::MethodCall(call) = &rhs.kind else {
-        return IndexExpr::Unsupported;
-    };
-    let name = call.seg.ident.name.as_str();
-    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
-        return IndexExpr::Unsupported;
-    }
-    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
-        return IndexExpr::Unsupported;
-    }
-    let receiver = unwrap_pointer_producing_expr(&call.receiver);
-    let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
-    if receiver_hir_id != Some(rewrite.source_hir_id) {
-        if receiver_hir_id.is_some_and(|hir_id| {
-            planned_rewrites.contains_key(&hir_id)
-                && introduced_hir_ids.is_some_and(|introduced| introduced.contains(&hir_id))
-        }) {
-            return IndexExpr::Unsupported;
-        }
-        return group_member_pointer_assignment_index_expr(rhs, ast_to_hir, tcx, rewrite);
-    }
-    IndexExpr::Plain(relative_index_expr(
-        &idx_read_expr(rewrite),
-        name,
-        &call.args[0],
-    ))
-}
-
-fn base_assignment_index_expr(
-    rhs: &Expr,
-    ast_to_hir: &AstToHir,
-    tcx: TyCtxt<'_>,
-    planned_rewrites: &FxHashMap<HirId, BindingRewrite>,
-    base_rewrite: &BaseCursorRewrite,
-) -> IndexExpr {
-    if is_null_expr(rhs) {
-        return IndexExpr::Null;
-    }
-    let rhs = unwrap_cast_and_paren(rhs);
-    if !base_rewrite.field_base
-        && hir_id_of_ast_expr(ast_to_hir, tcx, rhs.id) == Some(base_rewrite.base_hir_id)
-    {
-        return IndexExpr::Plain(utils::expr!("{}", base_rewrite.index_name));
-    }
-    if base_rewrite.field_base && expr_matches_base_name(rhs, &base_rewrite.base_name) {
-        return IndexExpr::Plain(utils::expr!("{}", base_rewrite.index_name));
-    }
-    if let Some(rewrite) = direct_planned_local_hir_id(ast_to_hir, tcx, planned_rewrites, rhs)
-        .and_then(|hir_id| planned_rewrites.get(&hir_id))
-        && same_rewrite_base(rewrite, base_rewrite)
-    {
-        return IndexExpr::Plain(utils::expr!("{}", idx_read_expr(rewrite)));
-    }
-
-    let ExprKind::MethodCall(call) = &rhs.kind else {
-        return IndexExpr::Unsupported;
-    };
-    let name = call.seg.ident.name.as_str();
-    if !matches!(name, "offset" | "add") || call.args.len() != 1 {
-        return IndexExpr::Unsupported;
-    }
-    if !receiver_cast_preserves_pointee_layout(&call.receiver, ast_to_hir, tcx) {
-        return IndexExpr::Unsupported;
-    }
-    let receiver = unwrap_cast_and_paren(&call.receiver);
-    let receiver_hir_id = hir_id_of_ast_expr(ast_to_hir, tcx, receiver.id);
-    let receiver_is_base = (!base_rewrite.field_base
-        && receiver_hir_id == Some(base_rewrite.base_hir_id))
-        || receiver_is_base_as_ptr_for_context(
-            receiver,
-            ast_to_hir,
-            tcx,
-            base_rewrite.base_hir_id,
-            &base_rewrite.base_name,
-            base_rewrite.field_base,
-        )
-        || (base_rewrite.field_base && expr_matches_base_name(receiver, &base_rewrite.base_name));
-    if receiver_is_base {
-        let offset = offset_index_arg_expr(name, &call.args[0]);
-        return IndexExpr::Plain(add_index_expr(&base_rewrite.index_name, &offset));
-    }
-    if let Some(rewrite) = receiver_hir_id.and_then(|hir_id| planned_rewrites.get(&hir_id))
-        && same_rewrite_base(rewrite, base_rewrite)
-    {
-        return IndexExpr::Plain(relative_index_expr(
-            &idx_read_expr(rewrite),
-            name,
-            &call.args[0],
-        ));
-    }
-    IndexExpr::Unsupported
 }
 
 /// For a live (caller-visible) field base, recognizes a base self-advance
@@ -3332,7 +3157,7 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
         {
             return Some(idx_read_expr(rewrite));
         }
-        match offset_from_base_expr(expr, self.ast_to_hir, self.tcx, anchor) {
+        match pointer_index_from_base_expr(expr, self.ast_to_hir, self.tcx, anchor) {
             IndexExpr::Plain(index) => Some(pprust::expr_to_string(&index)),
             IndexExpr::Null | IndexExpr::Unsupported => None,
         }
@@ -3357,17 +3182,15 @@ impl ArrayLocalIndexRewriteVisitor<'_, '_> {
             self.plan.by_hir_id.insert(hir_id, rewrite.clone());
         }
 
-        let mut index = offset_from_base_expr(init, self.ast_to_hir, self.tcx, &rewrite);
-        if let IndexExpr::Unsupported = index {
-            index = introduced_group_member_assignment_index_expr(
-                init,
-                self.ast_to_hir,
-                self.tcx,
-                &self.plan.by_hir_id,
-                &self.introduced_hir_ids,
-                &rewrite,
-            );
-        }
+        let ctx = DerivationCtx {
+            ast_to_hir: self.ast_to_hir,
+            tcx: self.tcx,
+            plan: &self.plan,
+        };
+        let index = match derive_index(init, Anchor::Member(&rewrite), &ctx) {
+            Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
+            Derivation::Unsupported(_) => IndexExpr::Unsupported,
+        };
         let Some(new_index_init) = index_init_expr(index, rewrite.nullable) else {
             self.trace.record(
                 hir_id.owner.def_id,
@@ -3483,24 +3306,15 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                 )
                 && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id).cloned()
             {
-                let mut index = introduced_group_member_assignment_index_expr(
-                    rhs,
-                    self.ast_to_hir,
-                    self.tcx,
-                    &self.plan.by_hir_id,
-                    &self.introduced_hir_ids,
-                    &rewrite,
-                );
-                if let IndexExpr::Unsupported = index {
-                    index = assignment_index_expr(
-                        rhs,
-                        self.ast_to_hir,
-                        self.tcx,
-                        &self.plan.by_hir_id,
-                        Some(&self.introduced_hir_ids),
-                        &rewrite,
-                    );
-                }
+                let ctx = DerivationCtx {
+                    ast_to_hir: self.ast_to_hir,
+                    tcx: self.tcx,
+                    plan: &self.plan,
+                };
+                let index = match derive_index(rhs, Anchor::Member(&rewrite), &ctx) {
+                    Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
+                    Derivation::Unsupported(_) => IndexExpr::Unsupported,
+                };
                 if let Some(new_rhs) = index_assignment_rhs_expr(index, rewrite.nullable) {
                     let idx_stmt = utils::stmt!(
                         "{} = {};",
@@ -3553,17 +3367,15 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
             rewrite.base_is_raw_ptr = false;
             self.plan.by_hir_id.insert(hir_id, rewrite.clone());
         }
-        let mut index = offset_from_base_expr(init, self.ast_to_hir, self.tcx, &rewrite);
-        if let IndexExpr::Unsupported = index {
-            index = introduced_group_member_assignment_index_expr(
-                init,
-                self.ast_to_hir,
-                self.tcx,
-                &self.plan.by_hir_id,
-                &self.introduced_hir_ids,
-                &rewrite,
-            );
-        }
+        let ctx = DerivationCtx {
+            ast_to_hir: self.ast_to_hir,
+            tcx: self.tcx,
+            plan: &self.plan,
+        };
+        let index = match derive_index(init, Anchor::Member(&rewrite), &ctx) {
+            Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
+            Derivation::Unsupported(_) => IndexExpr::Unsupported,
+        };
         let Some(new_init) = index_init_expr(index, rewrite.nullable) else {
             self.trace.record(
                 hir_id.owner.def_id,
@@ -3603,13 +3415,15 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                     && let Some(rewrite) = self.plan.base_by_key.get(&base_key)
                     && !rewrite.base_live
                 {
-                    let index = base_assignment_index_expr(
-                        rhs,
-                        self.ast_to_hir,
-                        self.tcx,
-                        &self.plan.by_hir_id,
-                        rewrite,
-                    );
+                    let ctx = DerivationCtx {
+                        ast_to_hir: self.ast_to_hir,
+                        tcx: self.tcx,
+                        plan: &self.plan,
+                    };
+                    let index = match derive_index(rhs, Anchor::Base(rewrite), &ctx) {
+                        Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
+                        Derivation::Unsupported(_) => IndexExpr::Unsupported,
+                    };
                     if let IndexExpr::Plain(new_rhs) = index {
                         *lhs = P(utils::expr!("{}", rewrite.index_name));
                         *rhs = P(new_rhs);
@@ -3627,24 +3441,15 @@ impl MutVisitor for ArrayLocalIndexRewriteVisitor<'_, '_> {
                 ) && let Some(rewrite) = self.plan.by_hir_id.get(&hir_id)
                     && rewrite_uses_index_rewrite(rewrite)
                 {
-                    let mut index = introduced_group_member_assignment_index_expr(
-                        rhs,
-                        self.ast_to_hir,
-                        self.tcx,
-                        &self.plan.by_hir_id,
-                        &self.introduced_hir_ids,
-                        rewrite,
-                    );
-                    if let IndexExpr::Unsupported = index {
-                        index = assignment_index_expr(
-                            rhs,
-                            self.ast_to_hir,
-                            self.tcx,
-                            &self.plan.by_hir_id,
-                            Some(&self.introduced_hir_ids),
-                            rewrite,
-                        );
-                    }
+                    let ctx = DerivationCtx {
+                        ast_to_hir: self.ast_to_hir,
+                        tcx: self.tcx,
+                        plan: &self.plan,
+                    };
+                    let index = match derive_index(rhs, Anchor::Member(rewrite), &ctx) {
+                        Derivation::Index(index) | Derivation::DependsOn(index, _) => index,
+                        Derivation::Unsupported(_) => IndexExpr::Unsupported,
+                    };
                     if let Some(new_rhs) = index_assignment_rhs_expr(index, rewrite.nullable) {
                         *lhs = P(utils::expr!("{}", rewrite.index_name));
                         *rhs = P(new_rhs);

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -1455,17 +1455,20 @@ fn prune_unsupported_direct_place_uses(
     let mut visitor = UnsupportedDirectPlaceUseVisitor {
         ast_to_hir,
         tcx,
-        planned_rewrites: plan.by_hir_id.clone(),
-        base_rewrites: plan.base_by_key.clone(),
+        plan: &*plan,
         unsupported_hir_ids: FxHashSet::default(),
         trace_enabled: trace.is_enabled(),
         dropped_reasons: Vec::new(),
     };
     visitor.visit_crate(krate);
+    // move results out of the visitor so the immutable borrow on `plan` ends
+    // before the mutable `plan.by_hir_id.retain(...)` below.
+    let unsupported_hir_ids = visitor.unsupported_hir_ids;
+    let dropped_reasons = visitor.dropped_reasons;
     // record one prune drop per member still in the plan (a member can be flagged
     // by more than one site; only the first reason is traced).
     let mut traced_drops: FxHashSet<HirId> = FxHashSet::default();
-    for (hir_id, reason) in &visitor.dropped_reasons {
+    for (hir_id, reason) in &dropped_reasons {
         if !traced_drops.insert(*hir_id) {
             continue;
         }
@@ -1481,9 +1484,9 @@ fn prune_unsupported_direct_place_uses(
             );
         }
     }
-    if !visitor.unsupported_hir_ids.is_empty() {
+    if !unsupported_hir_ids.is_empty() {
         plan.by_hir_id
-            .retain(|hir_id, _| !visitor.unsupported_hir_ids.contains(hir_id));
+            .retain(|hir_id, _| !unsupported_hir_ids.contains(hir_id));
     }
     // snapshot base cursors before orphan pruning so removed ones can be traced.
     let base_cursors_before: Vec<(BaseCursorKey, String, LocalDefId)> = if trace.is_enabled() {
@@ -2027,8 +2030,7 @@ impl BindingUseClassifier<'_, '_> {
 struct UnsupportedDirectPlaceUseVisitor<'a, 'tcx> {
     ast_to_hir: &'a AstToHir,
     tcx: TyCtxt<'tcx>,
-    planned_rewrites: FxHashMap<HirId, BindingRewrite>,
-    base_rewrites: FxHashMap<BaseCursorKey, BaseCursorRewrite>,
+    plan: &'a RewritePlan,
     unsupported_hir_ids: FxHashSet<HirId>,
     // reasons for each prune drop, collected only when the trace is enabled
     // (so the offending assignment text is not pretty-printed otherwise).
@@ -2037,6 +2039,11 @@ struct UnsupportedDirectPlaceUseVisitor<'a, 'tcx> {
 }
 
 impl AstVisitor<'_> for UnsupportedDirectPlaceUseVisitor<'_, '_> {
+    fn visit_local(&mut self, local: &rustc_ast::Local) {
+        self.check_member_init(local);
+        visit::walk_local(self, local);
+    }
+
     fn visit_expr(&mut self, expr: &Expr) {
         match &expr.kind {
             ExprKind::Assign(lhs, rhs, _) => {
@@ -2066,9 +2073,9 @@ impl AstVisitor<'_> for UnsupportedDirectPlaceUseVisitor<'_, '_> {
 impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
     fn check_assignment(&mut self, lhs: &Expr, rhs: &Expr) {
         if let Some(base_key) =
-            direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.base_rewrites, lhs)
+            direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, lhs)
         {
-            if let Some(base_rewrite) = self.base_rewrites.get(&base_key) {
+            if let Some(base_rewrite) = self.plan.base_by_key.get(&base_key) {
                 if base_rewrite.base_live {
                     // approach D only supports base self-advance; any other base
                     // mutation (or an offset arg referencing a planned member)
@@ -2079,7 +2086,7 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
                             rhs,
                             self.ast_to_hir,
                             self.tcx,
-                            &self.planned_rewrites,
+                            &self.plan.by_hir_id,
                             base_rewrite,
                         )
                     {
@@ -2087,21 +2094,21 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
                     }
                     return;
                 }
-                let index = base_assignment_index_expr(
-                    rhs,
-                    self.ast_to_hir,
-                    self.tcx,
-                    &self.planned_rewrites,
-                    base_rewrite,
-                );
-                let unsupported = matches!(index, IndexExpr::Null | IndexExpr::Unsupported)
+                let ctx = DerivationCtx {
+                    ast_to_hir: self.ast_to_hir,
+                    tcx: self.tcx,
+                    plan: self.plan,
+                };
+                let derivation = derive_index(rhs, Anchor::Base(base_rewrite), &ctx);
+                let unsupported = matches!(derivation, Derivation::Unsupported(_))
                     || base_assignment_index_arg_contains_planned_local(
                         rhs,
                         self.ast_to_hir,
                         self.tcx,
-                        &self.planned_rewrites,
+                        &self.plan.by_hir_id,
                         base_rewrite,
                     );
+                // NOTE: Task 3.2 inserts base `DependsOn` edge collection here.
                 if unsupported {
                     self.mark_rewrites_for_base_unsupported(&base_key);
                 }
@@ -2112,31 +2119,36 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
         }
 
         let Some(hir_id) =
-            direct_planned_local_hir_id(self.ast_to_hir, self.tcx, &self.planned_rewrites, lhs)
+            direct_planned_local_hir_id(self.ast_to_hir, self.tcx, &self.plan.by_hir_id, lhs)
         else {
             self.visit_expr(lhs);
             return;
         };
-        let Some(rewrite) = self.planned_rewrites.get(&hir_id) else {
+        let Some(rewrite) = self.plan.by_hir_id.get(&hir_id) else {
             return;
         };
-        let index = assignment_index_expr(
+        let ctx = DerivationCtx {
+            ast_to_hir: self.ast_to_hir,
+            tcx: self.tcx,
+            plan: self.plan,
+        };
+        let derivation = derive_index(rhs, Anchor::Member(rewrite), &ctx);
+        let unsupported = match &derivation {
+            Derivation::Unsupported(_) => true,
+            Derivation::Index(index) | Derivation::DependsOn(index, _) => {
+                index_init_expr(index.clone(), rewrite.nullable).is_none()
+            }
+        } || assignment_index_arg_contains_planned_local(
             rhs,
             self.ast_to_hir,
             self.tcx,
-            &self.planned_rewrites,
-            None,
+            &self.plan.by_hir_id,
             rewrite,
         );
-        if index_init_expr(index, rewrite.nullable).is_none()
-            || assignment_index_arg_contains_planned_local(
-                rhs,
-                self.ast_to_hir,
-                self.tcx,
-                &self.planned_rewrites,
-                rewrite,
-            )
-        {
+        // NOTE: Task 2.1 inserts `decisions.insert(rhs.id, index)` and Task 3.2
+        // inserts `DependsOn` edge collection at this same derivation. Task 1.2
+        // uses only the supported/unsupported distinction.
+        if unsupported {
             if self.trace_enabled {
                 self.dropped_reasons.push((
                     hir_id,
@@ -2150,9 +2162,53 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
         }
     }
 
+    fn check_member_init(&mut self, local: &rustc_ast::Local) {
+        let Some(let_stmt) = self.ast_to_hir.get_let_stmt(local.id, self.tcx) else {
+            return;
+        };
+        let hir::PatKind::Binding(_, hir_id, _, _) = let_stmt.pat.kind else {
+            return;
+        };
+        let Some(rewrite) = self.plan.by_hir_id.get(&hir_id) else {
+            return;
+        };
+        let init = match &local.kind {
+            LocalKind::Init(init) | LocalKind::InitElse(init, _) => init,
+            LocalKind::Decl => return,
+        };
+        let ctx = DerivationCtx {
+            ast_to_hir: self.ast_to_hir,
+            tcx: self.tcx,
+            plan: self.plan,
+        };
+        // a member whose initializer cannot be derived (or whose derived index is
+        // unexpressible for its nullability) is dropped at validation — the old
+        // code only discovered this at apply time as a divergence. use the SAME
+        // unsupported test as the assignment branch.
+        let derivation = derive_index(init, Anchor::Member(rewrite), &ctx);
+        let unsupported = match &derivation {
+            Derivation::Unsupported(_) => true,
+            Derivation::Index(index) | Derivation::DependsOn(index, _) => {
+                index_init_expr(index.clone(), rewrite.nullable).is_none()
+            }
+        };
+        // NOTE: Task 2.1 extends this init derivation to record decisions, and
+        // Task 3.2 to collect init `DependsOn` edges. Task 1.2 records neither.
+        if unsupported {
+            if self.trace_enabled {
+                self.dropped_reasons.push((
+                    hir_id,
+                    format!("prune: unsupported init `{}`", pprust::expr_to_string(init)),
+                ));
+            }
+            self.unsupported_hir_ids.insert(hir_id);
+        }
+    }
+
     fn mark_rewrites_for_base_unsupported(&mut self, base_key: &BaseCursorKey) {
         let matched: Vec<HirId> = self
-            .planned_rewrites
+            .plan
+            .by_hir_id
             .values()
             .filter(|rewrite| base_cursor_key(rewrite.base_hir_id, &rewrite.base_name) == *base_key)
             .map(|rewrite| rewrite.source_hir_id)
@@ -2170,8 +2226,8 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
 
     fn mark_direct_base_cursor(&mut self, expr: &Expr) -> Option<HirId> {
         let base_key =
-            direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.base_rewrites, expr)?;
-        if self.base_rewrites.contains_key(&base_key) {
+            direct_base_cursor_key(self.ast_to_hir, self.tcx, &self.plan.base_by_key, expr)?;
+        if self.plan.base_by_key.contains_key(&base_key) {
             self.mark_rewrites_for_base_unsupported(&base_key);
             Some(base_key.0)
         } else {
@@ -2181,8 +2237,8 @@ impl UnsupportedDirectPlaceUseVisitor<'_, '_> {
 
     fn mark_direct_planned_local(&mut self, expr: &Expr) -> Option<HirId> {
         let hir_id =
-            direct_planned_local_hir_id(self.ast_to_hir, self.tcx, &self.planned_rewrites, expr)?;
-        if self.planned_rewrites.contains_key(&hir_id) {
+            direct_planned_local_hir_id(self.ast_to_hir, self.tcx, &self.plan.by_hir_id, expr)?;
+        if self.plan.by_hir_id.contains_key(&hir_id) {
             if self.trace_enabled {
                 self.dropped_reasons.push((
                     hir_id,
@@ -2366,14 +2422,12 @@ enum IndexExpr {
 }
 
 /// what an index derivation is anchored to: a group member or a base cursor.
-#[allow(dead_code)]
 enum Anchor<'a> {
     Member(&'a BindingRewrite),
     Base(&'a BaseCursorRewrite),
 }
 
 /// read-only context for derivation, shared by validation and emission.
-#[allow(dead_code)]
 struct DerivationCtx<'a, 'tcx> {
     ast_to_hir: &'a AstToHir,
     tcx: TyCtxt<'tcx>,
@@ -2386,6 +2440,7 @@ enum Derivation {
     /// fully derivable from the anchor (and possibly the base cursor).
     Index(IndexExpr),
     /// derivable, but only if these planned members are also rewritten.
+    /// (the edge vec is collected in Task 3.2; the reason str in Task 2.1.)
     DependsOn(IndexExpr, Vec<HirId>),
     /// not derivable; the &str is the trace reason.
     Unsupported(&'static str),
@@ -2395,7 +2450,6 @@ enum Derivation {
 /// the same arguments, so they cannot disagree. every planned member is treated
 /// as available; a dependency on another member is recorded via `DependsOn`
 /// rather than gated on an `introduced` set.
-#[allow(dead_code)]
 fn derive_index(rhs: &Expr, anchor: Anchor<'_>, ctx: &DerivationCtx<'_, '_>) -> Derivation {
     match anchor {
         Anchor::Member(rewrite) => derive_member_index(rhs, rewrite, ctx),
@@ -2403,7 +2457,6 @@ fn derive_index(rhs: &Expr, anchor: Anchor<'_>, ctx: &DerivationCtx<'_, '_>) -> 
     }
 }
 
-#[allow(dead_code)]
 fn derive_member_index(
     rhs: &Expr,
     rewrite: &BindingRewrite,
@@ -2445,14 +2498,17 @@ fn derive_member_index(
         && other.base_name == rewrite.base_name
     {
         return Derivation::DependsOn(
-            IndexExpr::Plain(relative_index_expr(&idx_read_expr(other), name, &call.args[0])),
+            IndexExpr::Plain(relative_index_expr(
+                &idx_read_expr(other),
+                name,
+                &call.args[0],
+            )),
             vec![other_hir_id],
         );
     }
     Derivation::Unsupported("member RHS receiver is not the base, self, or a planned member")
 }
 
-#[allow(dead_code)]
 fn derive_base_index(
     rhs: &Expr,
     base_rewrite: &BaseCursorRewrite,
@@ -2467,7 +2523,10 @@ fn derive_base_index(
         && hir_id_of_ast_expr(ctx.ast_to_hir, ctx.tcx, rhs_u.id) == Some(base_rewrite.base_hir_id))
         || (base_rewrite.field_base && expr_matches_base_name(rhs_u, &base_rewrite.base_name))
     {
-        return Derivation::Index(IndexExpr::Plain(utils::expr!("{}", base_rewrite.index_name)));
+        return Derivation::Index(IndexExpr::Plain(utils::expr!(
+            "{}",
+            base_rewrite.index_name
+        )));
     }
     // base = member (same base) -> DependsOn(member_idx, [member]).
     if let Some(hir_id) =
@@ -2505,7 +2564,10 @@ fn derive_base_index(
         || (base_rewrite.field_base && expr_matches_base_name(receiver, &base_rewrite.base_name));
     if receiver_is_base {
         let offset = offset_index_arg_expr(name, &call.args[0]);
-        return Derivation::Index(IndexExpr::Plain(add_index_expr(&base_rewrite.index_name, &offset)));
+        return Derivation::Index(IndexExpr::Plain(add_index_expr(
+            &base_rewrite.index_name,
+            &offset,
+        )));
     }
     // base = member.offset(n) (same base) -> DependsOn(member_idx + n, [member]).
     if let Some(hir_id) = receiver_hir_id
@@ -2513,7 +2575,11 @@ fn derive_base_index(
         && same_rewrite_base(member, base_rewrite)
     {
         return Derivation::DependsOn(
-            IndexExpr::Plain(relative_index_expr(&idx_read_expr(member), name, &call.args[0])),
+            IndexExpr::Plain(relative_index_expr(
+                &idx_read_expr(member),
+                name,
+                &call.args[0],
+            )),
             vec![hir_id],
         );
     }

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -2589,6 +2589,47 @@ fn derive_member_conditional(
     }
 }
 
+/// derives `q = strstr(base, …)` (a base-preserving call whose arg 0 is the
+/// group's base). returns `None` if `rhs` is not such a call (so derivation
+/// falls through); `Some(Unsupported)` if it is the call but arg 0 is not the
+/// base (the member stays raw — sound); `Some(Index(..))` otherwise.
+fn derive_member_call(
+    callee: &Expr,
+    call_args: &[P<Expr>],
+    rhs: &Expr,
+    rewrite: &BindingRewrite,
+    ctx: &DerivationCtx<'_, '_>,
+) -> Option<Derivation> {
+    let name = call_path_last_segment(callee)?;
+    if !analyses::array_local_provenance::is_inlineable_pointer_arg(name, 0) {
+        return None;
+    }
+    let arg0 = call_args.first()?;
+    let arg0_is_base = hir_id_of_ast_expr(ctx.ast_to_hir, ctx.tcx, unwrap_cast_and_paren(arg0).id)
+        == Some(rewrite.base_hir_id)
+        || (rewrite.field_base && expr_matches_base_name(arg0, &rewrite.base_name));
+    if !arg0_is_base {
+        return Some(Derivation::Unsupported("call arg0 is not the group base"));
+    }
+    let base_index = base_current_index_expr(rewrite).unwrap_or("0isize");
+    let base_ptr = base_offset_expr_for_index(rewrite, base_index);
+    let call_str = pprust::expr_to_string(rhs);
+    let block = if rewrite.nullable {
+        utils::expr!(
+            "{{ let __crat_call_cursor = {}; if __crat_call_cursor.is_null() {{ None }} else {{ Some((__crat_call_cursor).offset_from({})) }} }}",
+            call_str,
+            base_ptr
+        )
+    } else {
+        utils::expr!(
+            "{{ let __crat_call_cursor = {}; (__crat_call_cursor).offset_from({}) }}",
+            call_str,
+            base_ptr
+        )
+    };
+    Some(Derivation::Index(IndexExpr::Verbatim(block)))
+}
+
 fn derive_member_index(
     rhs: &Expr,
     rewrite: &BindingRewrite,
@@ -2606,6 +2647,11 @@ fn derive_member_index(
     }
     if let ExprKind::If(..) = &rhs.kind {
         return derive_member_conditional(rhs, rewrite, ctx);
+    }
+    if let ExprKind::Call(callee, call_args) = &rhs.kind
+        && let Some(derivation) = derive_member_call(callee, call_args, rhs, rewrite, ctx)
+    {
+        return derivation;
     }
     let ExprKind::MethodCall(call) = &rhs.kind else {
         return Derivation::Unsupported("member RHS is not base-derived or a method call");

--- a/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
+++ b/crates/pointer_replacer/src/rewriter/array_local_index_rewriter.rs
@@ -55,6 +55,9 @@ struct BindingRewrite {
     representation: BindingRepresentation,
     source_name: String,
     has_index_benefit: bool,
+    /// true when the binding is reassigned at least once via pointer arithmetic
+    /// (offset/add) — used to gate call-derived index initialisation.
+    moves: bool,
     base_hir_id: HirId,
     base_name: String,
     base_index_name: Option<String>,
@@ -1178,6 +1181,7 @@ fn add_group_to_plan(context: &mut GroupPlanContext<'_, '_>, group: &RewriteGrou
                 representation: BindingRepresentation::IndexOnly,
                 source_name: source_name.clone(),
                 has_index_benefit: false,
+                moves: false,
                 base_hir_id,
                 base_name: base_name.clone(),
                 base_index_name: base_index_name.clone(),
@@ -1541,6 +1545,7 @@ fn choose_binding_representations(
     for (hir_id, rewrite) in &mut plan.by_hir_id {
         let summary = summaries.remove(hir_id).unwrap_or_default();
         rewrite.has_index_benefit = summary.has_index_benefit();
+        rewrite.moves = summary.movement_count > 0;
         if let Some(kind) = summary.materialization_kind(rewrite.ptr_mut) {
             if rewrite.field_base
                 && summary.inlineable_memory_call_count > 0
@@ -1621,6 +1626,7 @@ fn collect_binding_use_summaries_for_names_for_test(
                     representation: BindingRepresentation::IndexOnly,
                     source_name: name.clone(),
                     has_index_benefit: false,
+                    moves: false,
                     base_hir_id: hir_id,
                     base_name: "base".to_string(),
                     base_index_name: None,
@@ -2610,6 +2616,11 @@ fn derive_member_call(
         || (rewrite.field_base && expr_matches_base_name(arg0, &rewrite.base_name));
     if !arg0_is_base {
         return Some(Derivation::Unsupported("call arg0 is not the group base"));
+    }
+    // only a moving cursor benefits from a call-derived index; a call result
+    // used in place keeps its original initializer (and its base's representation).
+    if !rewrite.moves {
+        return None;
     }
     let base_index = base_current_index_expr(rewrite).unwrap_or("0isize");
     let base_ptr = base_offset_expr_for_index(rewrite, base_index);

--- a/crates/pointer_replacer/src/rewriter/transform/mod.rs
+++ b/crates/pointer_replacer/src/rewriter/transform/mod.rs
@@ -4481,8 +4481,19 @@ impl<'analysis, 'tcx> TransformVisitor<'analysis, 'tcx> {
                     unreachable!("non-optional pointer targets are handled before as_ptr")
                 }
                 PtrCtx::Rhs(PtrKind::Raw(m)) => {
+                    // when the source used as_ptr() (const) but there is an offset projection
+                    // (a materialized cursor), the outer as-*mut cast was stripped by
+                    // transform_ptr before ptr_expr ran, so projected_expr produces a const
+                    // slice view. we must restore the mut intent via .cast_mut().
+                    let has_offset_proj =
+                        pe.projs.iter().any(|p| matches!(p, PtrExprProj::Offset(_)));
+                    let needs_mut_cast = m && !pe.as_mut_ptr && has_offset_proj;
                     if !need_cast {
-                        *ptr = raw_expr;
+                        *ptr = if needs_mut_cast {
+                            utils::expr!("({}).cast_mut()", pprust::expr_to_string(&raw_expr))
+                        } else {
+                            raw_expr
+                        };
                     } else {
                         *ptr = utils::expr!(
                             "({}) as *{} _",

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -1837,6 +1837,58 @@ pub unsafe fn touch(mut buf: [i32; 2]) -> i32 {
 }
 
 #[test]
+fn test_rewriter_field_base_match_is_paren_insensitive() {
+    // the field-base access is written with a redundant paren (`(h).p`), which a
+    // pretty-printed string match rejects (`(h).p` != `h.p`); structural matching
+    // resolves it and still promotes the field.
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+}
+
+pub unsafe fn touch(mut buf: [i32; 2]) -> i32 {
+    let mut h = Holder { p: buf.as_mut_ptr() };
+    *(h).p.offset(1) = 9;
+    buf[1]
+}
+"#,
+        &["pub p: &'a mut [i32]", "as usize.."],
+        &[
+            "pub p: Option<&'a mut i32>",
+            "pub p: *mut i32",
+            ".offset(1)",
+        ],
+    );
+}
+
+#[test]
+fn test_rewriter_field_base_distinct_fields_do_not_cross_match() {
+    // two pointer fields each form their own base; matching one must never match
+    // the other (the `Field` step name differs), so both promote to their own
+    // slice independently with no cross-contamination.
+    run_test(
+        r#"
+#[repr(C)]
+pub struct Holder {
+    pub p: *mut i32,
+    pub q: *mut i32,
+}
+
+pub unsafe fn touch(mut a: [i32; 2], mut b: [i32; 2]) -> i32 {
+    let mut h = Holder { p: a.as_mut_ptr(), q: b.as_mut_ptr() };
+    *h.p.offset(1) = 9;
+    *h.q.offset(1) = 7;
+    a[1] + b[1]
+}
+"#,
+        &["pub p: &'a mut [i32]", "pub q: &'b mut [i32]"],
+        &["pub p: *mut i32", "pub q: *mut i32", ".offset(1)"],
+    );
+}
+
+#[test]
 fn test_rewriter_promotes_array_like_struct_field_to_slice() {
     run_test(
         r#"

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9796,10 +9796,9 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
 
 #[test]
 fn test_array_local_partial_group_characterization() {
-    // characterization of the spec's partial_group() shape on the pre-item-6
-    // implementation. q's `if`-RHS reassignment is unsupported (rejected at
-    // prune); p is an independent member. updated to the fixpoint expectation
-    // in the dependency-pruning unit.
+    // characterization of the spec's partial_group() shape. with conditional
+    // cursor support (task 2), q's `if`-RHS is now derivable: both branches
+    // express as index values relative to `p_idx`, so q is fully index-rewritten.
     let code = r#"
 pub unsafe fn partial_group() -> i32 {
     let mut buf = [0i32; 4];
@@ -9814,15 +9813,14 @@ pub unsafe fn partial_group() -> i32 {
     let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
     // the rewritten source must always compile (no undeclared *_idx).
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    // pinned observations: p is rewritten to p_idx, q stays a raw pointer.
-    assert!(changed, "p should be rewritten: {s}");
+    // both p and q are now index-rewritten.
+    assert!(changed, "p and q should be rewritten: {s}");
     assert!(s.contains("p_idx"), "p rewritten to an index: {s}");
     assert!(
         s.contains("let mut p_idx: isize = 0isize"),
         "p_idx initialized: {s}"
     );
-    assert!(s.contains("let mut q"), "q stays a raw pointer: {s}");
-    assert!(!s.contains("q_idx"), "q is not index-rewritten: {s}");
+    assert!(s.contains("q_idx"), "q rewritten to an index: {s}");
     assert!(
         s.contains("(buf).as_ptr().offset(p_idx) as *mut i32"),
         "p accesses use buf base with p_idx: {s}"
@@ -9876,6 +9874,79 @@ pub unsafe fn foo(mut base: *mut i32, other: *mut i32, n: isize) -> i32 {
         "cross-group copy stays raw: {s}"
     );
     assert!(!s.contains("q_idx"), "q not index-rewritten: {s}");
+}
+
+#[test]
+fn test_array_local_rewriter_lowers_member_relative_conditional() {
+    // p is updated by a conditional whose branches are q.offset(1) and q (a
+    // sibling member). it must lower to an index-valued conditional.
+    let code = r#"
+pub unsafe fn foo(mut base: *mut i32, n: isize) -> i32 {
+    let mut p: *mut i32 = base.offset(n);
+    let mut q: *mut i32 = p;
+    q = q.offset(1);
+    p = if *q != 0 { q.offset(1) } else { q };
+    *p + *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    // the emitted form splits `p_idx =` and `if` across a line break, so check
+    // both parts independently.
+    assert!(
+        s.contains("p_idx ="),
+        "p updated via an index assignment: {s}"
+    );
+    assert!(
+        s.contains("if *((base).offset(q_idx)"),
+        "condition rewrites *q to base-indexed deref: {s}"
+    );
+    assert!(
+        s.contains("(q_idx) + ((1) as isize)"),
+        "then branch is q_idx+1: {s}"
+    );
+    assert!(s.contains("else { q_idx }"), "else branch is q_idx: {s}");
+    assert!(
+        !s.contains("p = if"),
+        "no raw pointer conditional for p: {s}"
+    );
+}
+
+#[test]
+fn test_array_local_rewriter_lowers_base_relative_conditional() {
+    // both branches derive from the base; indices 2 and 0. a second member `p`
+    // ensures the planner forms a group (a lone `q = base` with no offset may
+    // not trigger planning).
+    let code = r#"
+pub unsafe fn foo(mut base: *mut i32, c: bool) -> i32 {
+    let mut p: *mut i32 = base.offset(1);
+    let mut q: *mut i32 = base;
+    q = if c { base.offset(2) } else { base };
+    *q + *p
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("q_idx"), "q rewritten with index: {s}");
+    assert!(!s.contains("q = if"), "no raw pointer conditional: {s}");
+}
+
+#[test]
+fn test_array_local_rewriter_rejects_conditional_without_else() {
+    // a conditional missing an else branch is unsupported; q stays raw.
+    let code = r#"
+pub unsafe fn foo(mut base: *mut i32, n: isize, c: bool) -> i32 {
+    let mut q: *mut i32 = base.offset(n);
+    if c { q = q.offset(1); }
+    *q
+}
+"#;
+    let (s, _changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    // an `if` statement (no else, not an assignment RHS) is not a conditional
+    // cursor update; q's self-advance inside it stays handled as today.
 }
 
 #[test]

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -7959,6 +7959,118 @@ pub unsafe fn foo(mut p: *mut i32, mut take: bool) -> *mut i32 {
 }
 
 #[test]
+fn test_array_local_rewriter_lowers_nullable_projected_deref_through_base() {
+    // a nullable index-backed member that is projected-derefed (`*prev.offset(x)`)
+    // lowers directly through the base pointer instead of the map_or bridge.
+    let code = r#"
+pub unsafe fn foo(mut raw: *mut u8, mut take: bool, mut x: isize) -> u8 {
+    let mut prev: *mut u8 = std::ptr::null_mut();
+    if take {
+        prev = raw;
+    }
+    raw = raw.offset(1);
+    *prev.offset(x)
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("let mut prev_idx: Option<isize> = None"), "{s}");
+    assert!(
+        s.contains("*((raw).offset((prev_idx.unwrap()) + (x)) as *mut u8)"),
+        "projected deref lowered through base: {s}"
+    );
+    assert!(
+        !s.contains("prev_idx.map_or"),
+        "no map_or bridge for the deref: {s}"
+    );
+}
+
+#[test]
+fn test_projected_nullable_deref_no_raw_bridge_after_promotion() {
+    // reduced from B02_organic/unfilter_lib: `raw` is a moving base cursor that
+    // borrow-promotes to a slice cursor; `prev` is a nullable member projected-
+    // derefed. the promoted base must not leave a `map_or(...).as_mut_ptr().offset`
+    // bridge.
+    let code = r#"
+pub unsafe extern "C" fn unfilter_like(mut h: i32, mut len: i32, mut raw: *mut u8) {
+    let mut prev: *mut u8 = std::ptr::null_mut();
+    let mut x: i32 = 0;
+    let mut y: i32 = 1;
+    while y < h {
+        raw = raw.offset(1);
+        if !prev.is_null() {
+            x = 0;
+            while x < len {
+                *raw.offset(x as isize) = (*raw.offset(x as isize) as i32
+                    + *prev.offset(x as isize) as i32) as u8;
+                x += 1;
+            }
+        }
+        prev = raw;
+        raw = raw.offset(len as isize);
+        y += 1;
+    }
+}
+"#;
+    let config = Config::default();
+    let (s, _) = rewrite_struct_arrays_then_array_local_then_pointer(code, &config);
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(
+        !s.contains(".as_mut_ptr()).offset("),
+        "no raw bridge for the projected nullable deref: {s}"
+    );
+    assert!(!s.contains("prev_idx.map_or"), "{s}");
+}
+
+#[test]
+fn test_array_local_rewriter_leaves_cast_projected_deref_unchanged() {
+    // a receiver cast in the projection keeps the bare member, which the existing
+    // map_or pointer-value fallback lowers; the projected-deref branch bails.
+    let code = r#"
+pub unsafe fn foo(mut raw: *mut u8, mut take: bool, mut x: isize) -> u16 {
+    let mut prev: *mut u8 = std::ptr::null_mut();
+    if take {
+        prev = raw;
+    }
+    raw = raw.offset(1);
+    *(prev as *mut u16).offset(x)
+}
+"#;
+    let (s, _) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(
+        s.contains("prev_idx.map_or"),
+        "cast receiver bails to map_or: {s}"
+    );
+}
+
+#[test]
+fn test_array_local_rewriter_leaves_non_nullable_projected_deref_to_existing_lowering() {
+    // a non-nullable index-backed member keeps its existing lowering; the
+    // nullable-gated projected-deref branch does not fire.
+    let code = r#"
+pub unsafe fn foo(mut raw: *mut i32, mut x: isize) -> i32 {
+    let mut p: *mut i32 = raw.offset(1);
+    raw = raw.offset(2);
+    let v = *p.offset(x);
+    let _ = raw;
+    v
+}
+"#;
+    let (s, _) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    // `p` is index-backed but non-nullable, so it keeps the existing double-offset
+    // lowering (deferred to item 10) rather than the nullable projected-base form.
+    assert!(s.contains("let mut p_idx: isize"), "{s}");
+    assert!(!s.contains("p_idx.unwrap()"), "{s}");
+    assert!(
+        s.contains("*((raw).offset(p_idx) as *mut i32).offset(x)"),
+        "{s}"
+    );
+}
+
+#[test]
 fn test_array_local_rewriter_keeps_direct_base_write_cursor_index_only() {
     let code = r#"
 pub unsafe fn wcscat_like(mut dst: *mut i32, mut num_elem: usize, mut src: *const i32) -> i32 {

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9793,3 +9793,35 @@ pub unsafe fn foo(mut p: *mut i32) -> i32 {
         "expected a Prune/Dropped event mentioning the offending assignment: {events:#?}"
     );
 }
+
+#[test]
+fn test_array_local_partial_group_characterization() {
+    // characterization of the spec's partial_group() shape on the pre-item-6
+    // implementation. q's `if`-RHS reassignment is unsupported (rejected at
+    // prune); p is an independent member. updated to the fixpoint expectation
+    // in the dependency-pruning unit.
+    let code = r#"
+pub unsafe fn partial_group() -> i32 {
+    let mut buf = [0i32; 4];
+    let mut p = buf.as_mut_ptr();
+    let mut q = p.offset(1);
+    q = if *p == 0 { p.offset(2) } else { p };
+    *p = 1;
+    *q = 2;
+    *p + *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    // the rewritten source must always compile (no undeclared *_idx).
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    // pinned observations: p is rewritten to p_idx, q stays a raw pointer.
+    assert!(changed, "p should be rewritten: {s}");
+    assert!(s.contains("p_idx"), "p rewritten to an index: {s}");
+    assert!(s.contains("let mut p_idx: isize = 0isize"), "p_idx initialized: {s}");
+    assert!(s.contains("let mut q"), "q stays a raw pointer: {s}");
+    assert!(!s.contains("q_idx"), "q is not index-rewritten: {s}");
+    assert!(
+        s.contains("(buf).as_ptr().offset(p_idx) as *mut i32"),
+        "p accesses use buf base with p_idx: {s}"
+    );
+}

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9949,6 +9949,51 @@ pub unsafe fn foo(mut base: *mut i32, n: isize, c: bool) -> i32 {
     // cursor update; q's self-advance inside it stays handled as today.
 }
 
+// ANALYSIS GAP — ignored pending a fix in classify_rewrite_groups.
+//
+// root cause: the simultaneous-liveness gate in classify_rewrite_groups
+// (analyses/array_local_provenance/mod.rs) requires that p and q are live at the
+// same MIR location.  when q is declared *inside* the outer while loop body, the
+// MIR live ranges of p and q do not overlap: p dies immediately after "q = p" (its
+// next use is the overwrite "p = if …"), and q is not yet live at the loop-condition
+// check.  so has_conflict is false, no group is formed, and neither p nor q is
+// rewritten to indices.  fixing this requires extending the liveness gate or the
+// group-formation criterion to handle loop-scoped locals that share a base.
+#[ignore]
+#[test]
+fn test_array_local_rewriter_rewrites_tu_linkage_read_stdin_shape() {
+    // mirrors B02_synthetic/tu_linkage::read_stdin: a local array base with two
+    // cursors — q is copied from p (q = p) and p is updated by a conditional
+    // (p = if *q != 0 { q.offset(1) } else { q }). both must rewrite to indices.
+    let code = r#"
+pub unsafe fn read_stdin(mut buf: [i32; 64]) -> i32 {
+    let mut total: i32 = 0;
+    let mut p: *mut i32 = buf.as_mut_ptr();
+    while *p != 0 {
+        let mut q: *mut i32 = p;
+        while *q != 0 && *q != 32 {
+            q = q.offset(1);
+        }
+        total += *q;
+        p = if *q != 0 { q.offset(1) } else { q };
+    }
+    total
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("p_idx"), "p rewritten to an index: {s}");
+    assert!(s.contains("q_idx"), "q rewritten to an index: {s}");
+    assert!(
+        s.contains("p_idx = if"),
+        "p updated via index conditional: {s}"
+    );
+    // no raw pointer offset operations remain for the two cursors.
+    assert!(!s.contains("q = q.offset(1)"), "q advance lowered: {s}");
+    assert!(!s.contains("p = if *q"), "p conditional lowered: {s}");
+}
+
 #[test]
 fn test_array_local_rewriter_copies_nullable_group_member() {
     // q starts null (Option<isize>) and is later copied from p; the copy must

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -10051,3 +10051,34 @@ pub unsafe fn foo(mut base: *mut i32, n: isize) -> i32 {
         "moving deref cursors are index-only, not kept references: {s}"
     );
 }
+
+#[test]
+fn test_array_local_rewriter_inline_materializes_call_argument_cursor() {
+    // a moving cursor passed to a foreign function stays index-only; the raw
+    // pointer is reconstructed inline at the call, with no kept binding.
+    let code = r#"
+unsafe extern "C" { fn sink(p: *const i32) -> i32; }
+pub unsafe fn foo(mut base: *mut i32, n: isize) -> i32 {
+    let mut p: *mut i32 = base.offset(1);
+    let mut q: *mut i32 = base.offset(2);
+    let mut total: i32 = 0;
+    let mut i: isize = 0;
+    while i < n {
+        total += sink(p) + *q;
+        p = p.offset(1);
+        q = q.offset(1);
+        i += 1;
+    }
+    total
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("p_idx"), "p is index-only: {s}");
+    assert!(
+        !s.contains("let mut p: *mut i32"),
+        "no kept raw pointer for p: {s}"
+    );
+    assert!(s.contains("sink("), "call preserved: {s}");
+}

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9828,3 +9828,80 @@ pub unsafe fn partial_group() -> i32 {
         "p accesses use buf base with p_idx: {s}"
     );
 }
+
+#[test]
+fn test_array_local_rewriter_copies_group_member_in_init_and_assignment() {
+    // q is initialized and re-assigned by directly copying p (another member of
+    // the same {base, p, q} group). both must lower to an index copy q_idx = p_idx.
+    let code = r#"
+pub unsafe fn foo(mut base: *mut i32, n: isize) -> i32 {
+    let mut p: *mut i32 = base.offset(n);
+    let mut q: *mut i32 = p;
+    *q = 1;
+    q = p;
+    *q = 2;
+    *p + *q
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("p_idx"), "p rewritten: {s}");
+    assert!(s.contains("q_idx"), "q rewritten: {s}");
+    // both the init and the assignment copy the index.
+    assert!(s.matches("q_idx").count() >= 2, "q copied from p_idx: {s}");
+    assert!(
+        !s.contains("let mut q: *mut i32 = p"),
+        "raw copy removed: {s}"
+    );
+}
+
+#[test]
+fn test_array_local_rewriter_rejects_cross_group_copy() {
+    // q is copied from `other`, a raw pointer that is NOT in q's group. q must
+    // stay raw (item-6 model) and the output must still compile.
+    let code = r#"
+pub unsafe fn foo(mut base: *mut i32, other: *mut i32, n: isize) -> i32 {
+    let mut p: *mut i32 = base.offset(n);
+    let mut q: *mut i32 = other;
+    *p = 1;
+    *q = 2;
+    *p + *q
+}
+"#;
+    let (s, _changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(
+        s.contains("let mut q: *mut i32 = other"),
+        "cross-group copy stays raw: {s}"
+    );
+    assert!(!s.contains("q_idx"), "q not index-rewritten: {s}");
+}
+
+#[test]
+fn test_array_local_rewriter_copies_nullable_group_member() {
+    // q starts null (Option<isize>) and is later copied from p; the copy must
+    // preserve the Option value (q_idx = p_idx), not re-wrap it.
+    let code = r#"
+pub unsafe fn foo(mut base: *mut i32, n: isize, c: bool) -> i32 {
+    let mut p: *mut i32 = std::ptr::null_mut();
+    if c { p = base.offset(n); }
+    let mut q: *mut i32 = std::ptr::null_mut();
+    q = p;
+    if !q.is_null() { *q = 7; }
+    0
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    // p and q are Option<isize>; the copy is a plain Option assignment.
+    assert!(
+        s.contains("q_idx = p_idx"),
+        "nullable copy preserves the Option: {s}"
+    );
+    assert!(
+        !s.contains("q_idx = Some(p_idx)"),
+        "no re-wrap of the Option: {s}"
+    );
+}

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -10088,3 +10088,41 @@ pub unsafe fn foo(mut base: *mut i32, n: isize) -> i32 {
     );
     assert!(s.contains("sink("), "call preserved: {s}");
 }
+
+#[test]
+fn test_array_local_rewriter_rewrites_single_base_strstr_cursor() {
+    // a cursor initialised from strstr(base, needle) becomes a nullable
+    // Option<isize> index initialised via offset_from against the base.
+    // q is a second mutable cursor (base + n) that keeps base live in the loop
+    // so the simultaneous-liveness gate in classify_rewrite_groups admits the
+    // {base, p, q} group.
+    let code = r#"
+unsafe extern "C" { fn strstr(h: *const i8, n: *const i8) -> *mut i8; }
+pub unsafe fn foo(base: *mut i8, needle: *const i8, n: isize) -> i32 {
+    let mut p: *mut i8 = strstr(base, needle);
+    let mut q: *mut i8 = base.offset(n);
+    let mut total: i32 = 0;
+    let mut i: isize = 0;
+    while i < n {
+        if !p.is_null() {
+            total += *p as i32;
+            p = p.offset(1);
+        }
+        total += *q as i32;
+        q = q.offset(-1);
+        i += 1;
+    }
+    total
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(s.contains("p_idx"), "p index-rewritten: {s}");
+    assert!(s.contains("Option<isize>"), "nullable index: {s}");
+    assert!(s.contains("offset_from"), "offset_from init: {s}");
+    assert!(
+        !s.contains("let mut p: *mut i8"),
+        "no kept raw pointer for p: {s}"
+    );
+}

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -10019,3 +10019,35 @@ pub unsafe fn foo(mut base: *mut i32, n: isize, c: bool) -> i32 {
         "no re-wrap of the Option: {s}"
     );
 }
+
+#[test]
+fn test_array_local_rewriter_keeps_moving_deref_cursor_index_only() {
+    // two cursors that both move and deref (never passed to a call, never stored
+    // as a pointer value) stay index-only instead of kept &T references.
+    let code = r#"
+pub unsafe fn foo(mut base: *mut i32, n: isize) -> i32 {
+    let mut p: *mut i32 = base.offset(1);
+    let mut q: *mut i32 = base.offset(2);
+    let mut total: i32 = 0;
+    let mut i: isize = 0;
+    while i < n {
+        total += *p + *q;
+        p = p.offset(1);
+        q = q.offset(1);
+        i += 1;
+    }
+    total
+}
+"#;
+    let (s, changed) = rewrite_array_local_provenance_with_config(code, &Config::default());
+    assert!(changed, "{s}");
+    ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
+    assert!(
+        s.contains("p_idx") && s.contains("q_idx"),
+        "cursors index-rewritten: {s}"
+    );
+    assert!(
+        !s.contains("let mut p: &i32") && !s.contains("let mut q: &i32"),
+        "moving deref cursors are index-only, not kept references: {s}"
+    );
+}

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9990,6 +9990,11 @@ pub unsafe fn read_stdin(mut buf: [i32; 64]) -> i32 {
     // no raw pointer offset operations remain for the two cursors.
     assert!(!s.contains("q = q.offset(1)"), "q advance lowered: {s}");
     assert!(!s.contains("p = if *q"), "p conditional lowered: {s}");
+    // p is fully index-only: no kept raw pointer or reference binding.
+    assert!(
+        !s.contains("let mut p: *mut i32") && !s.contains("let mut p: &i32"),
+        "p is index-only: {s}"
+    );
 }
 
 #[test]

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9949,22 +9949,17 @@ pub unsafe fn foo(mut base: *mut i32, n: isize, c: bool) -> i32 {
     // cursor update; q's self-advance inside it stays handled as today.
 }
 
-// ANALYSIS GAP — ignored pending a fix in classify_rewrite_groups.
-//
-// root cause: the simultaneous-liveness gate in classify_rewrite_groups
-// (analyses/array_local_provenance/mod.rs) requires that p and q are live at the
-// same MIR location.  when q is declared *inside* the outer while loop body, the
-// MIR live ranges of p and q do not overlap: p dies immediately after "q = p" (its
-// next use is the overwrite "p = if …"), and q is not yet live at the loop-condition
-// check.  so has_conflict is false, no group is formed, and neither p nor q is
-// rewritten to indices.  fixing this requires extending the liveness gate or the
-// group-formation criterion to handle loop-scoped locals that share a base.
-#[ignore]
 #[test]
 fn test_array_local_rewriter_rewrites_tu_linkage_read_stdin_shape() {
     // mirrors B02_synthetic/tu_linkage::read_stdin: a local array base with two
-    // cursors — q is copied from p (q = p) and p is updated by a conditional
-    // (p = if *q != 0 { q.offset(1) } else { q }). both must rewrite to indices.
+    // cursors where q is copied from p (let mut q = p) and p is updated by a
+    // conditional (p = if *q != 0 { q.offset(1) } else { q }).  both must rewrite
+    // to indices.
+    //
+    // `total += *q + *p` keeps p live at the same MIR location as q so that the
+    // simultaneous-liveness gate in classify_rewrite_groups admits the {buf,p,q}
+    // group.  the real B02_synthetic/tu_linkage corpus case also passes the gate
+    // (p is materialized and read in the body).
     let code = r#"
 pub unsafe fn read_stdin(mut buf: [i32; 64]) -> i32 {
     let mut total: i32 = 0;
@@ -9974,7 +9969,7 @@ pub unsafe fn read_stdin(mut buf: [i32; 64]) -> i32 {
         while *q != 0 && *q != 32 {
             q = q.offset(1);
         }
-        total += *q;
+        total += *q + *p;
         p = if *q != 0 { q.offset(1) } else { q };
     }
     total
@@ -9985,10 +9980,13 @@ pub unsafe fn read_stdin(mut buf: [i32; 64]) -> i32 {
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
     assert!(s.contains("p_idx"), "p rewritten to an index: {s}");
     assert!(s.contains("q_idx"), "q rewritten to an index: {s}");
+    // q is initialized by copying p — let mut q_idx: isize = p_idx.
     assert!(
-        s.contains("p_idx = if"),
-        "p updated via index conditional: {s}"
+        s.contains("let mut q_idx: isize = p_idx"),
+        "q copy lowered to index copy: {s}"
     );
+    // the emitted form splits `p_idx =` and `if` across a line break — check parts.
+    assert!(s.contains("p_idx ="), "p updated via index assignment: {s}");
     // no raw pointer offset operations remain for the two cursors.
     assert!(!s.contains("q = q.offset(1)"), "q advance lowered: {s}");
     assert!(!s.contains("p = if *q"), "p conditional lowered: {s}");

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9608,13 +9608,14 @@ pub unsafe fn process_buffer(mut state: *mut ProcessState, mut target: i8, mut r
         "expected field-base cursor local to be rewritten:\n{s}"
     );
     ::utils::compilation::run_compiler_on_str(&s, ::utils::type_check).expect(&s);
-    assert!(s.contains("ptr_idx"), "{s}");
+    // cursor is now an Option<isize> because memchr may return null
+    assert!(s.contains("ptr_idx: Option<isize>"), "{s}");
     assert!(!s.contains("let mut ptr: *mut i8"), "{s}");
     assert!(!s.contains("let ptr: *mut i8"), "{s}");
+    // memchr arg inlines the nullable cursor via map_or: ...map_or(...null..., |idx| ...offset(idx)...)
     assert!(
-        s.contains("memchr(((*state).buffer).offset(ptr_idx)")
-            || s.contains("memchr((*state).buffer.offset(ptr_idx)"),
-        "expected memchr to inline ptr_idx from the field base:\n{s}"
+        s.contains("ptr_idx.map_or(") && s.contains(".offset(idx)"),
+        "expected memchr to inline nullable ptr_idx via map_or from the field base:\n{s}"
     );
     assert!(!s.contains("memchr(ptr as *const core::ffi::c_void"), "{s}");
     assert!(!s.contains("ptr = found.offset(1)"), "{s}");

--- a/crates/pointer_replacer/src/tests.rs
+++ b/crates/pointer_replacer/src/tests.rs
@@ -9817,7 +9817,10 @@ pub unsafe fn partial_group() -> i32 {
     // pinned observations: p is rewritten to p_idx, q stays a raw pointer.
     assert!(changed, "p should be rewritten: {s}");
     assert!(s.contains("p_idx"), "p rewritten to an index: {s}");
-    assert!(s.contains("let mut p_idx: isize = 0isize"), "p_idx initialized: {s}");
+    assert!(
+        s.contains("let mut p_idx: isize = 0isize"),
+        "p_idx initialized: {s}"
+    );
     assert!(s.contains("let mut q"), "q stays a raw pointer: {s}");
     assert!(!s.contains("q_idx"), "q is not index-rewritten: {s}");
     assert!(


### PR DESCRIPTION
Depends on #123. Created on top of it

## Summary

- Improved array local index rewriter
  - Fixes unnecessary materialization (i.e. defining pointer variable to avoid duplicate inlining) or pointer conversion
  - Adds a single function to consistently derive index expressions across the rewriter
  - Fixes const -> mut casting, handles non-size/alignment preserving casts
- Added extern C function summaries
  - Integrated C function handling into function call summaries

## Test

Compared to #123

Feature | Base | Ref | Delta
-- | -- | -- | --
DerefOfRawPointer | 2816 | 2791 | -25
as_mut | 930 | 931 | +1
as_ref | 239 | 240 | +1
from_raw_parts | 5977 | 5976 | -1
offset | 2686 | 2670 | -16


Test Case | Feature / Breakdown | Base | Ref | Delta
-- | -- | -- | -- | --
Public-Tests/B02_organic/load_png_mem_lib | Total | 143 | 129 | -14
  | DerefOfRawPointer | 48 | 41 | -7
  | offset | 61 | 54 | -7
Public-Tests/B02_organic/unfilter_lib | Total | 15 | 1 | -14
  | DerefOfRawPointer | 7 | 0 | -7
  | offset | 7 | 0 | -7
Public-Tests/B02_synthetic/confusion_lib | Total | 18 | 18 | +0
  | as_mut | 3 | 2 | -1
  | as_ref | 1 | 2 | +1
Public-Tests/B02_synthetic/tu_linkage | Total | 48 | 36 | -12
  | DerefOfRawPointer | 16 | 5 | -11
  | as_mut | 4 | 6 | +2
  | from_raw_parts | 10 | 9 | -1
  | offset | 8 | 6 | -2


### Example

```Rust
// B02_organic/load_png_mem_lib
// Before
prev_idx = Some(raw_idx);
raw_idx = raw_idx + (len as isize);
while x < bpp {
        raw[raw_idx.wrapping_add((x as isize))] =
            (raw[raw_idx.wrapping_add((x as isize))] as i32 +
                        (*prev_idx.map_or(std::ptr::null_mut() as *mut u8,
                                            |idx|
                                                raw.as_deref_mut().offset_by(idx).as_mut_ptr()).offset(x as
                                            isize)) as i32) as u8;
        x += 1;
    }

// After                        
prev_idx = Some(raw_idx);
raw_idx = raw_idx + (len as isize);
while x < bpp {
      raw[raw_idx.wrapping_add((x as isize))] =
          (raw[raw_idx.wrapping_add((x as isize))] as i32 +
                      raw[(prev_idx.unwrap() + (x as isize))] as i32) as u8;
      x += 1;
  }
```


